### PR TITLE
fix(layout): restore mobile scroll on dashboard

### DIFF
--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -306,9 +306,14 @@ html, body {
   font-family: 'Space Grotesk', 'Space Grotesk Fallback', sans-serif;
   background: var(--bg);
   color: var(--text);
-  overflow: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Lock viewport scroll only at widths where the bento grid is sized to
+   fit 100dvh. Below 1100px the layout stacks vertically and MUST scroll. */
+@media (min-width: 1100px) {
+  html, body { overflow: hidden; }
 }
 
 /* ===== @SUPPORTS FALLBACKS ===== */


### PR DESCRIPTION
## Summary
- Mobile + tablet-768 viewports could not scroll the dashboard — content past the BIO terminal was unreachable.
- Root cause: `html, body { overflow: hidden }` in `src/layouts/Dashboard.astro:309` was applied unconditionally. Desktop hid the bug because the bento grid is sized to fit `100dvh`.
- Fix: scope the overflow lock to `@media (min-width: 1100px)` where the layout actually fits the viewport.

## Reproduction
Verified locally with BrowserOS at 390×844 iframe (iPhone 13):
- **Before fix:** wheel events over the page produced zero scroll displacement; everything past BIO column header was clipped.
- **After fix:** page scrolls normally; full dashboard accessible.

Probed at desktop preview (innerWidth=960): computed `html/body overflow: auto` confirming the rule is gated correctly; ≥1100px viewports retain the lock.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run test:build` — 57/57 passed
- [ ] Visual regression CI — **expected to fail on mobile-600 + tablet-768 + tablet-1100 fullPage dashboard baselines** because the captured page is now taller (legitimate). Baselines will need refresh from CI artifacts before merge.
- [ ] Verify scroll on live `jonathanlloyd.me` post-deploy at iPhone 13 width

## Risk
- Narrow: single CSS rule, gated by media query. Desktop-1400 behavior unchanged.
- Visual baselines committed at HEAD were generated in CI Docker; locally regenerated baselines (macOS) differ at the sub-pixel level — intentionally not included in this PR.