### PR TITLE
Image optimization: async decoding + AVIF pipeline

### DIFF
--- a/scripts/fetch-images.mjs
+++ b/scripts/fetch-images.mjs
@@ -34,11 +34,20 @@ function extractImageUrls(booksData, theatreData) {
       if (book.mainImage?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
         urls.push(book.mainImage);
       }
+      if (book.mainImageAvif?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
+        urls.push(book.mainImageAvif);
+      }
       if (book.mainImageThumb?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
         urls.push(book.mainImageThumb);
       }
+      if (book.mainImageThumbAvif?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
+        urls.push(book.mainImageThumbAvif);
+      }
       if (book.mainImageCard?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
         urls.push(book.mainImageCard);
+      }
+      if (book.mainImageCardAvif?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
+        urls.push(book.mainImageCardAvif);
       }
     }
   }
@@ -48,8 +57,14 @@ function extractImageUrls(booksData, theatreData) {
       if (review.imageUrl?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
         urls.push(review.imageUrl);
       }
+      if (review.imageUrlAvif?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
+        urls.push(review.imageUrlAvif);
+      }
       if (review.imageUrlCard?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
         urls.push(review.imageUrlCard);
+      }
+      if (review.imageUrlCardAvif?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
+        urls.push(review.imageUrlCardAvif);
       }
     }
   }

--- a/src/components/BookModal.astro
+++ b/src/components/BookModal.astro
@@ -62,7 +62,9 @@
 
     var html = '<div class="book-modal-header">';
     var fallbackAttr = (b.cover && cover !== b.cover) ? ' data-fallback="' + esc(b.cover) + '" onerror="this.src=this.dataset.fallback;this.onerror=null"' : '';
