### PR TITLE
feat: upgrade Astro 5→6 and migrate to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Astro to GitHub Pages
+name: Deploy to Cloudflare Pages
 
 on:
   push:
@@ -7,37 +7,39 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
   issues: write
 
 concurrency:
-  group: pages
+  group: deploy
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build Astro
-        uses: withastro/action@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=human-datastream
 
   check-images:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -78,16 +80,3 @@ jobs:
           \`\`\`
           EOF
           )"
-
-  purge-cache:
-    needs: deploy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Purge Cloudflare cache
-        run: |
-          curl -s -X POST \
-            "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
-            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            --data '{"purge_everything":true}' \
-            --fail-with-body

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -22,7 +22,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Run visual regression tests
         run: npx playwright test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-Human Datastream -- personal portfolio site for Jonathan Lloyd. A single-page sci-fi dashboard built with Astro 5.x (static output), hosted on GitHub Pages at https://jonathanlloyd.me.
+Human Datastream -- personal portfolio site for Jonathan Lloyd. A single-page sci-fi dashboard built with Astro 6.x (static output), hosted on Cloudflare Pages at https://jonathanlloyd.me.
 
 ## Build
 
@@ -58,7 +58,6 @@ Tests use Playwright `toHaveScreenshot()`. Baselines live in `tests/visual/__scr
 ## Do Not
 
 - Use ES6+ syntax in inline scripts
-- Remove `.nojekyll` (GitHub Pages needs it)
 - Modify CSS files without testing breakpoints at 1400px, 1100px, 900px, 600px
 
 ## Detailed Context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Personal portfolio site for Jonathan Lloyd, styled as a "Human Datastream" dashboard. Built with Astro (static site generation) and hosted on GitHub Pages. The site ships 0 KB JavaScript by default, with selective `is:inline` scripts for particles, map, and animations.
+Personal portfolio site for Jonathan Lloyd, styled as a "Human Datastream" dashboard. Built with Astro (static site generation) and hosted on Cloudflare Pages. The site ships 0 KB JavaScript by default, with selective `is:inline` scripts for particles, map, and animations.
 
 ## Site Identity & SEO
 
@@ -108,7 +108,6 @@ Backend Engineering, Software Engineering, Engineering Leadership, Cloud Infrast
 ├── .editorconfig             # 2-space indent, UTF-8, LF
 ├── .gitattributes            # Binary marker for screenshot PNGs
 ├── .gitignore
-├── .nojekyll                 # Bypass Jekyll on GitHub Pages
 ├── AGENTS.md                 # Cross-tool AI coding context (complements CLAUDE.md)
 └── README.md
 ```
@@ -158,7 +157,7 @@ Amazon/Squarespace → OptimizeImages Lambda → S3 (WebP) → CloudFront
                                                               ↓
                                               npm run fetch:images (run locally)
                                                               ↓
-                                              public/images/ → git commit → GitHub Pages → Cloudflare CDN
+                                              public/images/ → git commit → Cloudflare Pages
 ```
 
 **How it works:**
@@ -193,7 +192,7 @@ Three independent caching layers operating on separate domains with zero overlap
 
 **JSON freshness guarantee:** JSON data is fetched client-side from CloudFront (`d1pfm520aduift.cloudfront.net`), a completely separate origin from `jonathanlloyd.me`. Cloudflare never sees, touches, or caches JSON requests. This is an architectural invariant. All JSON fetches use `cache: 'no-store'` to bypass the browser HTTP cache. The SW uses `NetworkFirst` (3s timeout) so fresh data is always served when online, with cached fallback only when offline. Poll requests (`?_poll=1`) bypass the Workbox service worker entirely. A `pageshow` listener triggers `pollNow()` on bfcache restoration to refresh data when frozen tabs are restored.
 
-**Deploy pipeline:** Push to `main` → Build Astro → Deploy to GitHub Pages → Purge entire Cloudflare cache + Check for new images (parallel).
+**Deploy pipeline:** Push to `main` → Build Astro → Deploy to Cloudflare Pages + Check for new images (parallel). Cloudflare Pages auto-invalidates cache on deploy.
 
 **Cloudflare cache rules** (configured in dashboard, priority order):
 1. `/_astro/*` — 1 year edge + browser TTL (content-hashed, immutable)
@@ -348,7 +347,6 @@ Then run `npm run test:visual:update` to generate the new baseline.
 
 ### DO NOT
 - Use ES6+ syntax (`let`, `const`, arrow functions, template literals) in inline `<script is:inline>` blocks
-- Remove `.nojekyll` -- GitHub Pages needs it to serve the site without Jekyll processing
 - Modify `public/css/` files without testing all responsive breakpoints
 
 ### DO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,357 +2,227 @@
 
 ## Project Overview
 
-Personal portfolio site for Jonathan Lloyd, styled as a "Human Datastream" dashboard. Built with Astro (static site generation) and hosted on Cloudflare Pages. The site ships 0 KB JavaScript by default, with selective `is:inline` scripts for particles, map, and animations.
+Personal portfolio for Jonathan Lloyd at `jonathanlloyd.me`, styled as a sci-fi "Human Datastream" dashboard. Built with Astro 6 (static output, 0 KB JS by default), deployed to Cloudflare Pages via Wrangler. Selective `is:inline` scripts for particles, map, and animations.
 
-## Site Identity & SEO
+## Commands
 
-The site positions Jonathan Lloyd as a backend engineer whose portfolio **is** the technical showcase -- a living data dashboard tracking body and mind in an AI-centric world. All metadata copy derives from the core statement below.
+```bash
+npm install                  # use --legacy-peer-deps if @vite-pwa/astro peer dep gate fails
+npm run dev                  # localhost:4321 (includes /showcase/ routes)
+npm run build                # outputs to dist/
+npm run preview              # preview production build
 
-### Core Statement
+npm run test                 # Vitest unit tests (tests/lib/)
+npm run test:build           # Vitest build-output tests (tests/build/)
+npm run test:visual          # Playwright screenshot regression (4 viewports)
+npm run test:visual:update   # regenerate baselines after intentional visual changes
+npm run test:visual:ui       # interactive Playwright UI
 
-> Personal portfolio of Jonathan Lloyd, an engineering director and backend engineer, built as a living data dashboard. Real biometrics and constant updates of his whole body (health, activity, hydration, location) and mind (coding, reading, learning). Jack into his human datastream as the world becomes more AI-centric.
+npm run fetch:images         # download new images from CloudFront to public/images/
+npm run generate:types       # regenerate TS types from JSON schemas
+npm run generate:fixtures    # regenerate test fixtures
+npm run validate:fixtures    # validate generated fixtures against schemas
+npm run compliance           # widget specification compliance check
+```
 
