### PR TITLE
fix(middleware): don't cache 4xx/SPA-fallback responses + perf: bypass function on static asset paths

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -73,6 +73,24 @@ export async function onRequest(context: PagesContext): Promise<Response> {
     );
   }
 
+  // Never let an error response (4xx/5xx) be cached. Cloudflare Pages serves the
+  // SPA 404 fallback with `Cache-Control: max-age=2592000, public` (30 days),
+  // which means a transient miss (e.g. an image not yet built into a deploy)
+  // gets stuck in browsers' HTTP cache for a month — even after the asset
+  // appears. Force `no-store` on all error responses so the next request
+  // re-checks the origin.
+  //
+  // Also force `no-store` when the SPA fallback is served for an asset-shaped
+  // path (the file extension hints we wanted a binary, but we got HTML back).
+  // This covers Pages configs where the SPA fallback returns 200, not 404.
+  const ASSET_EXT = /\.(?:webp|avif|png|jpe?g|gif|svg|ico|css|js|mjs|woff2?|ttf|otf|map|json|xml|txt)$/i;
+  const looksLikeAsset = ASSET_EXT.test(url.pathname);
+  const respIsHtml = (headers.get('Content-Type') || '').includes('text/html');
+  if (response.status >= 400 || (looksLikeAsset && respIsHtml)) {
+    headers.set('Cache-Control', 'no-store');
+    headers.set('CDN-Cache-Control', 'no-store');
+  }
+
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "include": ["/*"],
+  "exclude": [
+    "/_astro/*",
+    "/fonts/*",
+    "/css/*",
+    "/vendor/*",
+    "/assets/*"
+  ]
+}


### PR DESCRIPTION
## Bug

A user reported a "broken image" for the City of Stairs book cover on production. DevTools showed:

```
080413717X-thumb.webp  404 text/html  (ServiceWorker)  Initiator: Other
080413717X-thumb.webp  404 fetch      (disk cache)     Initiator: workbox-6829fd8d.js:1
080413717X.webp        404 text/html  (ServiceWorker)  Initiator: index.astro...
080413717X.webp        404 fetch      (disk cache)     Initiator: workbox-6829fd8d.js:1
```

But all six image variants (main / thumb / card × webp / avif) actually exist in production and return 200 with the correct cover when fetched from a clean client:

```
$ curl -sIo /dev/null -w "%{http_code}\n" "https://jonathanlloyd.me/images/books/080413717X-thumb.webp"
200
```

## Root cause

When the user first loaded the page *before* this image was deployed to Cloudflare Pages, the browser fetched the URL and got back Cloudflare Pages' SPA-fallback 404 HTML. That fallback ships with:

```
HTTP/2 404
content-type: text/html; charset=utf-8
cache-control: max-age=2592000, public
```

**30 days of browser-cacheable 404.** Even after the asset appeared at the URL in a later deploy, the browser kept serving the stale cached 404 from disk cache, and the Service Worker (CacheFirst at `/images/(books|theatre)/`) dutifully fetched-and-returned that cached 404.

The actual bytes were never the problem — the `Cache-Control` on the negative response was.

