### PR TITLE
feat(copy): source dashboard accessibility labels from @lifegames/copy

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,9 +1,10 @@
 ---
 import Dashboard from '../layouts/Dashboard.astro';
+import { a11y } from '@lifegames/copy';
 ---
 <Dashboard title="Page Not Found — Jonathan Lloyd" description="The requested page could not be found." robots="noindex">
   <main id="main-content" class="glitch-page">
-    <div class="glitch-container" aria-label="404 error page">
+    <div class="glitch-container" aria-label={a11y.page404.region}>
       <div class="glitch-404" aria-hidden="true">404</div>
       <div class="glitch-subtitle">Glitch Protocol Engaged</div>
       <div class="glitch-sub2">datastream integrity compromised</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,7 @@ import {
   TheatreReviews,
 } from '@lifegames/web/production';
 import { loadDashboardData } from '../lib/load-dashboard-data';
+import { a11y } from '@lifegames/copy';
 
 const { profile, health, github, reading, books, system, starredRepos } = await loadDashboardData();
 ---
@@ -19,28 +20,28 @@ const { profile, health, github, reading, books, system, starredRepos } = await 
 
   <div class="command-layout">
 
-    <aside class="left-panel" aria-label="Profile">
+    <aside class="left-panel" aria-label={a11y.nav.profile}>
       <IdentityCard profile={profile} />
       <BioTerminal profile={profile} />
       <SystemStatus system={system} />
     </aside>
 
 
-    <nav aria-label="Dashboard">
+    <nav aria-label={a11y.nav.dashboard}>
       <header class="top-bar">
         <div class="top-bar-title">Human Datastream</div>
         <span id="pollStatus" class="poll-status">
           <span class="poll-dot poll-dot--off"></span>
           <span class="poll-label"></span>
         </span>
-        <div class="top-bar-clock" id="liveClock" aria-live="off" aria-label="Current time"></div>
+        <div class="top-bar-clock" id="liveClock" aria-live="off" aria-label={a11y.clock.currentTime}></div>
       </header>
     </nav>
 
     <main id="main-content" class="right-panel">
       <div class="triptych-grid" id="triptychGrid">
 
-        <section class="triptych-column triptych-column-body" aria-label="Body">
+        <section class="triptych-column triptych-column-body" aria-label={a11y.region.body}>
           <h2 class="column-header column-header-pink">Body</h2>
           <HeartRate health={health} />
           <MovementRings health={health} />
@@ -51,7 +52,7 @@ const { profile, health, github, reading, books, system, starredRepos } = await 
           {import.meta.env.DEV && <ExplorationOdometerV3 />}
         </section>
 
-        <section class="triptych-column triptych-column-mind" aria-label="Mind">
+        <section class="triptych-column triptych-column-mind" aria-label={a11y.region.mind}>
           <h2 class="column-header column-header-green">Mind</h2>
           <DevActivityLog events={github.devActivity} />
           <ReadingFeed reading={reading} />


### PR DESCRIPTION
## Summary

Sources the dashboard's accessibility copy from `@lifegames/copy` instead of hardcoded strings. `index.astro` (nav / region / clock aria-labels) and `404.astro` (region label) now read from the `a11y` namespace.

The widget labels themselves are owned by the design system package (design-system-Lifegames PR); this repo is otherwise unchanged and rebuilds against the updated package via yalc.

## Verification
- [x] `npm run build` green; rendered HTML confirms the a11y labels (Body / Mind / Profile / Dashboard / Current time / 404 error page)
- [x] visual-regression suite green

## Coordination
Depends on the design-system-Lifegames same-named branch (CI clones it to build the copy package). Merge together.