-### Metadata by Surface
-
-| Surface | Copy | Location |
-|---------|------|----------|
-| **Page Title** | Jonathan Lloyd — Human Datastream | `Dashboard.astro` frontmatter default |
-| **Meta Description** | A living data dashboard by engineer, Jonathan Lloyd — tracking body (health, activity, hydration) and mind (coding, reading). Jack into his human datastream. | `Dashboard.astro` `description` prop |
-| **OG / Twitter Description** | Personal portfolio of Jonathan Lloyd, an engineering director and backend engineer, built as a living data dashboard. Real biometrics tracking body (health, activity, hydration, location) and mind (coding, reading, learning). Jack into his human datastream. | `Dashboard.astro` `ogDescription` prop |
-| **JSON-LD WebSite** | *(Core statement, verbatim)* | `Dashboard.astro` JSON-LD block |
-| **JSON-LD Person** | Engineering director and backend engineer with 24+ years of experience. Built this portfolio as a living data dashboard -- real biometrics and constant updates of body (health, activity, hydration, location) and mind (coding, reading, learning). Jack into his human datastream as the world becomes more AI-centric. | `Dashboard.astro` JSON-LD block |
-| **PWA Manifest** | Living data dashboard -- tracking body and mind. Jack into his human datastream. | `astro.config.mjs` + `public/manifest.webmanifest` |
-| **OG Image Title** | ENGINEERING DIRECTOR | `src/components/OGImage.astro` |
-| **OG Image Quote** | Jack into his human datastream | `src/components/OGImage.astro` |
-| **Keywords** | backend engineer portfolio, software engineer portfolio, data visualization dashboard, living data dashboard, human datastream, engineering director, personal dashboard, biometrics dashboard, GitHub activity visualization, Astro static site | `Dashboard.astro` keywords meta tag |
-
-### JSON-LD knowsAbout
-
-Backend Engineering, Software Engineering, Engineering Leadership, Cloud Infrastructure, Data Visualization, Serverless Architecture, TypeScript, Go, AWS
-
-### Key SEO Architecture Decisions
-
-- `og:type` is `"profile"` (not `"website"`) -- enables `profile:first_name`/`profile:last_name` tags
-- `ogDescription` is a separate prop from `description` -- allows longer copy for social cards vs. Google snippet
-- JSON-LD `Person.description` is hardcoded (not the meta description prop) -- richer, personality-forward copy for structured data
-- Keywords meta tag targets Bing/DuckDuckGo (Google ignores it)
-- `robots.txt` blocks AI scraping bots (GPTBot, ClaudeBot, CCBot, etc.) but allows search engines and AI search (PerplexityBot, OAI-SearchBot); each blocked bot has `Allow: /llms.txt` before `Disallow: /` (Option A)
-- `llms.txt` is a **discovery index** (not complete content) — it points at backend-composed rich variants on CloudFront: `llms-small.txt`, `llms-full.txt`, `index.md`. See `docs/wiki/LLM-Content-Spec.md` for the full spec.
-- Rich LLM content (`llms-small.txt`, `llms-full.txt`, `index.md`) lives on CloudFront at `d1pfm520aduift.cloudfront.net` and is composed by the backend Lambda on data-change events — do not hand-edit these files here; edits will be overwritten on the next compose run
-- Keep `public/llms.txt` aligned with the backend composer spec in `docs/wiki/LLM-Content-Spec.md` when changing canonical URLs or data sources
-- Agent readiness files live in `public/.well-known/` — see `docs/wiki/LLM-Content-Spec.md` § "Agent Readiness" for the full inventory, Cloudflare configuration steps, and score breakdown
-- `robots.txt` includes `Content-Signal: search=yes, ai-train=no, ai-input=yes` per contentsignals.org IETF draft
-- WebMCP tools are registered in `Dashboard.astro` via `navigator.modelContext.provideContext()` with ES5 syntax and feature detection
-- If updating `SKILL.md`, recompute its SHA-256 digest and update `agent-skills/index.json`
+Deploy: push to `main` -> GitHub Actions (`deploy.yml`) -> `npm run build` -> `cloudflare/wrangler-action@v3` -> Cloudflare Pages. Parallel `check-images` job detects uncommitted CloudFront images and creates a GitHub issue.
 
 ## Repository Structure
 
 ```
 .
-├── astro.config.mjs          # Astro + PWA configuration
-├── package.json              # Dependencies and scripts
-├── tsconfig.json             # TypeScript (extends astro/tsconfigs/strict)
+├── astro.config.mjs          # Astro + PWA + sitemap + dev-only showcase integration
+├── package.json              # Astro 6, Vitest, Playwright, @vite-pwa/astro
+├── tsconfig.json             # extends astro/tsconfigs/strict
+├── vitest.config.ts          # unit tests (tests/lib/), coverage on src/lib/
+├── vitest.build.config.ts    # build-output tests (tests/build/)
+├── playwright.config.ts      # 4 viewport projects, Chromium only
 ├── src/
-│   ├── components/           # 14 .astro components (one per widget)
-│   ├── layouts/              # Dashboard.astro, Showcase.astro
-│   ├── pages/                # index.astro (data loading, page composition)
-│   └── showcase/             # Dev-only component showcase pages (not in src/pages/)
+│   ├── pages/
+│   │   ├── index.astro       # Single page: loads data/*.json, composes all widgets
+│   │   └── 404.astro         # Custom 404 page
+│   ├── layouts/
+│   │   ├── Dashboard.astro   # HTML head, SEO meta, JSON-LD, OG tags, analytics
+│   │   └── Showcase.astro    # Layout for dev-only showcase pages
+│   ├── components/           # 56 Astro components total
+│   │   ├── *.astro           # 17 top-level (IdentityCard, HeartRate, Bookshelf, etc.)
+│   │   ├── github/           # 29 GitHub widgets + co-located .query.ts files
+│   │   └── location/         # 10 location widgets (CityConstellation, WaffleGrid, etc.)
+│   ├── lib/                  # TypeScript modules
+│   │   ├── constants.ts      # ENDPOINTS, CLOUDFRONT_BASE, WEBSOCKET_URL, color maps
+│   │   ├── api.ts            # CloudFront data fetching
+│   │   ├── adapters.ts       # JSON -> component props (applies localizeImageUrl)
+│   │   ├── poll-engine.ts    # PollEngine: fast-tier (30s) and slow-tier (120s) refresh
+│   │   ├── ws-client.ts      # WebSocket client with adaptive polling fallback
+│   │   ├── image-utils.ts    # localizeImageUrl(), imgFallbackAttrs()
+│   │   ├── heart-rate.ts     # Heart rate data transforms
+│   │   ├── sleep.ts          # Sleep data transforms
+│   │   └── updaters*.ts      # DOM updaters (status, theatre, focus, odometer, leaderboard)
+│   ├── styles/
+│   │   └── layout.css        # Panel layout, responsive breakpoints
+│   └── showcase/             # Dev-only component showcase pages (14 routes)
 ├── public/
 │   ├── css/
 │   │   ├── tokens.css        # Design tokens (colors, typography, spacing, radii, blur, glows)
 │   │   ├── base.css          # Reset, body, scrollbar, global styles
-│   │   ├── layout.css        # .command-layout, .left-panel, .top-bar, .right-panel, responsive
 │   │   ├── components.css    # Widget cards, identity card, terminal, map, charts, modals
-│   │   ├── effects.css       # Animations, transitions, glows, particle canvas
-│   │   └── showcase.css      # Styles for dev-only component showcase
-│   ├── assets/               # avatar.svg, favicon.svg, logo.svg, PWA icons
-│   ├── js/
-│   │   ├── particles.js      # Three.js particle background (legacy, now inlined in index.astro)
-│   │   └── clock.js          # Live clock (legacy, now inlined in index.astro)
+│   │   └── effects.css       # Animations, transitions, glows, particle canvas
+│   ├── assets/               # avatar (svg/jpg/webp), favicon.svg, logo.svg, PWA icons, og-image
+│   ├── images/               # Locally cached book covers and theatre posters (AVIF)
 │   ├── .well-known/
 │   │   ├── api-catalog       # RFC 9727 API catalog (linkset JSON, extensionless)
 │   │   ├── mcp/server-card.json  # MCP Server Card (read-only data resources)
-│   │   └── agent-skills/     # Agent Skills Discovery v0.2.0
-│   │       ├── index.json    # Skills index with SHA-256 digests
-│   │       └── portfolio-expert/SKILL.md  # Portfolio context skill
-│   ├── llms.txt              # LLM site context (llmstxt.org spec)
-│   ├── robots.txt            # Crawl policy (blocks AI scrapers, allows search, Content Signals)
+│   │   └── agent-skills/     # Agent Skills Discovery v0.2.0 (index.json + SKILL.md)
+│   ├── llms.txt              # LLM discovery index (points to CloudFront-hosted rich variants)
+│   ├── robots.txt            # Blocks AI scrapers, allows search engines, Content-Signal header
 │   └── manifest.webmanifest  # PWA manifest
-├── data/
+├── data/                     # Build-time JSON data
 │   ├── profile.json          # Name, title, bio, avatar, social links
 │   ├── health.json           # Heart rate, steps, sleep, hydration, workouts
 │   ├── github.json           # Contribution heatmap, recent commits, stats
 │   ├── books.json            # Bookshelf with covers, authors, status
 │   ├── reading.json          # RSS/article feed items
 │   ├── system.json           # System status indicators
+│   ├── theatre-reviews-sample.json
 │   └── showcase-empty.json   # Empty state props for showcase pages
-├── docs/
-│   └── wiki/                 # Documentation (synced to GitHub Wiki)
-│       ├── Home.md           # Wiki homepage
-│       ├── Astro-Implementation.md  # Architecture and components
-│       ├── Brand-Guide.md    # Design system reference
-│       └── Why-Astro.md      # Framework evaluation
 ├── tests/
+│   ├── lib/                  # 12 unit test files covering all src/lib/ modules
+│   ├── build/                # 4 build-output tests (SEO, JSON-LD, data integrity, images)
 │   ├── visual/
-│   │   ├── dashboard.spec.ts # Visual regression tests (4 viewports × 4 tests)
-│   │   ├── screenshot.css    # Stabilization stylesheet (hides dynamic content)
-│   │   └── __screenshots__/  # Baseline PNGs organized by viewport project
+│   │   ├── dashboard.spec.ts # Screenshot tests (4 viewports)
+│   │   ├── screenshot.css    # Stabilization: hides clock, timestamps, particles
+│   │   └── __screenshots__/  # Baseline PNGs by viewport project
 │   └── fixtures/             # Stable JSON fixtures for API route interception
-├── .github/
-│   ├── workflows/
-│   │   ├── deploy.yml        # Build + deploy + Cloudflare purge + image check
-│   │   ├── visual-tests.yml  # Playwright visual regression tests on PRs
-│   │   └── sync-wiki.yml     # Sync docs/wiki/ to GitHub Wiki
-│   └── scripts/              # sync-wiki.sh, generate-sidebar.sh
-├── playwright.config.ts      # Playwright config (4 viewport projects, webServer)
-├── .editorconfig             # 2-space indent, UTF-8, LF
-├── .gitattributes            # Binary marker for screenshot PNGs
-├── .gitignore
-├── AGENTS.md                 # Cross-tool AI coding context (complements CLAUDE.md)
-└── README.md
+├── test/fixtures/            # Fixture factory system (generate, validate, variations)
+├── scripts/                  # fetch-images, generate-types, widget-compliance, agent-readiness
+├── cloudflare/               # Cloudflare Worker for API catalog Content-Type
+├── docs/wiki/                # Architecture docs (synced to GitHub Wiki via sync-wiki.yml)
+├── .github/workflows/
+│   ├── deploy.yml            # Build + deploy + Cloudflare purge + image check
+│   ├── visual-tests.yml      # Playwright visual regression on PRs
+│   └── sync-wiki.yml         # Sync docs/wiki/ to GitHub Wiki
+└── AGENTS.md                 # Cross-tool AI coding context (complements this file)
 ```
