### PR TITLE
refactor(markup): apply W16 comment discipline to dashboard templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,11 @@
 - [ ] If I added a `<script>` tag: it has a `src=` attribute (no inline body), OR it is a bundled module `<script>` (no `is:inline`).
 - [ ] If I added a DOM event handler: it's attached in `public/js/*.js`, not as an `on*=` attribute.
 
+## Comment discipline
+
+- [ ] Added markup comments encode a non-obvious WHY (per agent-enforcement W16)
+- [ ] In `.astro`, WHY notes use `{/* */}` (not `<!-- -->`, which ships to the DOM)
+
 ## Test plan
 
 <!-- How was this verified? -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,10 @@ em-dashes. No AI attribution (`Co-Authored-By: Claude`, etc.). Add git trailers
 (`Constraint:`, `Rejected:`, `Directive:`, `Confidence:`, `Scope-risk:`) per the
 global commit protocol when a change carries non-trivial decision context.
 
+### Rules and Guardrails
+
+- **Comment discipline in templates** — Defined in `~/Repositories/agent-enforcement/rules/web/comment-discipline.md` (Check W16). Default: zero markup comments. In `.astro`, a genuine WHY note uses `{/* */}` (compiled away), never `<!-- -->` (ships to the browser DOM). See the rule for allowed WHY categories, forbidden patterns, and the verification grep.
+
 ## Deeper Reference
 
 - `docs/wiki/` -- architecture, brand guide, LLM-content spec.

--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -19,11 +19,11 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
   <meta name="description" content={description}>
   <meta name="robots" content={robots}>
   <meta name="keywords" content="backend engineer portfolio, software engineer portfolio, data visualization dashboard, living data dashboard, human datastream, engineering director, personal dashboard, biometrics dashboard, GitHub activity visualization, Astro static site">
-  <!-- Security: CSP + Referrer-Policy served via HTTP headers (functions/_middleware.ts) -->
+  {/* Security: CSP + Referrer-Policy served via HTTP headers (functions/_middleware.ts) */}
   <meta name="author" content="Jonathan Lloyd">
   <meta property="og:locale" content="en_US">
   <link rel="canonical" href={canonicalURL}>
-  <!-- LLM-friendly alternate versions (backend-composed live on CloudFront) -->
+  {/* LLM-friendly alternate versions (backend-composed live on CloudFront) */}
   <link rel="alternate" type="text/markdown" href="https://d1pfm520aduift.cloudfront.net/llms-full.txt" title="LLM-friendly complete content">
   <link rel="alternate" type="text/markdown" href="https://d1pfm520aduift.cloudfront.net/llms-small.txt" title="LLM-friendly current-state snapshot">
   <link rel="alternate" type="text/markdown" href="https://jonathanlloyd.me/llms.txt" title="LLM discovery index">
@@ -33,7 +33,6 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
   <link rel="manifest" href="/manifest.webmanifest">
   <link rel="sitemap" href="/sitemap-index.xml">
 
-  <!-- OpenGraph -->
   <meta property="og:title" content={title}>
   <meta property="og:description" content={ogDescription}>
   <meta property="og:type" content="profile">
@@ -46,14 +45,12 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
   <meta property="profile:first_name" content="Jonathan">
   <meta property="profile:last_name" content="Lloyd">
 
-  <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content={title}>
   <meta name="twitter:description" content={ogDescription}>
   <meta name="twitter:image" content={ogImage}>
   <meta name="twitter:image:alt" content="Jonathan Lloyd — Human Datastream dashboard">
 
-  <!-- JSON-LD Structured Data -->
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@graph": [
@@ -215,15 +212,14 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
     ]
   })} />
 
-  <!-- Font preload (critical for swap timing)
+  {/* Font preload (critical for swap timing)
      Dev note: Chrome warns "preloaded but not used within a few seconds" on localhost.
      This is a Vite dev-server timing artifact — the middleware stack delays CSS delivery
      enough for Chrome's ~3s timer to fire before @font-face claims the font. Harmless;
-     does not occur in production where static files are served directly. -->
+     does not occur in production where static files are served directly. */}
   <link rel="preload" href="/fonts/space-grotesk-latin.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" as="image" type="image/webp" href="/assets/avatar.webp">
 