This matches the documented [Cloudflare community issue about Pages caching 404 responses in the browser](https://community.cloudflare.com/t/cloudflare-pages-caches-404-responses-in-the-browser/548753).

## Why fix it in the middleware

I explored Cloudflare-native alternatives before landing on the middleware:

| Option | Why not |
|---|---|
| `_routes.json` to exclude `/images/*` from the function | When Pages serves the SPA fallback for an excluded path, it happens *outside* the function — the `Cache-Control` we'd want to set never gets a chance. The fix would hide behind the exclude. |
| Reintroduce `public/_headers` | `_headers` is currently disabled by middleware, and even when it's the sole response shaper [it has documented trouble overriding 404 cache headers](https://community.cloudflare.com/t/pages-how-to-prevent-caching-404s-when-using-headers/516765). |
| Remove `dist/404.html` to enter SPA mode | Pages would rewrite missing assets to the root with status 200. The body is still HTML, so the `<img>` still can't render, and 200-for-missing is bad for SEO. |
| Cloudflare Transform Rules / "Configure Cache by Response Code" | Dashboard-managed (not version controlled) and the response-code option is [Enterprise-plan only](https://developers.cloudflare.com/cache/concepts/cache-control/). |
| `<meta http-equiv="Cache-Control">` in 404.html | Browsers can ignore meta-equiv cache directives; not reliable for response-level cache control. |

The middleware is the centralized response-header point in this codebase (it explicitly replaced `_headers`), runs on every response that needs shaping, and can read `response.status` + `Content-Type` to make the decision. Version-controlled, reviewable, testable. ([Cloudflare Pages Functions Routing docs](https://developers.cloudflare.com/pages/functions/routing/) · [Serving Pages docs](https://developers.cloudflare.com/pages/configuration/serving-pages/) · [Cloudflare Cache-Control docs](https://developers.cloudflare.com/cache/concepts/cache-control/))

## Commits

### `7251e88` — `fix(middleware): never cache 4xx/5xx or SPA-fallback asset responses`

`functions/_middleware.ts` now forces `Cache-Control: no-store` (and `CDN-Cache-Control: no-store`) on:

1. **Any response with status ≥ 400** — direct fix for the 404 case. A real miss should be re-checked on the next request, not cached for a month.
2. **Any `text/html` response served at an asset-shaped path** (`.webp`, `.avif`, `.png`, `.jpe?g`, `.gif`, `.svg`, `.ico`, `.css`, `.js`, `.mjs`, `.woff2?`, `.ttf`, `.otf`, `.map`, `.json`, `.xml`, `.txt`). This catches the case where Pages happens to return the SPA fallback with status 200 instead of 404 on certain configs.

Successful asset responses (2xx with `image/*`, `application/javascript`, etc.) are unaffected and continue to use Cloudflare's default cache headers, which is the desired behavior for hashed Astro asset bundles.

### `6ebe822` — `perf(pages): bypass the function for hash-stable static asset paths`

Adds `public/_routes.json` so Cloudflare Pages serves `/_astro/*`, `/fonts/*`, `/css/*`, `/vendor/*`, and `/assets/*` directly from static serving without invoking the Pages Function. These paths only contain content-hashed bundles (Astro) or stable deploy-coupled binaries (fonts, vendored JS, icons), so they never need the response shaping the middleware does (CSP, Referrer-Policy, Cache-Control on 4xx).

**NOT excluded:** `/images/*` — those legitimately go missing during deploy windows (book covers added in this build but not yet uploaded). Missing images need the middleware to set `Cache-Control: no-store` on the 404, otherwise the browser caches the SPA fallback for 30 days. The bug fix above only stays fixed if `/images/*` keeps flowing through the function.

Cloudflare Pages' free tier gives unlimited static asset requests but meters function invocations, so reducing the function fan-out on the bulk of asset traffic is a free perf + cost win.

## Verification

- `npx tsc --noEmit` clean
- `npm test` — 57/57 passing
- `npm run build` succeeds; `dist/_routes.json` is copied through correctly
- Existing markdown-negotiation path (Accept: `text/markdown` → `/llms-full.txt` with `no-store`) is unchanged
- `/` route's `Link` header + `CDN-Cache-Control: no-store` is unchanged
- `/.well-known/api-catalog` content-type override is unchanged

## For affected users

Anyone with a stuck-404 in their disk cache can clear it via DevTools → Application → Storage → "Clear site data" → reload. Going forward, the `no-store` header prevents the issue from recurring.

## Test plan

- [x] tsc + unit tests green; build emits `dist/_routes.json`
- [ ] After deploy: `curl -sI https://jonathanlloyd.me/images/books/definitely-does-not-exist.webp` returns `cache-control: no-store` on the 404
- [ ] `curl -sI https://jonathanlloyd.me/images/books/0525573844-card.webp` (existing image) is unaffected and still returns its image cache headers
- [ ] `curl -sI https://jonathanlloyd.me/_astro/index.astro_astro_type_script_index_0_lang.DZPqeL3U.js` returns successfully (verifies `_routes.json` exclude didn't break the asset path)
- [ ] After deploy + hard refresh / cache clear, City of Stairs cover renders in the bookshelf and modal