+
+## Data Flow
+
+| Context | Mechanism |
+|---|---|
+| Build-time | `fs.readFileSync` from `data/*.json` in `index.astro` frontmatter |
+| Client-side | Live data fetched from CloudFront (`d1pfm520aduift.cloudfront.net`) via `src/lib/api.ts` |
+| Polling | `PollEngine` refreshes fast-tier (30s) and slow-tier (120s); `?_poll=1` bypasses SW |
+| WebSocket | `ws-client.ts` connects to API Gateway WebSocket with adaptive polling fallback |
+
+**10 live endpoints** (defined in `src/lib/constants.ts`): health, sleep, workouts, books, starredRepos, githubEvents, articles, location, focus, theatreReviews.
+
+## Image Pipeline
+
+Book covers and theatre posters: Amazon/Squarespace -> OptimizeImages Lambda -> S3 (AVIF) -> CloudFront -> `npm run fetch:images` -> `public/images/` -> git commit -> Cloudflare Pages.
+
+- `scripts/fetch-images.mjs` downloads images locally or checks for new ones (`--check-only`)
+- `src/lib/image-utils.ts` rewrites CloudFront URLs to local `/images/` paths via `localizeImageUrl()`
+- `onerror` fallback swaps `<img>` src to CloudFront URL if local image missing
+- CI `check-images` job detects new images and creates a GitHub issue
+
+## Caching Architecture
+
+| Layer | Domain | TTL |
+|---|---|---|
+| Cloudflare | `jonathanlloyd.me` | HTML 5min, `/_astro/*` 1yr, images/fonts 1mo, SW 5min |
+| CloudFront | `d1pfm520aduift.cloudfront.net` | JSON 5min (s-maxage) |
+| Workbox SW | Both | Local images CacheFirst 30d, CloudFront JSON NetworkFirst 3s timeout |
+
+**Invariant:** JSON data is fetched client-side from CloudFront (separate origin). Cloudflare never caches JSON. All JSON fetches use `cache: 'no-store'`. Poll requests (`?_poll=1`) bypass the SW entirely. `pageshow` listener triggers `pollNow()` on bfcache restoration.
 
 ## Conventions
 
 ### Editor / Formatting
-- 2-space indentation (all files)
-- UTF-8 charset, LF line endings
-- Trim trailing whitespace (except `.md`)
-- Insert final newline
+- 2-space indentation, UTF-8, LF line endings, trim trailing whitespace (except `.md`), final newline
 
 ### CSS
-- All colors, typography, spacing, and effects use custom properties from `public/css/tokens.css`
-- Typography and spacing tokens use fluid `clamp()` values that scale between 600px–1400px viewports (e.g., `--font-size-base: clamp(0.62rem, 0.55rem + 0.20vw, 0.72rem)`)
-- Font-size clamp() values use `rem + vw` preferred values for WCAG 1.4.4 zoom compliance; spacing tokens use `px` bounds with `rem + vw` preferred values
-- `.tri-card` has `container-type: inline-size` enabling `@container` queries for widget-level responsive adaptation
-- Glass-morphism pattern: `background: var(--glass-bg); border: 1px solid var(--glass-border); backdrop-filter: blur(var(--blur-md));`
-- Widget card structure: `.tri-card` > `.widget-header` + `.widget-body`
+- All values from `public/css/tokens.css` custom properties (colors, spacing, typography)
+- Fluid `clamp()` tokens scale 600px-1400px; `rem + vw` preferred values for WCAG 1.4.4
+- `.tri-card` has `container-type: inline-size` for `@container` queries
+- Glass-morphism: `background: var(--glass-bg); border: 1px solid var(--glass-border); backdrop-filter: blur(var(--blur-md));`
+- Widget card: `.tri-card` > `.widget-header` + `.widget-body`
 - Widget header: `.widget-label` + `.widget-header-right` > `.live-dot` + `.widget-timestamp`
-- Accent classes: `.tri-card-accent-pink`, `-blue`, `-green`, `-amber`, `-purple`, `-red`, `-cyan`, `-orange`, `-indigo`
+- Accent classes: `.tri-card-accent-{pink,blue,green,amber,purple,red,cyan,orange,indigo}`
+- Layout CSS in `src/styles/layout.css`; all other CSS in `public/css/`
 
 ### JavaScript (Inline Scripts)
-- ES5 only: `var`, IIFEs, `function` declarations -- no `let`/`const`/arrow functions
-- Each script wrapped in an IIFE: `(function() { ... })();`
-- All client JS is embedded in `src/pages/index.astro` as `<script is:inline>` blocks
+- ES5 only in `<script is:inline>` blocks: `var`, IIFEs, `function` declarations -- no `let`/`const`/arrow functions
+- Each script wrapped in IIFE: `(function() { ... })();`
+- All client JS embedded in `src/pages/index.astro` as `<script is:inline>` blocks
 
 ### Astro Components
-- 14 components in `src/components/`, one per widget
+- 56 components across `src/components/` (17 top-level, 29 github/, 10 location/)
+- GitHub and location widgets use co-located `.query.ts` files for data transforms
 - Props receive data objects parsed from JSON files
 - No client-side framework -- all rendering is build-time
 
-## Data Flow
+### Responsive Breakpoints
+- Fluid tokens in `tokens.css` handle typography/spacing scaling
+- Container queries on `.tri-card` handle widget internals
+- Structural breakpoints in `src/styles/layout.css`: 1100px (narrow left panel), 900px (single column), 600px (compact)
 
-| Context | How data is loaded |
-|---|---|
-| Astro build | `fs.readFileSync` from `data/*.json` in `src/pages/index.astro` frontmatter |
-| Client-side | Live data fetched from CloudFront (`d1pfm520aduift.cloudfront.net`) via `src/lib/api.ts` |
-| Polling | `PollEngine` refreshes fast-tier (30s) and slow-tier (120s) endpoints with `?_poll=1` to bypass SW |
+## SEO & Metadata
 
-## Image Pipeline
+Core statement: "Personal portfolio of Jonathan Lloyd, an engineering director and backend engineer, built as a living data dashboard. Real biometrics and constant updates of his whole body (health, activity, hydration, location) and mind (coding, reading, learning). Jack into his human datastream as the world becomes more AI-centric."
 
-Book covers and theatre posters flow through a multi-stage pipeline ending with same-origin serving via Cloudflare CDN:
+Key decisions:
+- `og:type` is `"profile"` (not `"website"`)
+- `ogDescription` is a separate prop from `description` (longer copy for social cards)
+- JSON-LD `Person.description` is hardcoded (personality-forward copy for structured data)
+- Keywords meta targets Bing/DuckDuckGo (Google ignores it)
+- `robots.txt` blocks AI scraping bots but allows search engines; each blocked bot has `Allow: /llms.txt`
+- `robots.txt` includes `Content-Signal: search=yes, ai-train=no, ai-input=yes` per IETF draft
+- WebMCP tools registered via `navigator.modelContext.provideContext()` with ES5 syntax
 
-```
-Amazon/Squarespace → OptimizeImages Lambda → S3 (WebP) → CloudFront
-                                                              ↓
-                                              npm run fetch:images (run locally)
-                                                              ↓
-                                              public/images/ → git commit → Cloudflare Pages
-```
+### LLM Content
+- `public/llms.txt` is a discovery index pointing to CloudFront-hosted rich variants (`llms-small.txt`, `llms-full.txt`, `index.md`)
+- Rich LLM content composed by backend Lambda -- do not hand-edit; see `docs/wiki/LLM-Content-Spec.md`
+- Agent readiness files in `public/.well-known/` -- see `docs/wiki/LLM-Content-Spec.md`
+- If updating `SKILL.md`, recompute SHA-256 digest and update `agent-skills/index.json`
 
-**How it works:**
-1. The backend `OptimizeImages` Lambda downloads images from Amazon (book covers) and Squarespace (theatre posters), optimizes to WebP via sharp, and uploads to S3 at `images/books/{asin}.webp` and `images/theatre/{slug}.webp`
-2. The Lambda rewrites JSON exports (`books.json`, `theatre-reviews.json`) with CloudFront image URLs
-3. **Locally**, run `npm run fetch:images` to download new images from CloudFront to `public/images/`. Commit and push — they are served as same-origin static assets cached by Cloudflare
-4. **In CI**, the `check-images` job runs `--check-only` mode: compares CloudFront image URLs against committed files. If new images are detected, it creates a GitHub issue with instructions to fetch and commit them
-5. The adapter layer (`src/lib/image-utils.ts`) rewrites CloudFront image URLs to local `/images/` paths via `localizeImageUrl()`
-6. If a local image is missing (new book added between deploys), `onerror` fallback swaps the `<img>` src to the original CloudFront URL — the user never sees a broken image
+## Testing
 
