### PR TITLE
fix: City of Stairs cover — adapter must pass through CDN URLs

### DIFF
--- a/src/lib/adapters.ts
+++ b/src/lib/adapters.ts
@@ -6,7 +6,6 @@ import {
   computeSleepPercentages,
 } from './sleep';
 import type { HealthExport, SleepExport, WorkoutsExport, BooksExport, GithubEventsExport, ArticlesExport, GithubStarredReposExport } from '../types/exports';
-import { localizeImageUrl } from './image-utils';
 
 // ── Adapted output types (what adapters produce for updaters) ──────
 
@@ -329,12 +328,12 @@ export function adaptBooks(booksData: BooksExport): AdaptedBooks {
       rating: b.rating ?? null,
       progress,
       link: 'https://www.amazon.com/dp/' + b.asin + '?tag=lifegames04-20&linkCode=ll2&language=en_US&ref_=as_li_ss_tl',
-      cover: localizeImageUrl(b.mainImage ?? null),
-      coverThumb: localizeImageUrl(b.mainImageThumb ?? null),
-      coverCard: localizeImageUrl(b.mainImageCard ?? null),
-      coverAvif: localizeImageUrl(b.mainImageAvif ?? null),
-      coverThumbAvif: localizeImageUrl(b.mainImageThumbAvif ?? null),
-      coverCardAvif: localizeImageUrl(b.mainImageCardAvif ?? null),
+      cover: b.mainImage ?? null,
+      coverThumb: b.mainImageThumb ?? null,
+      coverCard: b.mainImageCard ?? null,
+      coverAvif: b.mainImageAvif ?? null,
+      coverThumbAvif: b.mainImageThumbAvif ?? null,
+      coverCardAvif: b.mainImageCardAvif ?? null,
       notes: b.notes ?? null,
     };
   });


### PR DESCRIPTION
## Summary

Follow-up to #10. The previous fix only adjusted ssrAsins collection, but the adapter was still calling `localizeImageUrl()` unconditionally on every image URL. For books NOT in the SSR snapshot (City of Stairs added to the user reading list after the last build), the adapter pre-localized the CDN URL to a local path that 404s, then the updater shouldLocalize gate at lines 881-883 was a no-op because the URL was already localized.

This commit removes the adapter-level pre-localization. The updater retains the authoritative ssrAsins gate: books in the SSR snapshot get local paths (their files exist in public/images/books/); books added after the last build use the CDN URL directly.

## Bug observed

Live page rendered `<img src="https://jonathanlloyd.me/images/books/080413717X.webp">` for City of Stairs — 404. Other books rendered `/images/books/{ASIN}-card.webp` from disk — 200.

## Root cause

`adaptBooks` at adapters.ts:332-337 called `localizeImageUrl(b.mainImageCard)` on every entry, which strips the CDN host and returns a local relative path. That happened before the updater could check `ssrAsins.has(b.asin)`. The downstream updater branch that should have used the CDN URL never saw the CDN URL.

## Test plan

- [x] `npm run build` passes (2 pages, 728ms)
- [x] Manual trace: with adapter passing through CDN URLs, the updater for non-SSR books resolves `img.src` to `https://d1pfm520aduift.cloudfront.net/images/books/080413717X-card.webp` (HTTP 200)
- [ ] Post-merge verification on jonathanlloyd.me after Cloudflare Pages deploy

After merge, Cloudflare Pages will redeploy and the City of Stairs cover will load.
