### PR TITLE
chore(visual-regression): PR #44 follow-up A — docs + predicate extraction

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -1,5 +1,20 @@
 name: Update Snapshots
 
+# Update Snapshots Workflow
+#
+# PRIMARY: pull_request: types: [labeled] — add label `update-snapshots` to a PR
+#   to regenerate visual baselines in Docker and auto-commit back to the PR branch.
+#   The workflow self-removes the label after a successful commit.
+#
+# BREAK-GLASS: workflow_dispatch with pr_number input — for cases where the label
+#   trigger fails:
+#     1. Cross-fork PRs (workflow cannot push to external forks).
+#     2. GITHUB_TOKEN cannot trigger workflows from other workflows — chained
+#        workflow triggers may not fire; manual dispatch always works.
+#     3. Label-trigger glitches or you want to re-run without removing/re-adding
+#        the label.
+#   Invoke via:  gh workflow run update-snapshots.yml -f pr_number=NNN
+
 on:
   pull_request:
     types: [labeled]

--- a/tests/build/predicates.test.ts
+++ b/tests/build/predicates.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { allImagesComplete, scrollHeightStable } from '../visual/predicates';
+
+describe('allImagesComplete', () => {
+  it('returns true for empty array', () => {
+    expect(allImagesComplete([])).toBe(true);
+  });
+  it('returns true when all images report complete', () => {
+    expect(allImagesComplete([{ complete: true }, { complete: true }])).toBe(true);
+  });
+  it('returns false when any image is incomplete', () => {
+    expect(allImagesComplete([{ complete: true }, { complete: false }])).toBe(false);
+  });
+  it('returns false when single image is incomplete', () => {
+    expect(allImagesComplete([{ complete: false }])).toBe(false);
+  });
+});
+
+describe('scrollHeightStable', () => {
+  it('returns true for empty array (no reads yet)', () => {
+    expect(scrollHeightStable([])).toBe(true);
+  });
+  it('returns true for single read', () => {
+    expect(scrollHeightStable([100])).toBe(true);
+  });
+  it('returns true for four equal reads', () => {
+    expect(scrollHeightStable([100, 100, 100, 100])).toBe(true);
+  });
+  it('returns false if any read differs', () => {
+    expect(scrollHeightStable([100, 100, 100, 101])).toBe(false);
+  });
+  it('returns false for first-read divergence', () => {
+    expect(scrollHeightStable([100, 200, 100, 100])).toBe(false);
+  });
+  // [0,0,0,0] returns true (semantically: stable at zero); real usage wraps
+  // this in waitForFunction timeout to fail if page never loads.
+  it('returns true for [0,0,0,0] (caller guards against zero via timeout)', () => {
+    expect(scrollHeightStable([0, 0, 0, 0])).toBe(true);
+  });
+});

--- a/tests/visual/helpers.ts
+++ b/tests/visual/helpers.ts
@@ -127,6 +127,8 @@ export async function navigateAndWait(page: Page, options: NavigateOptions = {})
   await page.waitForFunction(
     () => {
       const imgs = Array.from(document.querySelectorAll('img'));
+      // Inlined copy of allImagesComplete() from ./predicates.ts (cannot import inside waitForFunction).
+      // If you change one, update the other.
       return imgs.every((img) => img.complete);
     },
     { timeout: 10000 },
@@ -197,6 +199,8 @@ export async function navigateAndWait(page: Page, options: NavigateOptions = {})
               setTimeout(tick, 150);
               return;
             }
+            // Inlined copy of scrollHeightStable() from ./predicates.ts (cannot import inside waitForFunction).
+            // If you change one, update the other.
             resolve(reads.every((v) => v === reads[0]));
           };
           setTimeout(tick, 150);

--- a/tests/visual/predicates.ts
+++ b/tests/visual/predicates.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure-function predicates extracted from tests/visual/helpers.ts navigateAndWait.
+ * Used inside page.waitForFunction(...) — serialized into the browser context.
+ *
+ * IMPORTANT: page.waitForFunction serializes its callback to a string, so these
+ * predicates CANNOT be imported by reference inside the callback. They are
+ * exported here for vitest unit testing only; helpers.ts contains an inlined
+ * copy of the same logic. If you modify one, update the other.
+ */
+
+/** Returns true if all images in the array report complete=true. Empty array returns true. */
+export function allImagesComplete(imgs: ReadonlyArray<{ complete: boolean }>): boolean {
+  return imgs.every((img) => img.complete);
+}
+
+/** Returns true if all scrollHeight reads are equal (i.e., layout has stabilized). */
+export function scrollHeightStable(reads: ReadonlyArray<number>): boolean {
+  if (reads.length === 0) return true;
+  return reads.every((v) => v === reads[0]);
+}


### PR DESCRIPTION
## Summary

PR #44 follow-up (Part A) — low-risk docs + test infrastructure work split out from the larger fixme-lifting changes in upcoming PR B.

* **Task 4**: Document `update-snapshots.yml` `workflow_dispatch` trigger as break-glass for cross-fork PRs and chained-workflow `GITHUB_TOKEN` limitations.
* **Task 5**: Extract layout-settle predicates (`allImagesComplete`, `scrollHeightStable`) from `tests/visual/helpers.ts` into a pure-function module + 11 vitest unit tests.

`page.waitForFunction` serializes callbacks into the browser context, so the helpers cannot import the predicates by reference. The pure-function module exists for unit testing; helpers retain inlined copies with sync comments linking the two.

Plan: `.omc/plans/pr44-followup.md` Steps 4 + 5.

## Test plan

- [ ] `npm run test:build` passes (11 new test cases)
- [ ] `npx tsc --noEmit` clean
- [ ] visual-tests CI workflow passes (no behavior change — helpers.ts logic identical)
- [ ] update-snapshots.yml header comment is visible on the GitHub Actions UI