-**Key files:**
-- `scripts/fetch-images.mjs` — downloads images locally (`npm run fetch:images`) or checks for new ones (`--check-only`)
-- `src/lib/image-utils.ts` — `localizeImageUrl()` and `imgFallbackAttrs()` helpers
-- `src/lib/adapters.ts` — applies `localizeImageUrl()` to book cover/thumb URLs
-- `src/lib/updaters-theatre.ts` — applies `localizeImageUrl()` to theatre poster URLs
+### Unit Tests (Vitest)
+- `tests/lib/` -- 12 test files covering all `src/lib/` modules
+- `tests/build/` -- 4 build-output tests (SEO meta, JSON-LD, data integrity, image pipeline)
+- `test/fixtures/` -- factory-based fixture generation and validation system
+- Config: `vitest.config.ts` (unit), `vitest.build.config.ts` (build output)
 
-**When you add a new book or theatre review:**
-1. Backend Lambda optimizes the image and updates JSON on CloudFront
-2. Next deploy → CI `check-images` detects the new image → creates a GitHub issue
-3. Run `npm run fetch:images` locally → `git add public/images/ && git commit && git push`
-4. Image is now served from `jonathanlloyd.me`, cached by Cloudflare
+### Visual Regression (Playwright)
+- Chromium only, 4 viewports: desktop-1400, tablet-1100, tablet-768, mobile-600
+- Baselines in `tests/visual/__screenshots__/` (~1.3MB, committed to git)
+- CSS stylePath hides dynamic content; CloudFront endpoints stubbed with fixtures
+- Service worker blocked via `serviceWorkers: 'block'`
+- Cross-OS: generate baselines in Playwright Docker container for CI consistency
 
-## Caching Architecture
-
-Three independent caching layers operating on separate domains with zero overlap:
-
-| Layer | Domain | What it caches | TTL |
-|-------|--------|---------------|-----|
-| **Cloudflare** | `jonathanlloyd.me` | HTML (5min), `/_astro/*` JS/CSS (1yr), images/fonts (1mo), SW (5min) | Per cache rule |
-| **CloudFront** | `d1pfm520aduift.cloudfront.net` | JSON data exports (health, sleep, books, etc.) | 5min (s-maxage) |
-| **Workbox SW** | Both (separate rules) | Local images (CacheFirst 30d), CloudFront JSON (NetworkFirst 3s timeout) | Per strategy |
-
-**JSON freshness guarantee:** JSON data is fetched client-side from CloudFront (`d1pfm520aduift.cloudfront.net`), a completely separate origin from `jonathanlloyd.me`. Cloudflare never sees, touches, or caches JSON requests. This is an architectural invariant. All JSON fetches use `cache: 'no-store'` to bypass the browser HTTP cache. The SW uses `NetworkFirst` (3s timeout) so fresh data is always served when online, with cached fallback only when offline. Poll requests (`?_poll=1`) bypass the Workbox service worker entirely. A `pageshow` listener triggers `pollNow()` on bfcache restoration to refresh data when frozen tabs are restored.
-
-**Deploy pipeline:** Push to `main` → Build Astro → Deploy to Cloudflare Pages + Check for new images (parallel). Cloudflare Pages auto-invalidates cache on deploy.
-
-**Cloudflare cache rules** (configured in dashboard, priority order):
-1. `/_astro/*` — 1 year edge + browser TTL (content-hashed, immutable)
-2. `/sw.js`, `/manifest.webmanifest` — 5 min edge TTL (must stay fresh)
-3. Static media (png, jpg, webp, svg, woff2, ico) — 1 month edge, 1 week browser
-4. HTML catch-all — 5 min edge TTL
-
-## Component Showcase (Dev Only)
-
-A visual storyboard for iterating on components, available only during `npm run dev` at `/showcase/`. Routes are injected via a local Astro integration (`showcase-dev-only` in `astro.config.mjs`) that only activates when `command === 'dev'`. Showcase files live in `src/showcase/` (not `src/pages/`), so they are excluded from production builds.
-
-| Route | Page | Components |
-|---|---|---|
-| `/showcase` | `index.astro` | Landing page with cards linking to each domain group |
-| `/showcase/brand-guide` | `brand-guide.astro` | Colors, typography, glass-morphism, glows, spacing, animations |
-| `/showcase/identity-system` | `identity-system.astro` | IdentityCard, BioTerminal, SystemStatus, Command Bar, ComingSoon |
-| `/showcase/health-wellness` | `health-wellness.astro` | HeartRate, DailyActivity, Workouts, NightSummary, Hydration, Location |
-| `/showcase/contributions-commits` | `contributions-commits.astro` | ContributionGrid, ContributionCalendar, GitHubHeatmap, CommitLog, CommitTimeline, RecentCommits, + 6 trend widgets |
-| `/showcase/repositories-languages` | `repositories-languages.astro` | PinnedRepos, TopRepos, RepoShowcase, StarredRepoList, + 9 language/profile widgets |
-| `/showcase/activity-feeds` | `activity-feeds.astro` | DevActivityLog, DevActivityTimeline, DevActivityCards, DevActivityByRepo, DevActivityPulse, ActivityFeed |
-| `/showcase/reading-books` | `reading-books.astro` | ReadingFeed, Bookshelf, BookModal |
-| `/showcase/responsive-preview` | `responsive-preview.astro` | 4 device iframes + interactive widget scale slider (6 widgets at adjustable container widths) |
-
-Each component page renders all 45 components in 3 states (skeleton, empty, active) using data from `data/showcase-empty.json`, `data/*.json`, and `.query.ts` co-located exports.
-
-## Design System Quick Reference
-
-### Colors
-| Token | Value | Usage |
-|---|---|---|
-| `--bg` | `#06060f` | Page background |
-| `--neon-pink` | `#ff006e` | Primary accent, left panel border |
-| `--neon-blue` | `#3a86ff` | Secondary accent, hydration |
-| `--neon-green` | `#06d6a0` | Success, mind column |
-| `--neon-amber` | `#f59e0b` | Warning, heart rate |
-| `--neon-purple` | `#a855f7` | Sleep, night summary |
-| `--neon-red` | `#ef4444` | Alert states |
-| `--neon-cyan` | `#00d4ff` | Info, data streams |
-| `--neon-orange` | `#ff6b00` | Urgency, degraded state |
-| `--neon-indigo` | `#818cf8` | Deep/premium, cognitive |
-| `--text` | `#f0f0f0` | Primary text |
-| `--text-muted` | `#9ca3af` | Secondary text |
-
-### Glass-morphism
-```css
-background: var(--glass-bg-inset);     /* rgba(255,255,255,0.03) - recessed */
-background: var(--glass-bg);           /* rgba(255,255,255,0.07) - default */
-background: var(--glass-bg-raised);    /* rgba(255,255,255,0.11) - elevated */
-border: 1px solid var(--glass-border); /* rgba(255,255,255,0.1) */
-border: 1px solid var(--glass-border-strong); /* rgba(255,255,255,0.18) - emphasis */
-backdrop-filter: blur(var(--blur-md)); /* 16px */
-```
-
-### Typography
-- Font: `Space Grotesk` (Google Fonts)
-- 9 fluid tokens: `--font-size-xs` (0.36–0.42rem) through `--font-size-hero` (1.80–2.20rem)
-- All tokens use `clamp(min, preferred, max)` with `rem + vw` preferred values scaling across 600px–1400px viewports
-
-### Responsive Scaling
-The site uses a hybrid approach: **fluid `clamp()` tokens** for smooth scaling + **structural breakpoints** for layout changes.
-
-| Layer | Mechanism | What it handles |
-|---|---|---|
-| Fluid tokens | `clamp()` in `tokens.css` | Typography (9 tokens), spacing (16 tokens), top-bar height |
-| Container queries | `@container` on `.tri-card` | Widget internals: BPM size, book covers, hydration vessels, contribution grid |
-| Structural breakpoints | `@media` in `layout.css` | Panel stacking (900px), grid columns, identity card layout, safe-area insets |
-
-**Breakpoints** (structural layout changes only — font/spacing scaling is handled by fluid tokens):
-
-| Breakpoint | Behavior |
-|---|---|
-| `1100px` | Narrows left panel to 30%, adjusts identity card |
-| `900px` | Stacks to single column, horizontal identity card, 2-col widget grid |
-| `600px` | Single-column widgets, compact identity card, safe-area padding |
-
-**Key rules:**
-- Mobile overrides that fall **below** a fluid token's minimum (e.g., `.id-name` at 1.2rem vs `--font-size-hero` min of 1.80rem) are kept as structural overrides in `layout.css`
-- Component font sizes reference tokens (`var(--font-size-base)`) rather than hardcoded rem values
-- Widget padding uses spacing tokens (`var(--space-12)`, `var(--space-18)`, etc.)
-- The book modal uses fluid `clamp()` for width, padding, and border-radius — no breakpoint overrides
-
-## Running Locally
-
-```bash
-npm install
-npm run dev       # http://localhost:4321
-npm run build     # Outputs to dist/
-npm run preview   # Preview build locally
-```
-
-## Visual Regression Testing
-
-Screenshot tests using Playwright's built-in `toHaveScreenshot()` capture the dashboard at 4 viewport sizes to prevent layout regressions.
-
-### Test Architecture
-
-```
-playwright.config.ts          # 4 viewport projects, webServer: build && preview
-tests/visual/
-  dashboard.spec.ts           # 4 tests × 4 viewports = 16 total
-  screenshot.css              # Hides dynamic content for stable screenshots
-  __screenshots__/            # Baseline PNGs committed to git (~1.3MB)
-    desktop-1400/             # 1400×900
-    tablet-1100/              # 1100×800
-    tablet-768/               # 768×1024
-    mobile-600/               # 600×900
-tests/fixtures/               # 10 JSON files stubbing all CloudFront endpoints
-```
-
-### Key Design Decisions
-
-- **Chromium only** -- single-engine rendering eliminates cross-browser noise
-- **4 viewports** map to structural breakpoints in `layout.css` (1100px, 768px, 600px) plus default desktop
-- **Baselines in git** -- ~16 PNGs at ~1.3MB total; no Git LFS needed
-- **CSS stylePath** hides dynamic content: `#liveClock`, `.widget-timestamp`, `.live-dot`, `#particle-canvas`
-- **Route interception** stubs all 10 CloudFront endpoints (`src/lib/constants.ts` ENDPOINTS) with fixture JSON
-- **Service worker blocked** via `serviceWorkers: 'block'` to prevent Workbox caching interference
-- **Cross-OS rendering** -- font rendering differs macOS↔Linux; for CI, generate baselines inside the Playwright Docker container (`mcr.microsoft.com/playwright:v1.52.0-noble`)
-
-### Commands
-
-```bash
-npm run test:visual          # Compare against baselines
-npm run test:visual:update   # Regenerate baselines after intentional changes
-npm run test:visual:ui       # Interactive Playwright UI mode
-```
-
-### When to Update Baselines
-
-After intentional visual changes (new widget, layout shift, design token update):
-
+After intentional visual changes:
 ```bash
 npm run test:visual:update
 git add tests/visual/__screenshots__/
-git commit -m "Update visual baselines for [describe change]"
 ```
 
