### PR TITLE
ci: migrate workflows to self-hosted runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,13 +15,13 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, node]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -40,13 +40,13 @@ jobs:
           command: pages deploy dist --project-name=human-datastream
 
   check-images:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, node]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -15,16 +15,16 @@ permissions:
 
 jobs:
   sync-wiki:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, base]
 
     steps:
       - name: Checkout main repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: main
 
       - name: Checkout wiki repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary
- Migrate deploy and sync-wiki workflows from `ubuntu-latest` to self-hosted Apple Container micro-VMs on Mac Studio M3 Ultra
- build-and-deploy, check-images: `[self-hosted, linux, arm64, node]`
- sync-wiki: `[self-hosted, linux, arm64, base]`
- visual-tests: remains on `ubuntu-latest` (Playwright container requires Docker-in-Docker, unsupported on Apple Container micro-VMs)
- Bump `actions/checkout` and `actions/setup-node` from `@v4` to `@v6` across all workflows