### PR TITLE
fix(pwa): skipWaiting + clientsClaim so SW updates reach users

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,6 +42,10 @@ export default defineConfig({
         globPatterns: ['**/*.{css,js,html,svg,png,ico,txt,webmanifest,woff2}'],
         globIgnores: ['images/books/**', 'images/theatre/**'],
         navigateFallbackDenylist: [/\.xml$/],
+        // Immediate activation so fix deploys reach returning visitors on next
+        // page load instead of waiting for all tabs to close.
+        skipWaiting: true,
+        clientsClaim: true,
         runtimeCaching: [
           {
             // Local optimized images — CacheFirst (downloaded at build time from CloudFront)


### PR DESCRIPTION
## Problem
The scroll fix in #40 deployed correctly to Cloudflare, but returning visitors with the installed Workbox service worker still see the old HTML.

Diagnosis (BrowserOS probe against live `jonathanlloyd.me/?cb=verify-prod`):
- Page-source HTML on disk: fix is present (`@media (min-width: 1100px) { html, body { overflow: hidden } }`).
- Page actually served to client: pre-fix HTML — `html, body { overflow: hidden }` unconditional.
- After programmatic `serviceWorker.getRegistrations().unregister()` + `caches.delete()` + reload → fix appears, `htmlOverflow: auto` at 960px width, `body.scrollHeight = 3349` accessible.

So the SW is precaching HTML and serving stale precache. Default vite-plugin-pwa behavior keeps the new SW in "waiting" until every tab closes — which can be days.

## Fix
Workbox config now sets:
- `skipWaiting: true` — new SW activates immediately on install
- `clientsClaim: true` — new SW takes control of existing pages without reload

Next time a returning visitor hits the site, the new SW (from this build) installs, immediately activates, claims their tab, and serves the freshly precached HTML containing the scroll fix.

## Risk
Narrow — SW lifecycle change only. Caching strategies unchanged. Trade-off: a SW deploy can no longer ship in two stages that depend on the old version persisting; this is fine for our static site.

## Test plan
- [x] Local build produces sw.js with `self.skipWaiting()` + `e.clientsClaim()`
- [ ] CI passes (no test impact expected)
- [ ] After deploy, returning visitor with stale SW receives fix on next nav (will verify in production)