-### Adding New Tests
+## Component Showcase (Dev Only)
 
-To screenshot a new widget, add a test in `tests/visual/dashboard.spec.ts`:
+14 showcase routes injected only during `npm run dev` via `showcase-dev-only` integration in `astro.config.mjs`. Pages live in `src/showcase/` (excluded from production). Each page renders components in skeleton, empty, and active states.
 
-```typescript
-test('widget name', async ({ page }) => {
-  const widget = page.locator('.your-selector');
-  await expect(widget).toHaveScreenshot('widget-name.png', { stylePath });
-});
-```
-
-Then run `npm run test:visual:update` to generate the new baseline.
+Routes: `/showcase`, `/showcase/brand-guide`, `/showcase/identity-system`, `/showcase/health-wellness`, `/showcase/contributions-commits`, `/showcase/repositories-languages`, `/showcase/activity-feeds`, `/showcase/reading-books`, `/showcase/responsive-preview`, `/showcase/og-images`, `/showcase/location-widgets`, `/showcase/fullscreen-overlays`, `/showcase/404-pages`, `/showcase/theatre-reviews`
 
 ## Rules and Guardrails
 
 ### DO NOT
-- Use ES6+ syntax (`let`, `const`, arrow functions, template literals) in inline `<script is:inline>` blocks
-- Modify `public/css/` files without testing all responsive breakpoints
+- Use ES6+ syntax in `<script is:inline>` blocks
+- Modify `public/css/` files without testing all responsive breakpoints (1400, 1100, 900, 600)
+- Hand-edit CloudFront-composed LLM content files
 
 ### DO
-- Use CSS custom properties from `public/css/tokens.css` for all colors, spacing, and typography
-- Follow the widget HTML structure: `.tri-card` > `.widget-header` + `.widget-body`
-- Test all four responsive breakpoints (1400px, 1100px, 900px, 600px)
-- Run `npm run build` to verify changes compile correctly
-- Run `npm run test:visual` after CSS or layout changes to catch visual regressions
-- Refer to `docs/wiki/` for detailed documentation on architecture, design system, and decisions
+- Use CSS custom properties from `tokens.css` for all values
+- Follow widget HTML structure: `.tri-card` > `.widget-header` + `.widget-body`
+- Test all four responsive breakpoints after CSS/layout changes
+- Run `npm run build` to verify changes compile
+- Run `npm run test:visual` after CSS or layout changes
+- Run `npm run test` after modifying `src/lib/` modules
+- Refer to `docs/wiki/` for detailed architecture documentation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Human Datastream
 
