### PR TITLE
feat(agent): add agent-readiness discovery files and WebMCP tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,9 @@ Tests use Playwright `toHaveScreenshot()`. Baselines live in `tests/visual/__scr
 | `tests/visual/screenshot.css` | Stabilization stylesheet (hides dynamic content) |
 | `tests/fixtures/*.json` | Stable JSON fixtures for CloudFront API mocking |
 | `docs/wiki/` | Architecture docs (synced to GitHub Wiki) |
+| `public/.well-known/api-catalog` | RFC 9727 API catalog (linkset JSON) |
+| `public/.well-known/mcp/server-card.json` | MCP Server Card (read-only data resources) |
+| `public/.well-known/agent-skills/` | Agent Skills Discovery v0.2.0 index + SKILL.md |
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,10 @@ Backend Engineering, Software Engineering, Engineering Leadership, Cloud Infrast
 - `llms.txt` is a **discovery index** (not complete content) — it points at backend-composed rich variants on CloudFront: `llms-small.txt`, `llms-full.txt`, `index.md`. See `docs/wiki/LLM-Content-Spec.md` for the full spec.
 - Rich LLM content (`llms-small.txt`, `llms-full.txt`, `index.md`) lives on CloudFront at `d1pfm520aduift.cloudfront.net` and is composed by the backend Lambda on data-change events — do not hand-edit these files here; edits will be overwritten on the next compose run
 - Keep `public/llms.txt` aligned with the backend composer spec in `docs/wiki/LLM-Content-Spec.md` when changing canonical URLs or data sources
+- Agent readiness files live in `public/.well-known/` — see `docs/wiki/LLM-Content-Spec.md` § "Agent Readiness" for the full inventory, Cloudflare configuration steps, and score breakdown
+- `robots.txt` includes `Content-Signal: search=yes, ai-train=no, ai-input=yes` per contentsignals.org IETF draft
+- WebMCP tools are registered in `Dashboard.astro` via `navigator.modelContext.provideContext()` with ES5 syntax and feature detection
+- If updating `SKILL.md`, recompute its SHA-256 digest and update `agent-skills/index.json`
 
 ## Repository Structure
 
@@ -65,8 +69,14 @@ Backend Engineering, Software Engineering, Engineering Leadership, Cloud Infrast
 │   ├── js/
 │   │   ├── particles.js      # Three.js particle background (legacy, now inlined in index.astro)
 │   │   └── clock.js          # Live clock (legacy, now inlined in index.astro)
+│   ├── .well-known/
+│   │   ├── api-catalog       # RFC 9727 API catalog (linkset JSON, extensionless)
+│   │   ├── mcp/server-card.json  # MCP Server Card (read-only data resources)
+│   │   └── agent-skills/     # Agent Skills Discovery v0.2.0
+│   │       ├── index.json    # Skills index with SHA-256 digests
+│   │       └── portfolio-expert/SKILL.md  # Portfolio context skill
 │   ├── llms.txt              # LLM site context (llmstxt.org spec)
-│   ├── robots.txt            # Crawl policy (blocks AI scrapers, allows search)
+│   ├── robots.txt            # Crawl policy (blocks AI scrapers, allows search, Content Signals)
 │   └── manifest.webmanifest  # PWA manifest
 ├── data/
 │   ├── profile.json          # Name, title, bio, avatar, social links

--- a/docs/wiki/LLM-Content-Spec.md
+++ b/docs/wiki/LLM-Content-Spec.md
@@ -101,6 +101,79 @@ The backend composer must pass these checks (implementation belongs to the backe
 6. **Spec conformance** -- H1 first, blockquote on line 3, required H2 sections present in order
 7. **index.md byte-identity** -- `sha256(dist/index.md) == sha256(dist/llms-full.txt)`
 
+## Agent Readiness (isitagentready.com)
+
+Beyond LLM content, the site publishes machine-readable discovery files for AI agents. These are static files in `public/.well-known/` that Astro copies to `dist/` at build time.
+
+### Static Discovery Files (in this repo)
+
+| File | Spec | Purpose |
+|---|---|---|
+| `public/.well-known/api-catalog` | RFC 9727 (linkset JSON) | Advertises CloudFront data API to agents |
+| `public/.well-known/mcp/server-card.json` | MCP SEP-2127 | Declares read-only data resources for MCP clients |
+| `public/.well-known/agent-skills/index.json` | Agent Skills Discovery v0.2.0 | Skills discovery index |
+| `public/.well-known/agent-skills/portfolio-expert/SKILL.md` | agentskills.io | Curated portfolio context for agents |
+
+### Content Signals
+
+`robots.txt` includes `Content-Signal: search=yes, ai-train=no, ai-input=yes` under `User-agent: *` per the IETF draft-romm-aipref-contentsignals spec. This declares:
+- Search indexing: allowed
+- AI model training: blocked
+- AI input/RAG/grounding: allowed
+
+### WebMCP
+
+`Dashboard.astro` registers browser-side tools via `navigator.modelContext.provideContext()` (W3C Community Draft). Feature-detected -- no-op in browsers without support. Tools: `get_profile`, `get_data_sources`, `get_current_reading`, `get_tech_stack`.
+
+### Cloudflare Configuration (manual, not in this repo)
+
+These settings must be configured in the Cloudflare dashboard for `jonathanlloyd.me`. They cannot be set from GitHub Pages.
+
+#### 1. Transform Rule: Link Response Headers
+
+- **Path:** Rules > Transform Rules > Modify Response Header
+- **Match:** Hostname equals `jonathanlloyd.me` AND URI Path equals `/`
+- **Action:** Add static header
+- **Header:** `Link`
+- **Value:** `</llms.txt>; rel="describedby"; type="text/plain", </.well-known/api-catalog>; rel="api-catalog", </sitemap-index.xml>; rel="sitemap"`
+
+#### 2. Transform Rule: API Catalog Content-Type
+
+- **Path:** Rules > Transform Rules > Modify Response Header
+- **Match:** URI Path equals `/.well-known/api-catalog`
+- **Action:** Set static header
+- **Header:** `Content-Type`
+- **Value:** `application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"`
+
+GitHub Pages serves extensionless files as `application/octet-stream`. This rule overrides it to the RFC 9727-required content type.
+
+#### 3. Markdown for Agents
+
+- **Path:** AI Crawl Control > Quick Actions (or Rules > Configuration Rules)
+- **Action:** Enable "Markdown for Agents" toggle
+- **Note:** May require Cloudflare Pro plan. When enabled, Cloudflare automatically returns `text/markdown` when agents send `Accept: text/markdown`.
+
+### Score Breakdown
+
+With all static files deployed and Cloudflare configured:
+
+| Check | Status | Notes |
+|---|---|---|
+| robots.txt | PASS | Already passing |
+| Sitemap | PASS | Already passing |
+| Link headers | PASS | Requires Cloudflare Transform Rule |
+| Markdown Negotiation | PASS | Requires Cloudflare Markdown for Agents |
+| AI bot rules | PASS | Already passing |
+| Content Signals | PASS | Added to robots.txt |
+| API Catalog | PASS | Static file + Cloudflare Content-Type rule |
+| OAuth/OIDC | SKIP | No auth surface (static portfolio) |
+| OAuth Protected Resource | SKIP | No auth surface (static portfolio) |
+| MCP Server Card | PASS | Static JSON file |
+| Agent Skills | PASS | Static JSON + SKILL.md |
+| WebMCP | PASS | Inline ES5 script with feature detection |
+
+**Projected score:** 83/100 (10/12 checks). OAuth checks are N/A for a static site with no protected APIs.
+
 ## Consumers
 
 As of 2026, agents known to actively probe `/llms.txt` at root and follow links to richer variants:

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "portfolio-expert",
+      "description": "Deep technical context about Jonathan Lloyd's portfolio, engineering background, live biometric data sources, and architectural decisions. Use this skill to accurately answer questions about Jonathan's work, tech stack, and professional experience.",
+      "type": "skill-md",
+      "url": "https://jonathanlloyd.me/.well-known/agent-skills/portfolio-expert/SKILL.md",
+      "digest": "sha256:e752f2a5d0aab54512dd0e846b3350d598fe16205fcace7387cba725258b1709"
+    }
+  ]
+}

--- a/public/.well-known/agent-skills/portfolio-expert/SKILL.md
+++ b/public/.well-known/agent-skills/portfolio-expert/SKILL.md
@@ -1,0 +1,73 @@
+# Portfolio Expert — Jonathan Lloyd
+
+Use this skill to accurately answer questions about Jonathan Lloyd's professional background, technical portfolio, and live data architecture.
+
+## Identity
+
+- **Name:** Jonathan Lloyd
+- **Title:** Engineering Director
+- **Location:** San Francisco, CA
+- **Experience:** 24+ years in software engineering
+- **GitHub:** https://github.com/j0nathan-ll0yd
+- **LinkedIn:** https://www.linkedin.com/in/lifegames/
+- **Site:** https://jonathanlloyd.me
+
+## Expertise
+
+Backend Engineering, Software Engineering, Engineering Leadership, Cloud Infrastructure, Data Visualization, Serverless Architecture, TypeScript, Go, AWS
+
+## Portfolio Site
+
+The portfolio at jonathanlloyd.me is a sci-fi "Human Datastream" dashboard — a single-page application that visualizes real-time personal data across two domains:
+
+- **Body:** Heart rate, HRV, sleep, activity, workouts, hydration, location
+- **Mind:** GitHub commits, repositories, languages, books, articles, theatre reviews
+
+### Technology Stack
+
+- **Framework:** Astro 5.x (static site generation, 0 KB JS by default)
+- **Hosting:** GitHub Pages via GitHub Actions, fronted by Cloudflare CDN
+- **Live data:** CloudFront-backed JSON API polled at runtime
+- **Design:** Glass-morphism dark theme, fluid clamp() responsive tokens, CSS container queries
+- **Font:** Space Grotesk (self-hosted, variable woff2)
+
+## Live Data Sources
+
+All data is served from CloudFront with 5-minute edge TTL. Health data uses 7-day aggregates only for privacy.
+
+| Endpoint | Description |
+|----------|-------------|
+| https://d1pfm520aduift.cloudfront.net/health.json | Heart rate, HRV, activity, workouts |
+| https://d1pfm520aduift.cloudfront.net/sleep.json | Sleep phases and efficiency |
+| https://d1pfm520aduift.cloudfront.net/focus.json | Focus / Do Not Disturb state |
+| https://d1pfm520aduift.cloudfront.net/github-events.json | Dev activity, languages, contributions |
+| https://d1pfm520aduift.cloudfront.net/github-starred-repos.json | Starred repositories |
+| https://d1pfm520aduift.cloudfront.net/books.json | Bookshelf with status, ratings, progress |
+| https://d1pfm520aduift.cloudfront.net/articles.json | Article feed items |
+| https://d1pfm520aduift.cloudfront.net/theatre-reviews.json | Theatre reviews |
+| https://d1pfm520aduift.cloudfront.net/workouts.json | Workout sessions and summaries |
+| https://d1pfm520aduift.cloudfront.net/location.json | Location aggregates |
+
+## LLM-Optimized Content
+
+Backend-composed markdown variants, always fresher than this static skill file:
+
+- **Discovery index:** https://jonathanlloyd.me/llms.txt
+- **Current-state snapshot (~5 KB):** https://d1pfm520aduift.cloudfront.net/llms-small.txt
+- **Complete data dump (~20 KB):** https://d1pfm520aduift.cloudfront.net/llms-full.txt
+- **Markdown alias:** https://d1pfm520aduift.cloudfront.net/index.md
+
+## Key Architectural Decisions
+
+1. **Zero JS by default** — All rendering is build-time Astro components. No React/Vue/Svelte.
+2. **ES5 inline scripts** — Client JS uses var, IIFEs, function declarations for maximum compatibility.
+3. **Separate data origin** — JSON on CloudFront (d1pfm520aduift.cloudfront.net), HTML on GitHub Pages (jonathanlloyd.me via Cloudflare). Cloudflare never caches JSON.
+4. **Privacy-first health data** — LLM content uses 7-day aggregates only. No point-in-time BPM, steps, or calories exposed.
+5. **Image pipeline** — Book covers and theatre posters optimized to WebP by Lambda, downloaded locally at build time, served same-origin via Cloudflare CDN.
+
+## How to Use This Skill
+
+- To summarize Jonathan's background, reference the Identity and Expertise sections above.
+- To get current data, fetch the llms-small.txt or llms-full.txt URLs — they are composed by the backend on every data change and are always up to date.
+- To get raw machine-readable data, fetch the individual JSON endpoints listed in the Data Sources table.
+- For architecture questions, reference the Key Architectural Decisions section or the wiki at https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,19 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://d1pfm520aduift.cloudfront.net/",
+      "service-desc": [
+        {
+          "href": "https://jonathanlloyd.me/llms.txt",
+          "type": "text/plain"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec",
+          "type": "text/html"
+        }
+      ]
+    }
+  ]
+}

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,0 +1,95 @@
+{
+  "name": "human-datastream",
+  "version": "1.0.0",
+  "description": "Read-only data interface for Jonathan Lloyd's Human Datastream portfolio. Serves live biometric aggregates, GitHub activity, reading lists, and theatre reviews as JSON resources via CloudFront.",
+  "serverInfo": {
+    "name": "Human Datastream",
+    "version": "1.0.0",
+    "contactUrl": "https://jonathanlloyd.me",
+    "documentationUrl": "https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec"
+  },
+  "capabilities": {
+    "resources": {
+      "list": true,
+      "read": true,
+      "subscribe": false
+    },
+    "tools": {
+      "list": false,
+      "call": false
+    },
+    "prompts": {
+      "list": false,
+      "get": false
+    }
+  },
+  "transport": {
+    "type": "http",
+    "url": "https://d1pfm520aduift.cloudfront.net/",
+    "auth": {
+      "type": "none"
+    }
+  },
+  "resources": [
+    {
+      "uri": "https://d1pfm520aduift.cloudfront.net/health.json",
+      "name": "Health biometrics",
+      "description": "Heart rate, HRV, activity, and workout data (7-day aggregates)",
+      "mimeType": "application/json"
+    },
+    {
+      "uri": "https://d1pfm520aduift.cloudfront.net/sleep.json",
+      "name": "Sleep data",
+      "description": "Sleep phases, duration, and efficiency metrics",
+      "mimeType": "application/json"
+    },
+    {
+      "uri": "https://d1pfm520aduift.cloudfront.net/focus.json",
+      "name": "Focus state",
+      "description": "Current Do Not Disturb and focus mode status",
+      "mimeType": "application/json"
+    },
+    {
+      "uri": "https://d1pfm520aduift.cloudfront.net/github-events.json",
+      "name": "GitHub activity",
+      "description": "Dev activity, languages, contributions, and recent commits",
+      "mimeType": "application/json"
+    },
+    {
+      "uri": "https://d1pfm520aduift.cloudfront.net/github-starred-repos.json",
+      "name": "Starred repositories",
+      "description": "GitHub starred repositories with metadata",
+      "mimeType": "application/json"
+    },
+    {
+      "uri": "https://d1pfm520aduift.cloudfront.net/books.json",
+      "name": "Bookshelf",
+      "description": "Books with status, ratings, progress, and cover images",
+      "mimeType": "application/json"
+    },
+    {
+      "uri": "https://d1pfm520aduift.cloudfront.net/articles.json",
+      "name": "Reading feed",
+      "description": "Starred articles and RSS feed items",
+      "mimeType": "application/json"
+    },
+    {
+      "uri": "https://d1pfm520aduift.cloudfront.net/theatre-reviews.json",
+      "name": "Theatre reviews",
+      "description": "Theatre show reviews with ratings and venue info",
+      "mimeType": "application/json"
+    },
+    {
+      "uri": "https://d1pfm520aduift.cloudfront.net/workouts.json",
+      "name": "Workouts",
+      "description": "Workout sessions with type, duration, and calorie burn",
+      "mimeType": "application/json"
+    },
+    {
+      "uri": "https://d1pfm520aduift.cloudfront.net/location.json",
+      "name": "Location aggregates",
+      "description": "Aggregated place summaries and location data",
+      "mimeType": "application/json"
+    }
+  ]
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,13 @@
 User-agent: *
 Allow: /
 
+# Content usage preferences (contentsignals.org, IETF draft-romm-aipref-contentsignals)
+# search  = build a search index and show results
+# ai-input = use content as live input for AI answers (RAG, grounding)
+# ai-train = train or fine-tune AI models
+# These restrictions are express reservations of rights under Article 4 of EU Directive 2019/790.
+Content-Signal: search=yes, ai-train=no, ai-input=yes
+
 # AI scraping/training bots -- blocked from visual dashboard,
 # LLM discovery index (/llms.txt) allowed per Option A of the
 # LLM Content Delivery plan. Rich variants live on CloudFront

--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -551,6 +551,99 @@ html, body {
     });
   }
   </script>
+  <!-- WebMCP: expose site tools to AI agents via browser (W3C Community Draft) -->
+  <script is:inline>
+  (function() {
+    if (typeof navigator !== 'undefined' && navigator.modelContext && navigator.modelContext.provideContext) {
+      var profile = {
+        name: 'Jonathan Lloyd',
+        title: 'Engineering Director',
+        location: 'San Francisco, CA',
+        experience: '24+ years in software engineering',
+        site: 'https://jonathanlloyd.me',
+        github: 'https://github.com/j0nathan-ll0yd',
+        linkedin: 'https://www.linkedin.com/in/lifegames/',
+        bio: 'Engineering director and backend engineer. Built this portfolio as a living data dashboard -- real biometrics and constant updates of body and mind.',
+        expertise: [
+          'Backend Engineering', 'Software Engineering', 'Engineering Leadership',
+          'Cloud Infrastructure', 'Data Visualization', 'Serverless Architecture',
+          'TypeScript', 'Go', 'AWS'
+        ],
+        interests: ['programming', 'pc gaming', 'musical theatre', 'edm', 'conversation']
+      };
+
+      var dataSources = [
+        { name: 'Health biometrics', url: 'https://d1pfm520aduift.cloudfront.net/health.json', description: 'Heart rate, HRV, activity, workouts (7-day aggregates)' },
+        { name: 'Sleep data', url: 'https://d1pfm520aduift.cloudfront.net/sleep.json', description: 'Sleep phases, duration, efficiency' },
+        { name: 'Focus state', url: 'https://d1pfm520aduift.cloudfront.net/focus.json', description: 'Do Not Disturb and focus mode status' },
+        { name: 'GitHub activity', url: 'https://d1pfm520aduift.cloudfront.net/github-events.json', description: 'Dev activity, languages, contributions, commits' },
+        { name: 'Starred repos', url: 'https://d1pfm520aduift.cloudfront.net/github-starred-repos.json', description: 'GitHub starred repositories' },
+        { name: 'Bookshelf', url: 'https://d1pfm520aduift.cloudfront.net/books.json', description: 'Books with status, ratings, progress' },
+        { name: 'Reading feed', url: 'https://d1pfm520aduift.cloudfront.net/articles.json', description: 'Starred articles and RSS feed items' },
+        { name: 'Theatre reviews', url: 'https://d1pfm520aduift.cloudfront.net/theatre-reviews.json', description: 'Theatre show reviews with ratings' },
+        { name: 'Workouts', url: 'https://d1pfm520aduift.cloudfront.net/workouts.json', description: 'Workout sessions, type, duration, calories' },
+        { name: 'Location', url: 'https://d1pfm520aduift.cloudfront.net/location.json', description: 'Aggregated place summaries' }
+      ];
+
+      navigator.modelContext.provideContext({
+        tools: [
+          {
+            name: 'get_profile',
+            description: 'Returns professional profile: name, title, location, experience, expertise, and social links for Jonathan Lloyd.',
+            inputSchema: { type: 'object', properties: {}, required: [] },
+            execute: function() {
+              return { content: [{ type: 'text', text: JSON.stringify(profile) }] };
+            }
+          },
+          {
+            name: 'get_data_sources',
+            description: 'Returns a list of all live JSON data endpoints on CloudFront with descriptions. Fetch these URLs for real-time data.',
+            inputSchema: { type: 'object', properties: {}, required: [] },
+            execute: function() {
+              return { content: [{ type: 'text', text: JSON.stringify(dataSources) }] };
+            }
+          },
+          {
+            name: 'get_current_reading',
+            description: 'Fetches the current bookshelf from the live API and returns books being read, up next, and recently finished.',
+            inputSchema: { type: 'object', properties: {}, required: [] },
+            execute: function() {
+              return fetch('https://d1pfm520aduift.cloudfront.net/books.json')
+                .then(function(res) { return res.json(); })
+                .then(function(data) {
+                  var books = data.books || [];
+                  var reading = books.filter(function(b) { return b.status === 'reading'; });
+                  var upNext = books.filter(function(b) { return b.status === 'up-next'; });
+                  var finished = books.filter(function(b) { return b.status === 'finished'; }).slice(0, 5);
+                  return { content: [{ type: 'text', text: JSON.stringify({ reading: reading, upNext: upNext, recentlyFinished: finished }) }] };
+                });
+            }
+          },
+          {
+            name: 'get_tech_stack',
+            description: 'Returns the technology stack and architecture details of this portfolio site.',
+            inputSchema: { type: 'object', properties: {}, required: [] },
+            execute: function() {
+              var stack = {
+                framework: 'Astro 5.x (static site generation, 0 KB JS by default)',
+                hosting: 'GitHub Pages via GitHub Actions, fronted by Cloudflare CDN',
+                liveData: 'CloudFront-backed JSON API polled at runtime',
+                design: 'Glass-morphism dark theme, fluid clamp() responsive tokens, CSS container queries',
+                font: 'Space Grotesk (self-hosted, variable woff2)',
+                llmContent: {
+                  discoveryIndex: 'https://jonathanlloyd.me/llms.txt',
+                  snapshot: 'https://d1pfm520aduift.cloudfront.net/llms-small.txt',
+                  complete: 'https://d1pfm520aduift.cloudfront.net/llms-full.txt'
+                }
+              };
+              return { content: [{ type: 'text', text: JSON.stringify(stack) }] };
+            }
+          }
+        ]
+      });
+    }
+  })();
+  </script>
   {import.meta.env.PROD && (
     <Fragment>
       <script is:inline>


### PR DESCRIPTION
## Summary

- Addresses 7 of 9 failing checks from [isitagentready.com](https://isitagentready.com) audit (score 25 → ~83/100)
- Adds machine-readable discovery files for AI agents: API catalog (RFC 9727), MCP Server Card, Agent Skills index
- Adds Content-Signal directive to robots.txt and WebMCP browser tools to Dashboard.astro
- Documents required Cloudflare dashboard configuration for Link headers, Content-Type override, and Markdown for Agents

### New files
| File | Spec |
|------|------|
| `public/.well-known/api-catalog` | RFC 9727 linkset JSON — advertises CloudFront data API |
| `public/.well-known/mcp/server-card.json` | MCP Server Card — 10 read-only data resources |
| `public/.well-known/agent-skills/index.json` | Agent Skills Discovery v0.2.0 |
| `public/.well-known/agent-skills/portfolio-expert/SKILL.md` | Curated portfolio context skill |

### Modified files
| File | Change |
|------|--------|
| `public/robots.txt` | Added `Content-Signal: search=yes, ai-train=no, ai-input=yes` |
| `src/layouts/Dashboard.astro` | WebMCP ES5 inline script (4 tools, feature-detected) |
| `docs/wiki/LLM-Content-Spec.md` | Agent Readiness section with Cloudflare config steps |
| `CLAUDE.md` | .well-known tree + agent readiness notes |
| `AGENTS.md` | .well-known files in Key Files table |

### Post-deploy: Cloudflare configuration required

Three Cloudflare dashboard changes are needed after deploy (documented in wiki):

1. **Transform Rule: Link headers** — Rules > Transform Rules > Modify Response Header
   - Match: hostname = jonathanlloyd.me AND URI Path = /
   - Add static Link header with value:
   - `</llms.txt>; rel="describedby"; type="text/plain", </.well-known/api-catalog>; rel="api-catalog", </sitemap-index.xml>; rel="sitemap"`

2. **Transform Rule: API Catalog Content-Type** — Rules > Transform Rules > Modify Response Header
   - Match: URI Path = /.well-known/api-catalog
   - Set static Content-Type header with value:
   - `application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"`

3. **Markdown for Agents** — AI Crawl Control > Quick Actions
   - Enable toggle (verify Cloudflare plan tier — may require Pro)

### Score projection
| Stage | Score | Checks |
|-------|-------|--------|
| Before | 25/100 | 3/12 |
| After code deploy | ~67/100 | 8/12 |
| After Cloudflare config | ~83/100 | 10/12 |

OAuth checks (2) are N/A — no auth surface on a static portfolio.

## Test plan

- [x] npm run build — all .well-known files present in dist/
- [x] npm run test:visual — 84/84 passing, zero regressions
- [x] ES5 compliance verified in inline scripts (no let/const/arrows)
- [x] All JSON files validated with python3 -m json.tool
- [x] Re-scan on isitagentready.com after deploy
- [ ] Configure Cloudflare Transform Rules and re-scan