-    html += '<img class="book-modal-cover" src="' + esc(cover) + '" width="140" height="210" alt="' + esc(b.title) + ' cover"' + fallbackAttr + '>';
+    var avifSrc = b.coverAvif ? '<source srcset="' + esc(b.coverAvif) + '" type="image/avif">' : '';
+    var imgTag = '<img class="book-modal-cover" src="' + esc(cover) + '" width="140" height="210" alt="' + esc(b.title) + ' cover" decoding="async"' + fallbackAttr + '>';
+    html += avifSrc ? ('<picture>' + avifSrc + imgTag + '</picture>') : imgTag;
     html += '<div class="book-modal-info">';
     html += '<div class="book-modal-title">' + esc(b.title) + '</div>';
     if (b.series) {

--- a/src/components/Bookshelf.astro
+++ b/src/components/Bookshelf.astro
@@ -81,7 +81,14 @@ function hasLocalImage(asin: string): boolean {
         return (
           <li class={`shelf-book${b.status === 'in_progress' ? ' shelf-book-active' : ''}`} style={`animation-delay: ${i * 0.08}s`} data-book={bookData} tabindex="0" aria-label={`${b.title} by ${b.author}`}>
             <div class="shelf-cover-wrapper">
-              <img src={imgSrc} srcset={imgSrcset} width="80" height="120" alt={b.title} loading="lazy" data-fallback={fallbackAttr} onerror={fallbackAttr ? "this.srcset='';this.src=this.dataset.fallback;this.onerror=null" : undefined}>
+              {b.coverAvif ? (
+                <picture>
+                  <source srcset={`${b.coverCardAvif} 1x, ${b.coverThumbAvif} 2x`} type="image/avif" />
+                  <img src={imgSrc} srcset={imgSrcset} width="80" height="120" alt={b.title} loading="lazy" decoding="async" data-fallback={fallbackAttr} onerror={fallbackAttr ? "this.srcset='';this.src=this.dataset.fallback;this.onerror=null" : undefined} />
+                </picture>
+              ) : (
+                <img src={imgSrc} srcset={imgSrcset} width="80" height="120" alt={b.title} loading="lazy" decoding="async" data-fallback={fallbackAttr} onerror={fallbackAttr ? "this.srcset='';this.src=this.dataset.fallback;this.onerror=null" : undefined} />
+              )}
             </div>
             <div class="shelf-book-title"><span>{b.title}</span></div>
             <div class="shelf-book-author">{b.author}</div>

--- a/src/lib/adapters.ts
+++ b/src/lib/adapters.ts
@@ -94,6 +94,9 @@ export interface AdaptedBookEntry {
   cover: string | null;
   coverThumb: string | null;
   coverCard: string | null;
+  coverAvif: string | null;
+  coverThumbAvif: string | null;
+  coverCardAvif: string | null;
   notes: string | null;
 }
 
@@ -329,6 +332,9 @@ export function adaptBooks(booksData: BooksExport): AdaptedBooks {
       cover: localizeImageUrl(b.mainImage ?? null),
       coverThumb: localizeImageUrl(b.mainImageThumb ?? null),
       coverCard: localizeImageUrl((b as any).mainImageCard ?? null),
+      coverAvif: localizeImageUrl((b as any).mainImageAvif ?? null),
+      coverThumbAvif: localizeImageUrl((b as any).mainImageThumbAvif ?? null),
+      coverCardAvif: localizeImageUrl((b as any).mainImageCardAvif ?? null),
       notes: b.notes ?? null,
     };
   });

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -18,3 +18,16 @@ export function imgFallbackAttrs(localSrc: string | null, originalUrl: string | 
   if (!originalUrl || !localSrc || localSrc === originalUrl) return '';
   return ` data-fallback="${originalUrl}" onerror="this.srcset='';this.src=this.dataset.fallback;this.onerror=null"`;
 }
+
+/** Build <picture> markup for an image with AVIF + WebP sources.
+ *  Returns HTML string suitable for both Astro templates and ES5 inline scripts. */
+export function pictureWithAvif(opts: {
+  avifSrcset: string | null;
+  imgAttrs: string;
+}): string {
+  if (opts.avifSrcset) {
+    return '<picture><source srcset="' + opts.avifSrcset + '" type="image/avif">' +
+           '<img ' + opts.imgAttrs + '></picture>';
+  }
+  return '<img ' + opts.imgAttrs + '>';
+}

--- a/src/lib/updaters-theatre.ts
+++ b/src/lib/updaters-theatre.ts
@@ -33,9 +33,13 @@ export function updateTheatreReviews(data: TheatreReviewsExport): void {
       const cardUrl = localizeImageUrl((r as any).imageUrlCard ?? null);
       const fallback = imgFallbackAttrs(cardUrl || localSrc, r.imageUrl);
       if (cardUrl) {
-        html += `<img src="${esc(cardUrl)}" srcset="${esc(cardUrl)} 1x, ${esc(localSrc ?? r.imageUrl)} 2x" width="95" height="143" alt="${esc(r.title)}" loading="lazy" referrerpolicy="no-referrer"${fallback}>`;
+        var avifSrc = r.imageUrlCardAvif ? ('<source srcset="' + esc(r.imageUrlCardAvif) + ' 1x, ' + esc(r.imageUrlAvif ?? r.imageUrl) + ' 2x" type="image/avif">') : '';
+        var imgTag = '<img src="' + esc(cardUrl) + '" srcset="' + esc(cardUrl) + ' 1x, ' + esc(localSrc ?? r.imageUrl) + ' 2x" width="95" height="143" alt="' + esc(r.title) + '" loading="lazy" decoding="async" referrerpolicy="no-referrer"' + fallback + '>';
+        html += avifSrc ? ('<picture>' + avifSrc + imgTag + '</picture>') : imgTag;
       } else {
-        html += `<img src="${esc(localSrc ?? r.imageUrl)}" width="95" height="143" alt="${esc(r.title)}" loading="lazy" referrerpolicy="no-referrer"${fallback}>`;
+        var avifSrc = r.imageUrlAvif ? ('<source srcset="' + esc(r.imageUrlAvif) + '" type="image/avif">') : '';
+        var imgTag = '<img src="' + esc(localSrc ?? r.imageUrl) + '" width="95" height="143" alt="' + esc(r.title) + '" loading="lazy" decoding="async" referrerpolicy="no-referrer"' + fallback + '>';
+        html += avifSrc ? ('<picture>' + avifSrc + imgTag + '</picture>') : imgTag;
       }
     }
     if (r.rating) {

--- a/src/lib/updaters.ts
+++ b/src/lib/updaters.ts
@@ -1006,7 +1006,16 @@ export function updateBookshelf(data: AdaptedBooks): void {
       html += '<div class="shelf-book' + activeClass + '" style="animation-delay: ' + (i * 0.08) + 's" data-book=\'' + bookData.replace(/'/g, '&#39;') + '\' tabindex="0" aria-label="' + esc(b.title) + ' by ' + esc(b.author) + '">';
       html += '<div class="shelf-cover-wrapper">';
       const srcsetAttr = displayCardSrc ? ' srcset="' + esc(displayCardSrc) + ' 1x, ' + esc(displayCoverSrc) + ' 2x"' : '';
-      html += '<img src="' + esc(displayCardSrc || displayCoverSrc) + '"' + srcsetAttr + ' width="80" height="120" alt="' + esc(b.title) + '" loading="lazy"' + imgFallbackAttrs(displayCardSrc || displayCoverSrc, b.cover) + '>';
+      var avifSrcset = '';
+      if (b.coverCardAvif && b.coverThumbAvif) {
+        avifSrcset = ' srcset="' + esc(b.coverCardAvif) + ' 1x, ' + esc(b.coverThumbAvif) + ' 2x" type="image/avif"';
+      }
+      var imgAttrs = 'src="' + esc(displayCardSrc || displayCoverSrc) + '"' + srcsetAttr + ' width="80" height="120" alt="' + esc(b.title) + '" loading="lazy" decoding="async"' + imgFallbackAttrs(displayCardSrc || displayCoverSrc, b.cover);
+      if (avifSrcset) {
+        html += '<picture><source' + avifSrcset + '><img ' + imgAttrs + '></picture>';
+      } else {
+        html += '<img ' + imgAttrs + '>';
+      }
       html += '</div>';
       html += '<div class="shelf-book-title"><span>' + esc(b.title) + '</span></div>';
       html += '<div class="shelf-book-author">' + esc(b.author) + '</div>';

--- a/src/showcase/theatre-reviews.astro
+++ b/src/showcase/theatre-reviews.astro
@@ -98,13 +98,14 @@ const PLACEHOLDER = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg
                     return (
                       <div class="sc-theatre-card" style={`animation-delay: ${i * 0.08}s`}>
                         <div class="sc-theatre-poster-wrap">
-                          <img
-                            src={r.imageUrl ?? PLACEHOLDER}
-                            width="95"
-                            height="143"
-                            alt={r.title}
-                            loading="lazy"
-                          />
+                          {r.imageUrlAvif ? (
+                            <picture>
+                              <source srcset={r.imageUrlAvif} type="image/avif" />
+                              <img src={r.imageUrl ?? PLACEHOLDER} width="95" height="143" alt={r.title} loading="lazy" decoding="async" />
+                            </picture>
+                          ) : (
+                            <img src={r.imageUrl ?? PLACEHOLDER} width="95" height="143" alt={r.title} loading="lazy" decoding="async" />
+                          )}
                           {r.rating && (
                             <span
                               class="sc-theatre-grade"

--- a/src/types/exports.ts
+++ b/src/types/exports.ts
@@ -189,6 +189,9 @@ export interface TheatreReviewEntry {
   ratingNumeric: number | null;
   excerpt: string;
   imageUrl: string | null;
+  imageUrlAvif: string | null;
+  imageUrlCard: string | null;
+  imageUrlCardAvif: string | null;
   imageWidth: number | null;
   imageHeight: number | null;
 }


### PR DESCRIPTION
## Summary
- Add `decoding="async"` to all lazy-loaded images for non-blocking decode
- Add AVIF encoding to OptimizeImages Lambda (parallel with WebP)
- Update frontend types, adapters, and `<picture>` markup to serve AVIF as primary format
- Fix `CDN_DOMAIN` → `CLOUDFRONT_DOMAIN` (auto-wired by mantle framework)
- Rebuild sharp Lambda layer v2 with linux-arm64 native binaries

## Changes
- `Bookshelf.astro`, `BookModal.astro`, `theatre-reviews.astro`: `<picture>` with AVIF source
- `adapters.ts`, `exports.ts`: AVIF type fields
- `updaters.ts`, `updaters-theatre.ts`: AVIF-aware image resolution
- `fetch-images.mjs`: AVIF URL extraction
- `image-utils.ts`: AVIF priority helper

## Paired With
- Backend PR: https://github.com/j0nathan-ll0yd/mantle-LifegamesPortal/pull/new/image-optimization-decoding-avif