-A personal portfolio dashboard for Jonathan Lloyd, designed as a sci-fi dashboard with glass-morphism aesthetics and a particle background. Built with [Astro](https://astro.build) and hosted on GitHub Pages.
+A personal portfolio dashboard for Jonathan Lloyd, designed as a sci-fi dashboard with glass-morphism aesthetics and a particle background. Built with [Astro](https://astro.build) and hosted on Cloudflare Pages.
 
 <!-- TODO: Add screenshot -->
 

--- a/docs/wiki/Astro-Implementation.md
+++ b/docs/wiki/Astro-Implementation.md
@@ -18,7 +18,7 @@ This is Astro's **islands architecture**: the page is static HTML with selective
 
 ### GitHub Actions Deployment
 
-`.github/workflows/deploy.yml` uses the official `withastro/action@v3` to build and `actions/deploy-pages@v4` to deploy to GitHub Pages on every push to `main`.
+`.github/workflows/deploy.yml` builds with `npm run build` and deploys to Cloudflare Pages via `cloudflare/wrangler-action@v3` on every push to `main`.
 
 ## Data Flow
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # Human Datastream
 
-A personal portfolio dashboard for Jonathan Lloyd, designed as a sci-fi dashboard with glass-morphism aesthetics and a Three.js particle background. Built with [Astro](https://astro.build) and hosted on GitHub Pages.
+A personal portfolio dashboard for Jonathan Lloyd, designed as a sci-fi dashboard with glass-morphism aesthetics and a Three.js particle background. Built with [Astro](https://astro.build) and hosted on Cloudflare Pages.
 
 ## Quick Start
 
@@ -57,7 +57,6 @@ Deployment is automatic via GitHub Actions on push to `main`.
 ├── .github/workflows/        # Deploy + wiki sync actions
 ├── .editorconfig             # 2-space indent, UTF-8, LF
 ├── .gitignore
-├── .nojekyll                 # Bypass Jekyll on GitHub Pages
 ├── CLAUDE.md                 # AI assistant instructions
 └── README.md
 ```

--- a/docs/wiki/LLM-Content-Spec.md
+++ b/docs/wiki/LLM-Content-Spec.md
@@ -127,7 +127,7 @@ Beyond LLM content, the site publishes machine-readable discovery files for AI a
 
 ### Cloudflare Configuration (manual, not in this repo)
 
-These settings must be configured in the Cloudflare dashboard for `jonathanlloyd.me`. They cannot be set from GitHub Pages.
+These settings are configured in the Cloudflare dashboard for `jonathanlloyd.me`. Note: the Link response header has been migrated to `public/_headers` (version-controlled). The Transform Rule below is the legacy reference; the `_headers` file is now authoritative.
 
 #### 1. Transform Rule: Link Response Headers
 
@@ -143,7 +143,7 @@ Cloudflare Transform Rules cannot modify the `Content-Type` response header. A W
 
 Worker code lives in `cloudflare/api-catalog-content-type.js` with `cloudflare/wrangler.toml`. Deployed via `cd cloudflare && wrangler deploy`. Route: `jonathanlloyd.me/.well-known/api-catalog`.
 
-GitHub Pages serves extensionless files as `application/octet-stream`. This Worker overrides it to `application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"`. Free tier (100k req/day) is sufficient.
+Cloudflare Pages may serve extensionless files without the correct content type. This Worker overrides it to `application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"`. Free tier (100k req/day) is sufficient.
 
 #### 3. Markdown for Agents
 

--- a/docs/wiki/Why-Astro.md
+++ b/docs/wiki/Why-Astro.md
@@ -2,7 +2,7 @@
 
 **Decision Date**: February 2026
 **Status**: Approved
-**TL;DR**: Astro scored 10/10 across performance, developer experience, viability, and GitHub Pages fit. It ships 0 KB JavaScript by default, has perfect Lighthouse scores, and was acquired by Cloudflare in January 2026.
+**TL;DR**: Astro scored 10/10 across performance, developer experience, viability, and hosting fit. It ships 0 KB JavaScript by default, has perfect Lighthouse scores, and was acquired by Cloudflare in January 2026. Originally deployed to GitHub Pages; migrated to Cloudflare Pages in April 2026.
 
 ---
 
@@ -13,7 +13,7 @@
 | Performance | High | Lighthouse scores, bundle size, Core Web Vitals |
 | Developer Experience | High | Satisfaction ratings, component model, TypeScript support |
 | Long-term Viability | High | Corporate backing, community size, release cadence |
-| GitHub Pages Fit | High | Static output, deployment simplicity |
+| Hosting Fit | High | Static output, deployment simplicity (GitHub Pages → Cloudflare Pages) |
 | Community & Ecosystem | Medium | npm downloads, learning resources, integrations |
 | Job Market | Low | Relevant but secondary for a personal portfolio |
 
@@ -43,7 +43,7 @@ Four parallel implementations were built to compare frameworks hands-on.
 - Build-time JSON loading via `fs.readFileSync`
 - Perfect Lighthouse scores (40% faster FCP than Next.js, 90% less JavaScript)
 - Cloudflare acquisition ensures long-term viability
-- Official GitHub Pages deployment action (`withastro/action`)
+- Official deployment actions for GitHub Pages and Cloudflare Pages
 
 ### HTMX + Handlebars -- 3/10
 
@@ -146,7 +146,7 @@ The data is unambiguous across every metric that matters:
 2. **Developer Experience**: #1 satisfaction (State of JS 2025). Component-based. TypeScript. HMR.
 3. **Long-term Viability**: Cloudflare acquisition (Jan 2026). MIT-licensed. 113 releases in 2025.
 4. **Community**: 1.25M weekly npm downloads. 56.6K GitHub stars. Growing 2.5x YoY.
-5. **GitHub Pages Fit**: Official deployment action. Static HTML output. `.nojekyll` already in place.
+5. **Hosting Fit**: Static HTML output deploys to any static host. Originally GitHub Pages, migrated to Cloudflare Pages (April 2026) for HTTP header control and `_headers`/`_redirects` support.
 6. **Architecture Match**: Islands architecture is exactly right for static widgets with selective hydration.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "human-datastream",
       "version": "1.0.0",
       "dependencies": {
-        "astro": "^5.0.0"
+        "astro": "^6.0.0"
       },
       "devDependencies": {
         "@astrojs/sitemap": "^3.7.0",
@@ -101,29 +101,31 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
-      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
+      "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.5.tgz",
-      "integrity": "sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==",
-      "license": "MIT"
-    },
-    "node_modules/@astrojs/markdown-remark": {
-      "version": "6.3.10",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.10.tgz",
-      "integrity": "sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
+      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.7.5",
-        "@astrojs/prism": "3.3.0",
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.1.tgz",
+      "integrity": "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/prism": "4.0.1",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
-        "import-meta-resolve": "^4.2.0",
         "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
@@ -132,25 +134,26 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "shiki": "^3.19.0",
-        "smol-toml": "^1.5.2",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.0",
+        "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
         "unist-util-visit-parents": "^6.0.2",
         "vfile": "^6.0.3"
       }
     },
     "node_modules/@astrojs/prism": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
-      "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.1.tgz",
+      "integrity": "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==",
       "license": "MIT",
       "dependencies": {
         "prismjs": "^1.30.0"
       },
       "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -166,17 +169,16 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
+      "integrity": "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==",
       "license": "MIT",
       "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
+        "ci-info": "^4.4.0",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "is-docker": "^3.0.0",
-        "is-wsl": "^3.1.0",
+        "is-docker": "^4.0.0",
+        "is-wsl": "^3.1.1",
         "which-pm-runs": "^1.1.0"
       },
       "engines": {
@@ -1798,6 +1800,28 @@
         "node": ">=18"
       }
     },
+    "node_modules/@clack/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.2.0",
+        "fast-string-width": "^1.1.0",
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
@@ -2862,7 +2886,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2884,7 +2908,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2894,7 +2918,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2911,7 +2935,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3349,64 +3373,97 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.22.0.tgz",
-      "integrity": "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.22.0",
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.22.0.tgz",
-      "integrity": "sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.22.0",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.22.0.tgz",
-      "integrity": "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.22.0",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.22.0.tgz",
-      "integrity": "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.22.0"
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.22.0.tgz",
-      "integrity": "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.22.0"
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.22.0.tgz",
-      "integrity": "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
@@ -3457,9 +3514,9 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -3529,7 +3586,7 @@
       "version": "25.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -3742,6 +3799,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3767,80 +3825,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-align": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.1.0"
-      }
-    },
-    "node_modules/ansi-align/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/ansi-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-align/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -3855,9 +3839,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3967,80 +3951,71 @@
       "license": "MIT"
     },
     "node_modules/astro": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.17.2.tgz",
-      "integrity": "sha512-7jnMqGo53hOQNwo1N/wqeOvUp8wwW/p+DeerSjSkHNx8L/1mhy6P7rVo7EhdmF8DpKqw0tl/B5Fx1WcIzg1ysA==",
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.9.tgz",
+      "integrity": "sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^2.13.0",
-        "@astrojs/internal-helpers": "0.7.5",
-        "@astrojs/markdown-remark": "6.3.10",
-        "@astrojs/telemetry": "3.3.0",
+        "@astrojs/compiler": "^3.0.1",
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/markdown-remark": "7.1.1",
+        "@astrojs/telemetry": "3.3.1",
         "@capsizecss/unpack": "^4.0.0",
+        "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
         "@rollup/pluginutils": "^5.3.0",
-        "acorn": "^8.15.0",
         "aria-query": "^5.3.2",
         "axobject-query": "^4.1.0",
-        "boxen": "8.0.1",
-        "ci-info": "^4.3.1",
+        "ci-info": "^4.4.0",
         "clsx": "^2.1.1",
-        "common-ancestor-path": "^1.0.1",
+        "common-ancestor-path": "^2.0.0",
         "cookie": "^1.1.1",
-        "cssesc": "^3.0.0",
-        "debug": "^4.4.3",
-        "deterministic-object-hash": "^2.0.2",
-        "devalue": "^5.6.2",
+        "devalue": "^5.6.3",
         "diff": "^8.0.3",
-        "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "es-module-lexer": "^1.7.0",
-        "esbuild": "^0.27.0",
-        "estree-walker": "^3.0.3",
+        "es-module-lexer": "^2.0.0",
+        "esbuild": "^0.27.3",
         "flattie": "^1.1.1",
-        "fontace": "~0.4.0",
+        "fontace": "~0.4.1",
         "github-slugger": "^2.0.0",
         "html-escaper": "3.0.3",
         "http-cache-semantics": "^4.2.0",
-        "import-meta-resolve": "^4.2.0",
         "js-yaml": "^4.1.1",
         "magic-string": "^0.30.21",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "mrmime": "^2.0.1",
         "neotraverse": "^0.6.18",
-        "p-limit": "^6.2.0",
-        "p-queue": "^8.1.1",
+        "obug": "^2.1.1",
+        "p-limit": "^7.3.0",
+        "p-queue": "^9.1.0",
         "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
-        "prompts": "^2.4.2",
+        "picomatch": "^4.0.4",
         "rehype": "^13.0.2",
-        "semver": "^7.7.3",
-        "shiki": "^3.21.0",
+        "semver": "^7.7.4",
+        "shiki": "^4.0.2",
         "smol-toml": "^1.6.0",
-        "svgo": "^4.0.0",
-        "tinyexec": "^1.0.2",
+        "svgo": "^4.0.1",
+        "tinyclip": "^0.1.12",
+        "tinyexec": "^1.0.4",
         "tinyglobby": "^0.2.15",
         "tsconfck": "^3.1.6",
         "ultrahtml": "^1.6.0",
-        "unifont": "~0.7.3",
-        "unist-util-visit": "^5.0.0",
-        "unstorage": "^1.17.4",
+        "unifont": "~0.7.4",
+        "unist-util-visit": "^5.1.0",
+        "unstorage": "^1.17.5",
         "vfile": "^6.0.3",
-        "vite": "^6.4.1",
-        "vitefu": "^1.1.1",
+        "vite": "^7.3.2",
+        "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
-        "yargs-parser": "^21.1.1",
-        "yocto-spinner": "^0.2.3",
-        "zod": "^3.25.76",
-        "zod-to-json-schema": "^3.25.1",
-        "zod-to-ts": "^1.2.0"
+        "yargs-parser": "^22.0.0",
+        "zod": "^4.3.6"
       },
       "bin": {
-        "astro": "astro.js"
+        "astro": "bin/astro.mjs"
       },
       "engines": {
-        "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+        "node": ">=22.12.0",
         "npm": ">=9.6.5",
         "pnpm": ">=7.1.0"
       },
