### PR TITLE
fix(middleware): replace HTML body on asset 404s so no-store actually sticks

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -73,20 +73,40 @@ export async function onRequest(context: PagesContext): Promise<Response> {
     );
   }
 
-  // Never let an error response (4xx/5xx) be cached. Cloudflare Pages serves the
-  // SPA 404 fallback with `Cache-Control: max-age=2592000, public` (30 days),
-  // which means a transient miss (e.g. an image not yet built into a deploy)
-  // gets stuck in browsers' HTTP cache for a month — even after the asset
-  // appears. Force `no-store` on all error responses so the next request
-  // re-checks the origin.
+  // Cloudflare Pages serves the SPA 404 fallback (a `text/html` response) with
+  // `Cache-Control: max-age=2592000, public` (30 days), and Pages re-applies its
+  // default Cache-Control after the Function runs WHENEVER the response is HTML
+  // (per the homepage note at the top of this branch). That means setting
+  // `Cache-Control: no-store` via `headers.set(...)` does nothing on the 404
+  // HTML response — Pages overwrites it on the way out.
   //
-  // Also force `no-store` when the SPA fallback is served for an asset-shaped
-  // path (the file extension hints we wanted a binary, but we got HTML back).
-  // This covers Pages configs where the SPA fallback returns 200, not 404.
+  // The win: for any asset-shaped URL (`.webp`, `.avif`, `.js`, etc.), no human
+  // ever sees the 404 body — it loads via `<img>`/`<script>`/`<link>`. So we
+  // can fully replace the response with an empty `text/plain` body. Pages does
+  // NOT override Cache-Control on non-HTML responses, so our `no-store` sticks
+  // and the browser never caches the 404. Once the asset is uploaded in a later
+  // deploy, the very next request re-checks origin and gets the real bytes.
   const ASSET_EXT = /\.(?:webp|avif|png|jpe?g|gif|svg|ico|css|js|mjs|woff2?|ttf|otf|map|json|xml|txt)$/i;
   const looksLikeAsset = ASSET_EXT.test(url.pathname);
   const respIsHtml = (headers.get('Content-Type') || '').includes('text/html');
-  if (response.status >= 400 || (looksLikeAsset && respIsHtml)) {
+  if (looksLikeAsset && (response.status >= 400 || respIsHtml)) {
+    return new Response('', {
+      status: response.status >= 400 ? response.status : 404,
+      headers: {
+        'Cache-Control': 'no-store',
+        'CDN-Cache-Control': 'no-store',
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Content-Security-Policy': CSP,
+        'X-Content-Type-Options': 'nosniff',
+        'Referrer-Policy': 'strict-origin-when-cross-origin',
+      },
+    });
+  }
+
+  // Non-asset error responses: still try `no-store`. Pages will likely override
+  // for HTML, but `CDN-Cache-Control` blocks the edge cache and that helps
+  // navigation 404s clear faster than max-age=2592000.
+  if (response.status >= 400) {
     headers.set('Cache-Control', 'no-store');
     headers.set('CDN-Cache-Control', 'no-store');
   }


### PR DESCRIPTION
## Follow-up to #27

PR #27 set `Cache-Control: no-store` on 4xx responses via `headers.set(...)`. **It didn't take effect on the live 404.** Verified after the deploy:

```
$ curl -sI https://jonathanlloyd.me/images/books/definitely-not-real.webp
HTTP/2 404
cache-control: max-age=2592000, public   ← Pages re-applied its 30-day default
cdn-cache-control: no-store              ← our header survived
```

Pages overrides Function-set `Cache-Control` on HTML responses (this is documented in the existing comment at `_middleware.ts:62-64`). `CDN-Cache-Control` survived (which stopped edge caching), but **browsers ignore `CDN-Cache-Control`** and obey `Cache-Control`, which Pages had reset.

## Fix

For asset-shaped paths (`.webp`, `.avif`, `.js`, `.css`, etc.), the response body is never user-visible — it loads via `<img>` / `<script>` / `<link>` and the browser only cares about the status + cache headers. So replace the 404 body entirely with an empty `text/plain` response. Pages does NOT override `Cache-Control` on non-HTML responses, so our `no-store` sticks.

For non-asset HTML 404s (user navigations like `/missing-blog-post`), keep the existing 404.html page and best-effort set `Cache-Control: no-store` + `CDN-Cache-Control: no-store`. Pages will likely override the browser cache header but the edge cache directive still helps the negative response clear faster.

## Verification (this PR)

- `npx tsc --noEmit` clean
- `npm test` — 57/57 passing

## Verification (live after merge + deploy)

- [ ] `curl -sI https://jonathanlloyd.me/images/books/does-not-exist.webp` returns `cache-control: no-store` AND `content-type: text/plain; charset=utf-8`
- [ ] `curl -sI https://jonathanlloyd.me/images/books/0525573844-card.webp` (existing image) still returns 200 with `image/webp` and unchanged cache headers
- [ ] After a hard refresh / cache clear, the City of Stairs cover renders in the bookshelf

## Why this works

Pages' Cache-Control override is HTML-specific (the comment at line 62-64 of the prior version of this file documented it). By making the response non-HTML, we sidestep that override entirely. Non-HTML responses keep whatever `Cache-Control` we set them.
