### PR TITLE
fix(adapter): consume DS fix that stops localizing non-fixture book images

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -73,44 +73,6 @@ export async function onRequest(context: PagesContext): Promise<Response> {
     );
   }
 
-  // Cloudflare Pages serves the SPA 404 fallback (a `text/html` response) with
-  // `Cache-Control: max-age=2592000, public` (30 days), and Pages re-applies its
-  // default Cache-Control after the Function runs WHENEVER the response is HTML
-  // (per the homepage note at the top of this branch). That means setting
-  // `Cache-Control: no-store` via `headers.set(...)` does nothing on the 404
-  // HTML response — Pages overwrites it on the way out.
-  //
-  // The win: for any asset-shaped URL (`.webp`, `.avif`, `.js`, etc.), no human
-  // ever sees the 404 body — it loads via `<img>`/`<script>`/`<link>`. So we
-  // can fully replace the response with an empty `text/plain` body. Pages does
-  // NOT override Cache-Control on non-HTML responses, so our `no-store` sticks
-  // and the browser never caches the 404. Once the asset is uploaded in a later
-  // deploy, the very next request re-checks origin and gets the real bytes.
-  const ASSET_EXT = /\.(?:webp|avif|png|jpe?g|gif|svg|ico|css|js|mjs|woff2?|ttf|otf|map|json|xml|txt)$/i;
-  const looksLikeAsset = ASSET_EXT.test(url.pathname);
-  const respIsHtml = (headers.get('Content-Type') || '').includes('text/html');
-  if (looksLikeAsset && (response.status >= 400 || respIsHtml)) {
-    return new Response('', {
-      status: response.status >= 400 ? response.status : 404,
-      headers: {
-        'Cache-Control': 'no-store',
-        'CDN-Cache-Control': 'no-store',
-        'Content-Type': 'text/plain; charset=utf-8',
-        'Content-Security-Policy': CSP,
-        'X-Content-Type-Options': 'nosniff',
-        'Referrer-Policy': 'strict-origin-when-cross-origin',
-      },
-    });
-  }
-
-  // Non-asset error responses: still try `no-store`. Pages will likely override
-  // for HTML, but `CDN-Cache-Control` blocks the edge cache and that helps
-  // navigation 404s clear faster than max-age=2592000.
-  if (response.status >= 400) {
-    headers.set('Cache-Control', 'no-store');
-    headers.set('CDN-Cache-Control', 'no-store');
-  }
-
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,


### PR DESCRIPTION
## Reverts the middleware Cache-Control experiments from #27 and #29

PR [#27](https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/pull/27) and [#29](https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/pull/29) tried to fix a "broken book cover" bug by setting `Cache-Control: no-store` on 4xx responses (and on `text/html` responses to asset-shaped paths) from `functions/_middleware.ts`. **Neither worked.** Verified live after both deploys:

```
$ curl -sI https://jonathanlloyd.me/images/books/does-not-exist.webp
HTTP/2 404
cache-control: max-age=2592000, public   ← Pages re-applied its default
cdn-cache-control: no-store              ← our middleware header survived
```

Empirically, Cloudflare Pages re-applies its default `Cache-Control` after the Function returns, regardless of whether the Function set a different value. `CDN-Cache-Control` survives (browsers ignore it; it's a CDN-only directive), but the browser-honored `Cache-Control` does not.

[Cloudflare's "Cache Status By Response Code"](https://developers.cloudflare.com/cache/concepts/cache-control/) — which would let us override 404 cache behavior — is Enterprise-plan only. So the middleware approach is structurally dead on free tier.

## Real fix is upstream

The actual root cause was in [design-system-Lifegames#33](https://github.com/j0nathan-ll0yd/design-system-Lifegames/pull/33): the books adapter unconditionally rewrote CloudFront URLs to same-origin local paths, but local paths only exist for ASINs that someone manually committed to `public/images/books/`. For any new book the LP backend adds (City of Stairs in the live incident), the local path 404s and Pages' 30-day cache stuck the 404.

The DS fix removes the unconditional rewrite. CloudFront URLs flow through to the `<img>` for non-fixture books and load correctly. No 404s, no cache traps.

## What this PR changes

- **Reverts**: the asset-404 → `text/plain` empty response logic + the 4xx `no-store` fallback from `functions/_middleware.ts` (38 lines of dead code)
- **Keeps**: `public/_routes.json` (the perf win from #27 — excluding `/_astro/*`, `/fonts/*`, `/css/*`, `/vendor/*`, `/assets/*` from the function is independent and valid)
- **Keeps**: every other middleware behavior — markdown negotiation, CSP, Referrer-Policy, `/` Link header, `/.well-known/api-catalog` content-type override

## Verification

- `npx tsc --noEmit` clean
- `npm test` — 57/57 passing
- After DS PR merges and this PR redeploys: City of Stairs cover renders from CloudFront with a 200 response, the cache-trap bug class is gone for any new book the backend surfaces

## Cross-repo dependency

- Depends on `design-system-Lifegames#33` (matching branch resolution in CI workflow will pick it up automatically)
- Merge DS first, then this PR