@@ -4050,6 +4025,15 @@
       },
       "optionalDependencies": {
         "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/astro/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/async": {
@@ -4179,12 +4163,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -4210,28 +4188,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
-    },
-    "node_modules/boxen": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
-      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-align": "^3.0.1",
-        "camelcase": "^8.0.0",
-        "chalk": "^5.3.0",
-        "cli-boxes": "^3.0.0",
-        "string-width": "^7.2.0",
-        "type-fest": "^4.21.0",
-        "widest-line": "^5.0.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "5.0.2",
@@ -4284,7 +4240,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/call-bind": {
@@ -4337,18 +4293,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/camelcase": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
-      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001770",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
@@ -4388,18 +4332,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -4506,18 +4438,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4547,10 +4467,13 @@
       }
     },
     "node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
-      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
-      "license": "ISC"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/common-tags": {
       "version": "1.8.2",
@@ -4583,9 +4506,9 @@
       }
     },
     "node_modules/cookie-es": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
-      "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
@@ -4675,18 +4598,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/csso": {
@@ -4922,9 +4833,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -4952,22 +4863,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/deterministic-object-hash": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
-      "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-64": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/devalue": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
+      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -5112,12 +5011,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -5234,9 +5127,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -5353,6 +5246,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -5404,6 +5298,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^1.2.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -5420,6 +5329,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^1.1.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -5632,18 +5550,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5712,7 +5618,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -5790,14 +5696,14 @@
       "license": "ISC"
     },
     "node_modules/h3": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
-      "integrity": "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
       "license": "MIT",
       "dependencies": {
-        "cookie-es": "^1.2.2",
+        "cookie-es": "^1.2.3",
         "crossws": "^0.3.5",
-        "defu": "^6.1.4",
+        "defu": "^6.1.6",
         "destr": "^2.0.5",
         "iron-webcrypto": "^1.2.1",
         "node-mock-http": "^1.0.4",
@@ -6165,16 +6071,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -6335,15 +6231,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6373,15 +6269,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -6430,6 +6317,21 @@
       },
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6683,9 +6585,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -6999,15 +6901,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7146,9 +7039,9 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -8087,7 +7980,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
       "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -8112,19 +8004,19 @@
       "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
-      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
-      "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
       "license": "MIT",
       "dependencies": {
-        "oniguruma-parser": "^0.12.1",
-        "regex": "^6.0.1",
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
       }
     },
@@ -8147,43 +8039,43 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
-      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
       "license": "MIT",
       "dependencies": {
-        "yocto-queue": "^1.1.1"
+        "yocto-queue": "^1.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-queue": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
-      "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
+      "integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
+        "p-timeout": "^7.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8313,9 +8205,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8445,19 +8337,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/property-information": {
@@ -8812,7 +8691,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -9007,9 +8886,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -9168,19 +9047,22 @@
       }
     },
     "node_modules/shiki": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.22.0.tgz",
-      "integrity": "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.22.0",
-        "@shikijs/engine-javascript": "3.22.0",
-        "@shikijs/engine-oniguruma": "3.22.0",
-        "@shikijs/langs": "3.22.0",
-        "@shikijs/themes": "3.22.0",
-        "@shikijs/types": "3.22.0",
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/side-channel": {
@@ -9323,9 +9205,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -9361,7 +9243,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -9372,7 +9254,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -9430,23 +9312,6 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
@@ -9564,21 +9429,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/strip-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
@@ -9616,9 +9466,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
-      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -9627,7 +9477,7 @@
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.4.1"
+        "sax": "^1.5.0"
       },
       "bin": {
         "svgo": "bin/svgo.js"
@@ -9693,7 +9543,7 @@
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -9712,7 +9562,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tiny-inflate": {
@@ -9728,10 +9578,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyclip": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
+      "integrity": "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >= 17.3.0"
+      }
+    },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9857,7 +9716,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -9871,18 +9730,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -9963,20 +9810,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
@@ -10028,7 +9861,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -10252,16 +10085,16 @@
       }
     },
     "node_modules/unstorage": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz",
-      "integrity": "sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^5.0.0",
         "destr": "^2.0.5",
-        "h3": "^1.15.5",
-        "lru-cache": "^11.2.0",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
         "node-fetch-native": "^1.6.7",
         "ofetch": "^1.5.1",
         "ufo": "^1.6.3"
@@ -10432,23 +10265,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -10457,14 +10290,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
         "jiti": ">=1.21.0",
-        "less": "*",
+        "less": "^4.0.0",
         "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -10536,467 +10369,10 @@
         }
       }
     },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
-      }
-    },
     "node_modules/vitefu": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
-      "integrity": "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
       "license": "MIT",
       "workspaces": [
         "tests/deps/*",
@@ -11004,7 +10380,7 @@
         "tests/projects/workspace/packages/*"
       ],
       "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "vite": {
@@ -11093,13 +10469,6 @@
           "optional": false
         }
       }
-    },
-    "node_modules/vitest/node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -11296,21 +10665,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/widest-line": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
-      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/workbox-background-sync": {
@@ -11642,23 +10996,6 @@
         "workbox-core": "7.4.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -11690,12 +11027,12 @@
       "license": "ISC"
     },
     "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {
@@ -11710,58 +11047,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yocto-spinner": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
-      "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.19"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
-      }
-    },
-    "node_modules/zod-to-ts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
-      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
-      "peerDependencies": {
-        "typescript": "^4.9.4 || ^5.0.2",
-        "zod": "^3"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "compliance": "node scripts/widget-compliance.mjs"
   },
   "dependencies": {
-    "astro": "^5.0.0"
+    "astro": "^6.0.0"
   },
   "devDependencies": {
     "@astrojs/sitemap": "^3.7.0",

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "description": "Deep technical context about Jonathan Lloyd's portfolio, engineering background, live biometric data sources, and architectural decisions. Use this skill to accurately answer questions about Jonathan's work, tech stack, and professional experience.",
       "type": "skill-md",
       "url": "https://jonathanlloyd.me/.well-known/agent-skills/portfolio-expert/SKILL.md",
-      "digest": "sha256:e752f2a5d0aab54512dd0e846b3350d598fe16205fcace7387cba725258b1709"
+      "digest": "sha256:de0b3c87b52024f93139a078be314c2d879def1170bb1659b52086aa1067e084"
     }
   ]
 }

--- a/public/.well-known/agent-skills/portfolio-expert/SKILL.md
+++ b/public/.well-known/agent-skills/portfolio-expert/SKILL.md
@@ -25,8 +25,8 @@ The portfolio at jonathanlloyd.me is a sci-fi "Human Datastream" dashboard — a
 
 ### Technology Stack
 
-- **Framework:** Astro 5.x (static site generation, 0 KB JS by default)
-- **Hosting:** GitHub Pages via GitHub Actions, fronted by Cloudflare CDN
+- **Framework:** Astro 6.x (static site generation, 0 KB JS by default)
+- **Hosting:** Cloudflare Pages via GitHub Actions
 - **Live data:** CloudFront-backed JSON API polled at runtime
 - **Design:** Glass-morphism dark theme, fluid clamp() responsive tokens, CSS container queries
 - **Font:** Space Grotesk (self-hosted, variable woff2)
@@ -61,7 +61,7 @@ Backend-composed markdown variants, always fresher than this static skill file:
 
 1. **Zero JS by default** — All rendering is build-time Astro components. No React/Vue/Svelte.
 2. **ES5 inline scripts** — Client JS uses var, IIFEs, function declarations for maximum compatibility.