-  <!-- DNS prefetch fallbacks + preconnect hints -->
   <link rel="preconnect" href="https://d1pfm520aduift.cloudfront.net" crossorigin>
   {import.meta.env.PROD && (
     <link rel="prefetch" href="https://d1pfm520aduift.cloudfront.net/health.json" as="fetch" crossorigin>
@@ -235,10 +231,10 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
   <link rel="dns-prefetch" href="https://scripts.simpleanalyticscdn.com">
   <link rel="dns-prefetch" href="https://queue.simpleanalyticscdn.com">
   <link rel="stylesheet" href="/vendor/leaflet/leaflet.css" media="print" id="leafletCss">
-  <!-- Design system tokens: 3-line public contract (preamble + layered values + bare-name compat aliases).
+  {/* Design system tokens: 3-line public contract (preamble + layered values + bare-name compat aliases).
        Astro processes this <style> (non-inline), resolves the @imports via @lifegames/tokens,
        and inlines the result at build time because astro.config.mjs sets build.inlineStylesheets: 'always'.
-       LCP behavior is preserved vs the previous in-file :root token block. -->
+       LCP behavior is preserved vs the previous in-file :root token block. */}
   <style is:global>
     @import '@lifegames/tokens/preamble';
     @import '@lifegames/tokens/css.layered';
@@ -426,16 +422,15 @@ html, body {
   <noscript><style>.tri-card,.identity-card,.left-panel-status,.left-panel-bio{opacity:1!important;transform:none!important;}</style></noscript>
   <a href="#main-content" class="lg-skip-link">Skip to main content</a>
   <slot />
-  <!-- BookModal: externalized activation (CSP script-src 'self'). Delegated
-       handler on document.body parses .shelf-book[data-book] JSON and opens the modal. -->
+  {/* BookModal: externalized activation (CSP script-src 'self'). Delegated
+       handler on document.body parses .shelf-book[data-book] JSON and opens the modal. */}
   <script is:inline src="/js/book-modal.js" defer></script>
-  <!-- IdentityCard social-click analytics: externalized delegated handler (CSP). -->
+  {/* IdentityCard social-click analytics: externalized delegated handler (CSP). */}
   <script is:inline src="/js/social-click-track.js" defer></script>
-  <!-- Leaflet: lazy-loaded via IntersectionObserver when a map widget scrolls into view -->
+  {/* Leaflet: lazy-loaded via IntersectionObserver when a map widget scrolls into view */}
   <script is:inline src="/js/leaflet-lazy.js"></script>
-  <!-- Service Worker -->
   <script is:inline src="/js/sw-register.js"></script>
-  <!-- WebMCP: expose site tools to AI agents via browser (W3C Community Draft) -->
+  {/* WebMCP: expose site tools to AI agents via browser (W3C Community Draft) */}
   <script is:inline src="/js/webmcp.js"></script>
   {import.meta.env.PROD && (
     <Fragment>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,6 @@ const { profile, health, github, reading, books, system, starredRepos } = await 
 
   <div class="command-layout">
 
-    <!-- LEFT PANEL: Identity -->
     <aside class="left-panel" aria-label="Profile">
       <IdentityCard profile={profile} />
       <BioTerminal profile={profile} />
@@ -27,7 +26,6 @@ const { profile, health, github, reading, books, system, starredRepos } = await 
     </aside>
 
 
-    <!-- TOP BAR -->
     <nav aria-label="Dashboard">
       <header class="top-bar">
         <div class="top-bar-title">Human Datastream</div>
@@ -39,11 +37,9 @@ const { profile, health, github, reading, books, system, starredRepos } = await 
       </header>
     </nav>
 
-    <!-- RIGHT PANEL: Triptych Grid -->
     <main id="main-content" class="right-panel">
       <div class="triptych-grid" id="triptychGrid">
 
-        <!-- COLUMN 1: BODY -->
         <section class="triptych-column triptych-column-body" aria-label="Body">
           <h2 class="column-header column-header-pink">Body</h2>
           <HeartRate health={health} />
@@ -55,7 +51,6 @@ const { profile, health, github, reading, books, system, starredRepos } = await 
           {import.meta.env.DEV && <ExplorationOdometerV3 />}
         </section>
 
-        <!-- COLUMN 2: MIND -->
         <section class="triptych-column triptych-column-mind" aria-label="Mind">
           <h2 class="column-header column-header-green">Mind</h2>
           <DevActivityLog events={github.devActivity} />
@@ -72,7 +67,6 @@ const { profile, health, github, reading, books, system, starredRepos } = await 
 
   <BookModal />
 
-  <!-- Particles -->
   <script>
     window.addEventListener('load', () => {
       if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
@@ -80,16 +74,12 @@ const { profile, health, github, reading, books, system, starredRepos } = await 
     });
   </script>
 
-  <!-- Live Clock -->
   <script is:inline src="/js/clock.js"></script>
 
-  <!-- Staggered Card Reveal -->
   <script is:inline src="/js/card-reveal.js"></script>
 
-  <!-- Scroll Depth Tracking -->
   <script is:inline src="/js/scroll-depth.js"></script>
 
-  <!-- Live Data Integration -->
   <script>
     import '@lifegames/web/runtime/live-data';
   </script>


### PR DESCRIPTION
## Summary

- Applies **agent-enforcement Check W16** (markup comment discipline) to the dashboard templates.
- **`index.astro`**: deletes 10 WHAT-noise `<!-- -->` comments that merely restated the adjacent `aria-label`, class, `src`, or component name.
- **`Dashboard.astro`**: deletes 5 WHAT-noise comments (OpenGraph, Twitter Card, JSON-LD, DNS prefetch, Service Worker) and converts 8 genuine-WHY notes from `<!-- -->` to `{/* */}` (CSP/quirk/runtime-contract pointers) so they are stripped at build instead of shipping to the public DOM.
- CSS `/* */` comments inside `<style>` and frontmatter `//` comments are **untouched** (out of scope).
- Adds a "Rules and Guardrails" pointer to `CLAUDE.md` and a comment-discipline checkbox to the PR template.

## Why convert instead of just delete

Astro emits `<!-- -->` HTML comments into the browser DOM (visible in View Source); `{/* */}` JS-style comments are compiled away. `compressHTML` does not strip HTML comments and third-party stripping is unsafe (breaks server-island hydration), so the only safe way to keep a dev-only note off the public DOM is to author it as `{/* */}`.

## Verification

- Comments do not render and `{/* */}` is stripped → **zero rendered drift expected**; baselines should not change.
- Local arm64 cannot run the Playwright Docker suite (SwiftShader SIGSEGV under QEMU) — visual regression is verified by CI on native runners.

## Depends on

- `agent-enforcement#15` (defines the W16 rule this references).

## Test plan

- [x] CI build green
- [x] Visual-regression suite: zero baseline drift
