### PR TITLE
feat(copy): consume @lifegames/copy identity (Dashboard + PWA manifest)

### DIFF
--- a/.contract-lock.json
+++ b/.contract-lock.json
@@ -1,10 +1,10 @@
 {
   "generatedFrom": {
     "repo": "j0nathan-ll0yd/design-system-Lifegames",
-    "sha": "9bd0ee2b80204526afb97a206ade2b388ec1b8ec",
-    "checksum": "sha256:d118e40da7e265f2a5e8c2fa5a565b5d6380fac4959926c32713aaaa9bb3f3a1"
+    "sha": "3ea863817dff3607971041bc19cfe78f9dc7eda8",
+    "checksum": "sha256:c6648b3d2e1ce0a153cdbeb2510151750cbb89ad67e9b1244dd125e6e1c17f49"
   },
-  "generatedAt": "2026-06-11T04:39:22.852Z",
+  "generatedAt": "2026-06-11T22:17:46.484Z",
   "generatorVersion": "1.0.0",
   "files": {
     "raw-schemas/articles-export.schema.json": "sha256:4a3d6514ab959b251ad88bef79020747bbddb865d0a7c913e71fe36f608ffd36",
@@ -14,7 +14,7 @@
     "raw-schemas/github-starred-repos-export.schema.json": "sha256:dab7effd7bb7fa6a5444d4e32b43fdfff4d8ae1721e6be69ccd0a88be159c33f",
     "raw-schemas/health-export.schema.json": "sha256:a2730ea3b342b46672abe7bf98275e3627863dcd4b173d3c54b40d852226a3a2",
     "raw-schemas/location-export.schema.json": "sha256:72eaba34504ccc55c691857c8879b354b9fbdeba03d9e353b8b295bd13b01f1b",
-    "raw-schemas/sleep-export.schema.json": "sha256:c4ac6b7a3b26b49dfc1ce828ff59e1ea1ccb17f6af94f988ecb51fbc96fc2557",
+    "raw-schemas/sleep-export.schema.json": "sha256:ab11c1abeb9cbb3dc327243eb50507dab31f843d9f2a8cea367522431f16b85d",
     "raw-schemas/theatre-reviews-export.schema.json": "sha256:22d3a138fad1007d00e19786c7368086b79e4465864b034ecc907ed5e2d1998d",
     "raw-schemas/workouts-export.schema.json": "sha256:1814cc3935a95c345eece02fb0f560c95ce8bca92a4b90705489c21c7182c67e",
     "authored/dashboard-books.schema.json": "sha256:53f0f614b4df58e900c475529c1914ab0423e5129eb306b2ff6375bfa09732f8",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Production widgets, CSS, and runtime scripts come from `@lifegames/web/productio
 - Import runtime modules from `@lifegames/web/runtime/*` -- never relative paths like `../lib/` or `../scripts/`.
 - CSS flows from `@lifegames/tokens` via `@import`; there are no `public/css/*.css` files. Mark `<style>` blocks that import DS CSS with `is:global`.
 - `data/*.json` is Ajv-validated against `@lifegames/schemas` in the prebuild hook (`additionalProperties: false` -- any unmapped field fails the build).
+- **Customer-facing identity strings** come from `@lifegames/copy` (single source of truth; zero duplication). The Astro Content Collection `copy` (`src/content.config.ts`) loads `@lifegames/copy/identity.flat.json`, validated by the generated flat Zod (`@lifegames/copy/identity.zod`); `Dashboard.astro` reads `getEntry('copy','identity').data`; `astro.config.mjs` imports the flat JSON for the PWA manifest. Never hardcode bios, names, titles, expertise, or skip/OG-image text -- add or edit them in `design-system-Lifegames/packages/copy/src/identity.en-US.json` (ICU MF1), then `pnpm yalc:publish` from the DS. Spec: `docs/wiki/Copy-Package-Spec.md`.
 
 ## Conventions
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'astro/config';
 import AstroPWA from '@vite-pwa/astro';
 import sitemap from '@astrojs/sitemap';
 import { CLOUDFRONT_BASE } from '@lifegames/portal-contract/constants';
+import identity from '@lifegames/copy/identity.flat.json';
 
 // Host portion of CLOUDFRONT_BASE, regex-escaped for use in service-worker
 // urlPattern RegExps so the CloudFront host is never hardcoded here.
@@ -38,9 +39,9 @@ export default defineConfig({
     AstroPWA({
       registerType: 'autoUpdate',
       manifest: {
-        name: 'Jonathan Lloyd — Human Datastream',
-        short_name: 'Human Datastream',
-        description: 'Living data dashboard — tracking body and mind. Jack into his human datastream.',
+        name: identity.site.fullName,
+        short_name: identity.site.name,
+        description: identity.site.pwaDescription,
         start_url: '/',
         scope: '/',
         theme_color: '#06060f',

--- a/docs/wiki/Copy-Package-Spec.md
+++ b/docs/wiki/Copy-Package-Spec.md
@@ -91,8 +91,10 @@ freshness-gated (`git diff` over `packages/copy/dist` + `Sources/LifegamesCopy`)
 
 ## Distribution
 
-Phase 1 yalc (today): `pnpm yalc:publish` from the DS builds + pushes
-`@lifegames/copy` to consumers' `.yalc/`. iOS resolves the DS via SPM path/tag.
-Backend is a first-time yalc *consumer* (`.yalc/` gitignored; `file:.yalc/...` in
-`package.json` is the durable ref — CI parity needs a yalc-setup step, tracked for
-follow-up). Phase 2 flips JS consumers to GitHub Packages npm.
+JS consumers (web, backend) link `@lifegames/copy` via **yalc**: `pnpm yalc:publish`
+from the DS builds + pushes it to each consumer's `.yalc/`. iOS resolves the DS via
+SPM (path/tag). `.yalc/` is gitignored, so CI repopulates it by cloning the **public**
+design-system repo and building the (self-contained, zero-dep) copy package — web via
+`scripts/ci-setup.sh`, backend via `scripts/ci-setup-copy.sh` (both prefer a same-named
+DS branch for coordinated PRs, else `main`). yalc-only — there is no npm/registry
+publishing.

--- a/docs/wiki/Copy-Package-Spec.md
+++ b/docs/wiki/Copy-Package-Spec.md
@@ -51,7 +51,7 @@ as a **rich** tree. Every leaf is `{ value, _meta }`:
 
 `packages/copy/scripts/build.ts` (run via `pnpm -F @lifegames/copy build`):
 
-1. **Validate the rich file** against `packages/schemas/authored/copy.identity.schema.json`
+1. **Validate the rich file** against `packages/copy/schema/identity.schema.json`
    (draft-07, `$defs` `CopyString`/`CopyStringList`) with Ajv + `ajv-formats`.
 2. **Derive a FLAT schema** by tree-walking the rich schema and replacing only the
    leaf `$ref`s (`CopyString`→`{type:string}`, `CopyStringList`→`{type:array}`),

--- a/docs/wiki/Copy-Package-Spec.md
+++ b/docs/wiki/Copy-Package-Spec.md
@@ -1,0 +1,98 @@
+# Cross-Platform Copy Package (`@lifegames/copy`)
+
+Single source of truth for every customer-facing string across the four Lifegames
+Portal repos. Produced by the **design system** (`design-system-Lifegames`),
+consumed by **web**, **iOS**, the **backend**, and the **design system** itself.
+The invariant is **zero customer-facing string duplication**.
+
+Origin: ONBOARDING review item #10 ("extract all strings into a format with better
+context management, cross-repository").
+
+## Scope
+
+| Wave | Surface |
+|---|---|
+| **V1 (shipped)** | The **identity slice**: `person`, `site`, `seo`, `a11y`. Migrated everywhere the identity was hardcoded/duplicated (web `Dashboard.astro` + PWA manifest, backend LLM-content pipeline, the DS OG-image widget, iOS Settings→About). |
+| **V2 (backlog)** | Widget labels + empty-states, error/validation messages (passthrough model — copy holds display text, client may override), iOS feature-module sweep, a11y breadth, email/notification templates. |
+
+**Never copy:** dynamic/interpolated runtime values (book titles, `${status}`), debug
+logs, JSON-LD machine metadata that isn't prose, and **test/`#Preview` mock data**.
+Known excluded surfaces today: SwiftUI `#Preview` blocks (e.g. `BioTerminalView`),
+and the private, non-deployed `apps/portfolio` DS showcase.
+
+## Authoring model
+
+Strings are authored in `design-system-Lifegames/packages/copy/src/identity.en-US.json`
+as a **rich** tree. Every leaf is `{ value, _meta }`:
+
+```jsonc
+"shortBio": {
+  "value": "A living data dashboard by engineer, Jonathan Lloyd — …",  // ICU MessageFormat 1
+  "_meta": {
+    "description": "SEO meta description.",
+    "usage": ["web:Dashboard.astro:5 (meta description)"],  // every render site
+    "tone": "marketing",
+    "owner": "jonathan",
+    "lastReviewed": "2026-06-11",          // format:date, Ajv-enforced
+    "constraints": { "maxChars": 160 },     // CI-linted
+    "rationale": "Distinct from socialBio: …"
+  }
+}
+```
+
+- **ICU MessageFormat 1** syntax (static passthrough — no MF runtime in V1; only
+  literal `{`/`}` escape). CI parse-tests every string.
+- **Uniqueness-first** reconciliation: every existing variant is captured as its own
+  field. The V1 identity set keeps **5 distinct bios** (`shortBio`, `socialBio`,
+  `longBio`, `site.description`, `flavorBio`) deliberately — merging is a later,
+  explicit review, not a default.
+
+## Build & codegen
+
+`packages/copy/scripts/build.ts` (run via `pnpm -F @lifegames/copy build`):
+
+1. **Validate the rich file** against `packages/schemas/authored/copy.identity.schema.json`
+   (draft-07, `$defs` `CopyString`/`CopyStringList`) with Ajv + `ajv-formats`.
+2. **Derive a FLAT schema** by tree-walking the rich schema and replacing only the
+   leaf `$ref`s (`CopyString`→`{type:string}`, `CopyStringList`→`{type:array}`),
+   preserving every object wrapper, `required`, and `additionalProperties:false`.
+3. **Round-trip guard**: the derived flat schema must validate the flat instance, so
+   a derivation bug cannot silently drop a `required` field.
+4. Generate, **all from the single flat schema** (never the rich one):
+   - `dist/identity.flat.json` — flat values (`_meta` stripped)
+   - `dist/identity.ts` — flat TS types (`json-schema-to-typescript`)
+   - `dist/identity.zod.ts` — flat Zod `identitySchema` (`json-schema-to-zod`)
+   - `dist/index.ts` — typed barrel (zero-dep; no Zod import)
+   - `Sources/LifegamesCopy/Identity.generated.swift` — `public Sendable` Codable (`quicktype`)
+   - `Sources/LifegamesCopy/Resources/identity.en-US.json` — bundled device resource
+
+Build is idempotent (byte-identical re-runs). Generated artifacts are committed and
+freshness-gated (`git diff` over `packages/copy/dist` + `Sources/LifegamesCopy`).
+
+## Consumption
+
+| Layer | How |
+|---|---|
+| **Web** | Astro Content Collection `copy` in `src/content.config.ts` — `file()` loader over `@lifegames/copy/identity.flat.json` (object-map parser: `{ identity: data }`, so Astro uses the key as id and validates the untouched value), `schema: identitySchema` (the generated flat Zod). `Dashboard.astro` reads `getEntry('copy','identity').data`. `astro.config.mjs` imports the flat JSON for the PWA manifest. |
+| **iOS** | SPM product `LifegamesCopy` (`design-system-Lifegames`). `CopyLoader.loadIdentity()` (throwing) or `CopyLoader.identity` (non-throwing, for default args). Shown in Settings → About. |
+| **Backend** | `import identity from '@lifegames/copy/identity.flat.json'` — esbuild inlines it into the `ComposeLlmContent` Lambda. Drives `profile.ts`, `view.ts` (`EXPERTISE`), and the `llms-txt.eta` blockquote (`siteDescription`). |
+| **Design system** | `LifegamesWidgets` `OGImageProps` defaults from `CopyLoader.identity`. |
+
+## Enforcement (highest-tier, not docs)
+
+- **D9 leaf boundary**: `eslint-local-rules/copy-src-no-dependencies.js` forbids
+  `packages/copy/src` from importing any `@lifegames/*` or UI framework, so the
+  backend Lambda imports copy without pulling in UI/DS code. The schema is a
+  build-time devDep importable only from `packages/copy/scripts/`.
+- **CI** `copy` job: `build` + `test` (Ajv + ICU MF1 parse + `maxChars` + flat
+  round-trip) + `lint`.
+- **Freshness** git-diff in `packages/schemas/scripts/check-freshness.sh`.
+- **GOVERNANCE P3.1** (`design-system-Lifegames/GOVERNANCE.md`).
+
+## Distribution
+
+Phase 1 yalc (today): `pnpm yalc:publish` from the DS builds + pushes
+`@lifegames/copy` to consumers' `.yalc/`. iOS resolves the DS via SPM path/tag.
+Backend is a first-time yalc *consumer* (`.yalc/` gitignored; `file:.yalc/...` in
+`package.json` is the durable ref — CI parity needs a yalc-setup step, tracked for
+follow-up). Phase 2 flips JS consumers to GitHub Packages npm.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "human-datastream",
       "version": "1.0.0",
       "dependencies": {
+        "@lifegames/copy": "file:.yalc/@lifegames/copy",
         "@lifegames/portal-contract": "file:.yalc/@lifegames/portal-contract",
         "@lifegames/schemas": "file:.yalc/@lifegames/schemas",
         "@lifegames/tokens": "file:.yalc/@lifegames/tokens",
@@ -27,6 +28,9 @@
         "vitest": "^4.1.8",
         "wrangler": "^4.98.0"
       }
+    },
+    ".yalc/@lifegames/copy": {
+      "version": "0.1.0"
     },
     ".yalc/@lifegames/portal-contract": {
       "version": "0.1.0"
@@ -3342,6 +3346,10 @@
       "peerDependencies": {
         "tslib": "2"
       }
+    },
+    "node_modules/@lifegames/copy": {
+      "resolved": ".yalc/@lifegames/copy",
+      "link": true
     },
     "node_modules/@lifegames/portal-contract": {
       "resolved": ".yalc/@lifegames/portal-contract",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:smoke": "npx playwright test --config=playwright.smoke.config.ts"
   },
   "dependencies": {
+    "@lifegames/copy": "file:.yalc/@lifegames/copy",
     "@lifegames/portal-contract": "file:.yalc/@lifegames/portal-contract",
     "@lifegames/schemas": "file:.yalc/@lifegames/schemas",
     "@lifegames/tokens": "file:.yalc/@lifegames/tokens",

--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Phase 2 CI install step. Replaces the default `npm ci --legacy-peer-deps`.
 # Clones design-system-Lifegames, builds its packages, yalc-publishes the
-# three @lifegames/* packages, pulls them into this repo's .yalc/, and then
-# runs npm ci so the file:.yalc/* deps in package.json resolve.
+# @lifegames/* packages (tokens, web, schemas, copy), pulls them into this
+# repo's .yalc/ alongside portal-contract, and then runs npm ci so the
+# file:.yalc/* deps in package.json resolve.
 #
 # Override via env:
 #   DS_REPO  — git URL  (default: HTTPS to j0nathan-ll0yd/design-system-Lifegames)
@@ -59,7 +60,7 @@ echo "[ci-setup] yalc:publish from DS..."
 (cd "$DS_DIR" && pnpm yalc:publish)
 
 echo "[ci-setup] yalc add into consumer..."
-npx yalc add @lifegames/portal-contract @lifegames/tokens @lifegames/web @lifegames/schemas
+npx yalc add @lifegames/portal-contract @lifegames/tokens @lifegames/web @lifegames/schemas @lifegames/copy
 
 echo "[ci-setup] npm ci --legacy-peer-deps..."
 npm ci --legacy-peer-deps

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,19 @@
+import { defineCollection } from 'astro:content';
+import { file } from 'astro/loaders';
+import { fileURLToPath } from 'node:url';
+import { identitySchema } from '@lifegames/copy/identity.zod';
+
+const identityPath = fileURLToPath(import.meta.resolve('@lifegames/copy/identity.flat.json'));
+
+const copy = defineCollection({
+  // file() does not natively handle a single flat object, so wrap it under one
+  // entry id. Returning an object map ({ identity: data }) — rather than an
+  // array with an injected `id` field — keeps the entry data clean: Astro uses
+  // the key as the entry id and validates the untouched value, which the
+  // generated `.strict()` identitySchema requires (an injected `id` key would
+  // be rejected as an unrecognized property).
+  loader: file(identityPath, { parser: (text) => ({ identity: JSON.parse(text) }) }),
+  schema: identitySchema,
+});
+
+export const collections = { copy };

--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -1,9 +1,11 @@
 ---
+import { getEntry } from 'astro:content';
 import { CLOUDFRONT_BASE, ENDPOINTS, LLM_CONTENT_PATHS } from '@lifegames/portal-contract/constants';
+const identity = (await getEntry('copy', 'identity')).data;
 const {
-  title = 'Jonathan Lloyd — Human Datastream | Live Engineering Dashboard',
-  description = 'A living data dashboard by engineer, Jonathan Lloyd — tracking body (health, activity, hydration) and mind (coding, reading). Jack into his human datastream.',
-  ogDescription = 'A living data dashboard by engineering director Jonathan Lloyd. Real biometrics — heart rate, sleep, hydration, coding, reading. Jack into his human datastream.',
+  title = identity.seo.title,
+  description = identity.person.shortBio,
+  ogDescription = identity.person.socialBio,
   robots = 'index, follow',
 } = Astro.props;
 const siteUrl = Astro.site?.toString().replace(/\/$/, '');
@@ -19,9 +21,9 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
   <meta name="color-scheme" content="dark">
   <meta name="description" content={description}>
   <meta name="robots" content={robots}>
-  <meta name="keywords" content="backend engineer portfolio, software engineer portfolio, data visualization dashboard, living data dashboard, human datastream, engineering director, personal dashboard, biometrics dashboard, GitHub activity visualization, Astro static site">
+  <meta name="keywords" content={identity.seo.keywords.join(', ')}>
   {/* Security: CSP + Referrer-Policy served via HTTP headers (functions/_middleware.ts) */}
-  <meta name="author" content="Jonathan Lloyd">
+  <meta name="author" content={identity.person.name}>
   <meta property="og:locale" content="en_US">
   <link rel="canonical" href={canonicalURL}>
   {/* LLM-friendly alternate versions (backend-composed live on CloudFront) */}
@@ -40,16 +42,16 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
   <meta property="og:image" content={ogImage}>
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="Jonathan Lloyd — Human Datastream dashboard">
-  <meta property="og:site_name" content="Human Datastream">
-  <meta property="profile:first_name" content="Jonathan">
-  <meta property="profile:last_name" content="Lloyd">
+  <meta property="og:image:alt" content={identity.a11y.ogImageAlt}>
+  <meta property="og:site_name" content={identity.site.name}>
+  <meta property="profile:first_name" content={identity.person.firstName}>
+  <meta property="profile:last_name" content={identity.person.lastName}>
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content={title}>
   <meta name="twitter:description" content={ogDescription}>
   <meta name="twitter:image" content={ogImage}>
-  <meta name="twitter:image:alt" content="Jonathan Lloyd — Human Datastream dashboard">
+  <meta name="twitter:image:alt" content={identity.a11y.ogImageAlt}>
 
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
@@ -57,8 +59,8 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
       {
         "@type": "WebSite",
         "@id": siteUrl + "#website",
-        "name": "Jonathan Lloyd — Human Datastream",
-        "description": "Personal portfolio of Jonathan Lloyd, an engineering director and backend engineer, built as a living data dashboard. Real biometrics and constant updates of his whole body (health, activity, hydration, location) and mind (coding, reading, learning). Jack into his human datastream as the world becomes more AI-centric.",
+        "name": identity.site.fullName,
+        "description": identity.site.description,
         "url": siteUrl,
         "inLanguage": "en-US",
         "publisher": { "@id": siteUrl + "#person" }
@@ -75,9 +77,9 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
       {
         "@type": "Person",
         "@id": siteUrl + "#person",
-        "name": "Jonathan Lloyd",
+        "name": identity.person.name,
         "alternateName": "j0nathan-ll0yd",
-        "jobTitle": "Engineering Director",
+        "jobTitle": identity.person.jobTitle,
         "url": siteUrl,
         "image": {
           "@type": "ImageObject",
@@ -87,19 +89,9 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
           "https://www.linkedin.com/in/lifegames/",
           "https://github.com/j0nathan-ll0yd"
         ],
-        "knowsAbout": [
-          "Backend Engineering",
-          "Software Engineering",
-          "Engineering Leadership",
-          "Cloud Infrastructure",
-          "Data Visualization",
-          "Serverless Architecture",
-          "TypeScript",
-          "Go",
-          "AWS"
-        ],
+        "knowsAbout": identity.seo.expertise,
         "knowsLanguage": ["en"],
-        "description": "Engineering director and backend engineer with 24+ years of experience. Built this portfolio as a living data dashboard — real biometrics and constant updates of body (health, activity, hydration, location) and mind (coding, reading, learning). Jack into his human datastream as the world becomes more AI-centric."
+        "description": identity.person.longBio
       },
       {
         "@type": "Dataset",
@@ -414,7 +406,7 @@ html, body {
 <body>
   <div class="hud-frame" aria-hidden="true"></div>
   <noscript><style>.tri-card,.identity-card,.left-panel-status,.left-panel-bio{opacity:1!important;transform:none!important;}</style></noscript>
-  <a href="#main-content" class="lg-skip-link">Skip to main content</a>
+  <a href="#main-content" class="lg-skip-link">{identity.a11y.skipToMain}</a>
   <slot />
   {/* BookModal: externalized activation (CSP script-src 'self'). Delegated
        handler on document.body parses .shelf-book[data-book] JSON and opens the modal. */}


### PR DESCRIPTION
## Summary
Read customer-facing identity from `@lifegames/copy` instead of hardcoding it.

- New Astro Content Collection `copy` (`src/content.config.ts`) over `@lifegames/copy/identity.flat.json`, validated by the generated flat Zod.
- `Dashboard.astro` reads `getEntry('copy','identity').data` (meta, OG/Twitter, WebSite + Person JSON-LD, skip link).
- `astro.config.mjs` PWA manifest (`name`/`short_name`/`description`) imports the flat JSON.
- `ci-setup.sh` yalc-adds `@lifegames/copy`.

Rendered output is byte-identical (uniqueness-first preserved exact strings).

## Cross-repo coordination
Part of a 4-PR set. Depends on the **design-system** PR — merge that first. The visual-tests CI builds the same-named DS branch, so it coordinates pre-merge; jobs that use DS `main` go green once the DS PR lands.

## Test plan
- [x] `npm run test:build` (75 tests) + rendered `dist` HTML verified
- [ ] visual-regression (CI-only on amd64; no delta expected — head-only changes)