-3. **Separate data origin** — JSON on CloudFront (d1pfm520aduift.cloudfront.net), HTML on GitHub Pages (jonathanlloyd.me via Cloudflare). Cloudflare never caches JSON.
+3. **Separate data origin** — JSON on CloudFront (d1pfm520aduift.cloudfront.net), HTML on Cloudflare Pages (jonathanlloyd.me). Cloudflare never caches JSON.
 4. **Privacy-first health data** — LLM content uses 7-day aggregates only. No point-in-time BPM, steps, or calories exposed.
 5. **Image pipeline** — Book covers and theatre posters optimized to WebP by Lambda, downloaded locally at build time, served same-origin via Cloudflare CDN.
 

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,7 @@
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://scripts.simpleanalyticscdn.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://*.basemaps.cartocdn.com https://m.media-amazon.com https://images.squarespace-cdn.com https://d1pfm520aduift.cloudfront.net https://queue.simpleanalyticscdn.com; connect-src 'self' https://d1pfm520aduift.cloudfront.net wss://iu1k9jv4mi.execute-api.us-west-2.amazonaws.com https://queue.simpleanalyticscdn.com https://cloudflareinsights.com; worker-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+
+/
+  Link: </llms.txt>; rel="describedby"; type="text/plain", </.well-known/api-catalog>; rel="api-catalog", </sitemap-index.xml>; rel="sitemap"

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -37,8 +37,8 @@ All endpoints are served with `Cache-Control: public, s-maxage=300` (5-minute ed
 
 ## Technology
 
-- **Framework**: Astro 5.x (static site generation, 0 KB JS by default)
-- **Hosting**: GitHub Pages via GitHub Actions, fronted by Cloudflare CDN
+- **Framework**: Astro 6.x (static site generation, 0 KB JS by default)
+- **Hosting**: Cloudflare Pages via GitHub Actions
 - **Live data**: CloudFront-backed JSON API polled at runtime by the dashboard; same JSON composed into LLM-friendly markdown by the backend
 - **Design**: Glass-morphism, dark theme, fluid `clamp()` responsive tokens, CSS container queries
 

--- a/repomix-prompt.md
+++ b/repomix-prompt.md
@@ -1,4 +1,4 @@
-This is the **Human Datastream** portfolio — a single-page sci-fi dashboard built with Astro 5.x (static output, zero JS by default), hosted on GitHub Pages at jonathanlloyd.me. Created by Jonathan Lloyd.
+This is the **Human Datastream** portfolio — a single-page sci-fi dashboard built with Astro 6.x (static output, zero JS by default), hosted on Cloudflare Pages at jonathanlloyd.me. Created by Jonathan Lloyd.
 
 ## Read CLAUDE.md First
 

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -3,7 +3,7 @@
   "output": {
     "style": "xml",
     "filePath": "repomix-output.xml",
-    "headerText": "Human Datastream — Astro 5.x personal portfolio dashboard by Jonathan Lloyd (jonathanlloyd.me)",
+    "headerText": "Human Datastream — Astro 6.x personal portfolio dashboard by Jonathan Lloyd (jonathanlloyd.me)",
     "instructionFilePath": "repomix-prompt.md",
     "showLineNumbers": false,
     "removeComments": false,

--- a/scripts/agent-readiness-check.sh
+++ b/scripts/agent-readiness-check.sh
@@ -248,13 +248,13 @@ else
     if echo "$ct" | grep -qi 'application/linkset+json'; then
       log_pass "Content-Type is application/linkset+json (RFC 9727 compliant)"
     else
-      log_info "  Content-Type: $ct (GitHub Pages serves as application/octet-stream)"
+      log_info "  Content-Type: $ct (expected application/linkset+json via Cloudflare Worker)"
       log_info "  Fix: Cloudflare Worker to override Content-Type to application/linkset+json"
       log_info "  Scanner may still pass on 200 + valid JSON body"
     fi
   else
     log_fail "api-catalog returns HTTP $status (expected 200)"
-    log_info "  Fix: Deploy PR #2 code to GitHub Pages"
+    log_info "  Fix: Deploy latest code to Cloudflare Pages"
   fi
 fi
 
@@ -323,7 +323,7 @@ else
     fi
   else
     log_fail "server-card.json returns HTTP $status (expected 200)"
-    log_info "  Fix: Deploy PR #2 code to GitHub Pages"
+    log_info "  Fix: Deploy latest code to Cloudflare Pages"
   fi
 fi
 
@@ -364,7 +364,7 @@ else
     fi
   else
     log_fail "agent-skills/index.json returns HTTP $status (expected 200)"
-    log_info "  Fix: Deploy PR #2 code to GitHub Pages"
+    log_info "  Fix: Deploy latest code to Cloudflare Pages"
   fi
   # Check SKILL.md
   skill_status=$(http_status "${BASE_URL}/.well-known/agent-skills/portfolio-expert/SKILL.md")
@@ -372,7 +372,7 @@ else
     log_pass "SKILL.md returns 200"
   else
     log_fail "SKILL.md returns HTTP $skill_status (expected 200)"
-    log_info "  Fix: Deploy PR #2 code to GitHub Pages"
+    log_info "  Fix: Deploy latest code to Cloudflare Pages"
   fi
 fi
 
@@ -406,7 +406,7 @@ else
     fi
   else
     log_fail "WebMCP script not found in page source"
-    log_info "  Fix: Deploy PR #2 code to GitHub Pages"
+    log_info "  Fix: Deploy latest code to Cloudflare Pages"
   fi
 fi
 
@@ -446,8 +446,8 @@ if [ -z "$BUILD_DIR" ]; then
   wf_status=$(http_status "${BASE_URL}/.well-known/api-catalog")
   if [ "$wf_status" = "404" ]; then
     echo -e "  ${RED}WARNING: .well-known files are NOT deployed!${NC}"
-    echo -e "  PR #2 code has not reached GitHub Pages."
-    echo -e "  Fix: Resolve GitHub Actions billing issue, then push to main."
+    echo -e "  .well-known files have not been deployed to Cloudflare Pages."
+    echo -e "  Fix: Push to main to trigger deploy, or check GitHub Actions status."
   else
     echo -e "  ${GREEN}Deployment appears current.${NC}"
   fi

--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -19,10 +19,7 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
   <meta name="description" content={description}>
   <meta name="robots" content={robots}>
   <meta name="keywords" content="backend engineer portfolio, software engineer portfolio, data visualization dashboard, living data dashboard, human datastream, engineering director, personal dashboard, biometrics dashboard, GitHub activity visualization, Astro static site">
-  <!-- Security: CSP (GitHub Pages cannot set HTTP headers) -->
-  <!-- img-src keeps CloudFront for onerror fallback when local images are missing -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://scripts.simpleanalyticscdn.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://*.basemaps.cartocdn.com https://m.media-amazon.com https://images.squarespace-cdn.com https://d1pfm520aduift.cloudfront.net https://queue.simpleanalyticscdn.com; connect-src 'self' https://d1pfm520aduift.cloudfront.net wss://iu1k9jv4mi.execute-api.us-west-2.amazonaws.com https://queue.simpleanalyticscdn.com https://cloudflareinsights.com; worker-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';">
-  <meta name="referrer" content="strict-origin-when-cross-origin">
+  <!-- Security: CSP + Referrer-Policy served via HTTP headers (public/_headers for Cloudflare Pages) -->
   <meta name="author" content="Jonathan Lloyd">
   <meta property="og:locale" content="en_US">
   <link rel="canonical" href={canonicalURL}>
@@ -625,8 +622,8 @@ html, body {
             inputSchema: { type: 'object', properties: {}, required: [] },
             execute: function() {
               var stack = {
-                framework: 'Astro 5.x (static site generation, 0 KB JS by default)',
-                hosting: 'GitHub Pages via GitHub Actions, fronted by Cloudflare CDN',
+                framework: 'Astro 6.x (static site generation, 0 KB JS by default)',
+                hosting: 'Cloudflare Pages via GitHub Actions',
                 liveData: 'CloudFront-backed JSON API polled at runtime',
                 design: 'Glass-morphism dark theme, fluid clamp() responsive tokens, CSS container queries',
                 font: 'Space Grotesk (self-hosted, variable woff2)',


### PR DESCRIPTION
## Summary

- **Astro 6.1.9** upgrade from 5.x (Vite 7, Zod 4) — all 434 unit tests and 57 build tests pass
- **Cloudflare Pages** migration — replaces GitHub Pages deploy with `wrangler pages deploy`, adds `public/_headers` for CSP/security headers, removes `.nojekyll`
- **13-file documentation sweep** — updates all references across docs, wiki, llms.txt, SKILL.md, agent-readiness script, and WebMCP tools

## Before merging

These manual steps are required in the Cloudflare dashboard and GitHub settings:

- [x] Create Cloudflare Pages project named `human-datastream` (Workers & Pages → Create → Pages, do NOT connect git)
- [x] Add `CLOUDFLARE_ACCOUNT_ID` secret to GitHub repo settings
- [ ] Test Worker + Pages coexistence: deploy to `*.pages.dev` and verify markdown negotiation (`curl -H "Accept: text/markdown"`) and API catalog content-type still work
- [ ] Configure custom domain `jonathanlloyd.me` on Cloudflare Pages project
- [ ] Disable GitHub Pages in repo settings (Settings → Pages → Source: None)
- [ ] Remove Cloudflare Transform Rule for Link header (now in `public/_headers`)

## Key decisions

| Decision | Rationale |
|----------|-----------|
| `--legacy-peer-deps` for install | `@vite-pwa/astro` peer deps cap at `^5.0.0` but underlying `vite-plugin-pwa` supports Vite 7 |
| No `@astrojs/cloudflare` adapter | Site is purely static (`output: 'static'`), no SSR needed |
| GHA deploy (not CF git integration) | Need GHA pipeline for image checks and visual tests on PRs |
| CSP moved to `_headers` file | Cloudflare Pages supports HTTP headers; stronger than `<meta>` tag |

## Test plan

- [x] `npm run build` — succeeds (1.27s)
- [x] `npm run test` — 434 unit tests pass
- [x] `npm run test:build` — 57 build tests pass
- [x] `sw.js` + `manifest.webmanifest` generated (PWA works with Vite 7)
- [x] `sitemap-index.xml` generated
- [x] Dev server starts cleanly on Astro 6.1.9
- [x] No remaining "GitHub Pages" references (except historical context in Why-Astro.md)
- [x] Visual regression tests in CI (Linux Docker baselines)
- [ ] Worker + Pages coexistence verified on `*.pages.dev`
- [ ] Production site loads correctly after DNS cutover

🤖 Generated with [Claude Code](https://claude.com/claude-code)