### PR TITLE
feat(web): add /humans.txt endpoint with discovery and tests

### DIFF
--- a/docs/wiki/Metadata-Files-Spec.md
+++ b/docs/wiki/Metadata-Files-Spec.md
@@ -1,0 +1,188 @@
+# Metadata Files Spec
+
+## Purpose
+
+`jonathanlloyd.me` maintains a family of root-level metadata files — each
+addressing a distinct audience and machine-readability level. Taken together
+they make the site legible to search crawlers, AI agents, developer tools,
+and human visitors without duplicating the information in each file.
+
+The guiding framing: **every metadata file has an intended audience**. Writing
+for the wrong audience (e.g., plain-text email in a publicly scraped file,
+crawl-unfriendly redirect chains in a sitemap) is a failure mode, not a
+configuration choice. Each file below targets one audience and is generated
+by the mechanism best suited to that audience's freshness requirements.
+
+## Inventory
+
+| Path                        | Audience                  | Generation                                                           | Spec / reference |
+| --------------------------- | ------------------------- | -------------------------------------------------------------------- | ---------------- |
+| `/robots.txt`               | Machines (crawlers)       | Build-time endpoint (`src/pages/robots.txt.ts`)                      | robotstxt.org    |
+| `/sitemap-index.xml`        | Machines (search engines) | `@astrojs/sitemap` integration                                       | sitemaps.org     |
+| `/llms.txt`                 | AI agents                 | Backend-composed live (CloudFront proxy via `functions/llms.txt.ts`) | llmstxt.org      |
+| `/humans.txt`               | Humans                    | Build-time endpoint (`src/pages/humans.txt.ts`)                      | humanstxt.org    |
+| `/.well-known/api-catalog`  | Machines (API clients)    | Static file (`public/.well-known/api-catalog`)                       | RFC 9727         |
+| `/.well-known/security.txt` | Machines + humans         | (Future) Static file at `/.well-known/security.txt`                  | RFC 9116         |
+
+`/llms.txt` is the only backend-composed file because its value proposition is
+**live data** — it reflects the current health, reading, and activity state and
+is recomposed by the `ComposeLlmContent` Lambda on every EventBridge trigger.
+Every other file is build-time: their contents are stable across deploys.
+
+## Design Principles
+
+### Build-time where possible
+
+Backend composition is expensive operationally (Lambda + CloudFront TTL
+management, cache invalidation, event-trigger timing). It is warranted only
+when the file's audience needs **live** data — as AI agents querying `llms.txt`
+do. Static metadata (who made the site, which crawlers are allowed, what
+standards the site uses) is known at build time and must not depend on runtime
+infrastructure.
+
+### Strings from `@lifegames/copy` for customer-facing content
+
+Any string a human or agent reads as prose — name, location, job title, bio,
+social links — is sourced from `@lifegames/copy/identity.flat.json`. Endpoints
+import this flat JSON at build time; the copy package is the single source of
+truth. Presentational scaffolding (section delimiters like `/* TEAM */`,
+protocol field labels like `Name:`, `Hosting:`) lives in the endpoint itself
+because it is format-specific layout, not content. See [Copy Package
+Spec](Copy-Package-Spec.md) for authoring conventions.
+
+### Privacy-first
+
+No plain-text email appears in any metadata file. The site is a read-only,
+public surface with no authentication; a plain-text email in a file accessible
+to every scraper is a harvesting invitation. Existing public profile URLs
+(LinkedIn, GitHub — from `identity.person.sameAs`) provide contact channels
+without the exposure risk.
+
+Location is coarse: city-level only (`identity.person.location`), consistent
+with the 6-layer location privacy framework on the backend export pipeline.
+
+### Discovery via `<link>` and `Link` header
+
+Machine consumers need a reliable way to discover metadata files without
+guessing paths. This site uses two complementary signals:
+
+- **HTML `<link>` in `<head>`** (`Dashboard.astro`) — declarative, parsed by
+  browsers and crawlers that fetch the HTML document.
+- **HTTP `Link` response header** (`functions/_middleware.ts`) — injected on
+  the homepage (`/`) only, for agents that inspect headers without parsing HTML.
+
+The middleware is the **single authority for response headers**. The `_headers`
+file at repo root is inert — Cloudflare Pages disables `_headers` processing
+when a root Pages Function middleware is present. Any header change must go in
+`functions/_middleware.ts`.
+
+Discovery `<link>` relations in use:
+
+| Relation        | File                 | Standard             |
+| --------------- | -------------------- | -------------------- |
+| `rel="sitemap"` | `/sitemap-index.xml` | HTML Living Standard |
+| `rel="author"`  | `/humans.txt`        | HTML Living Standard |
+
+### Honest metadata
+
+Metadata that lies is worse than absent metadata. Two specific anti-patterns
+this site avoids:
+
+- **`lastmod` stamped to the deploy date.** A deploy-time `lastmod` on an
+  unchanged page teaches search engines the signal is fake. The sitemap either
+  derives `lastmod` from real content history or omits it. See
+  [sitemap-philosophy.md](.omc/plans/sitemap-philosophy.md) for the full ADR.
+- **Rotting hardcoded dates.** `humans.txt` derives `Last update:` from
+  `new Date().toISOString().slice(0, 10)` at build time. This is honest: the
+  file IS regenerated on every deploy (because it is a prerendered endpoint),
+  so the build date accurately reflects the file's state.
+
+## Privacy Stance
+
+### No email
+
+RFC 9116 (`security.txt`) and the humanstxt.org convention both suggest an
+email contact. This site deliberately omits email from all plain-text metadata
+files. The reasoning:
+
+1. Plain-text email in a publicly indexed file is trivially harvestable.
+2. The site's public profile links (LinkedIn, GitHub) are adequate contact
+   channels for any legitimate inquiry.
+3. The site operator's email is not a secret, but it is not the site's job to
+   make harvesting it easy.
+
+When `/security.txt` is eventually added (RFC 9116), it will use
+`Contact: https://...` (URL form) rather than `Contact: mailto:...`.
+
+### Coarse location
+
+`humans.txt` includes a `From:` field using city-level location only
+(`identity.person.location`). This matches the granularity already public on
+professional profiles and is consistent with the backend's location privacy
+framework, which delays, suppresses, and broadens precise location data before
+it reaches the web surface.
+
+## File Notes
+
+### `/robots.txt` — build-time endpoint
+
+Managed in `src/pages/robots.txt.ts`. Contains allow/disallow directives for
+search engines and 9 named AI bots, a `Sitemap:` pointer, and a
+`Content-Signal:` line per the IETF `draft-romm-aipref-contentsignals` spec
+(`search=yes, ai-train=no, ai-input=yes`). Source of truth for which bots are
+allowed to crawl and under what conditions.
+
+### `/sitemap-index.xml` — `@astrojs/sitemap` integration
+
+Auto-generated at build time by `@astrojs/sitemap`. Lists the single canonical
+URL `https://jonathanlloyd.me/`. `lastmod` is omitted (config: no `lastmod`
+option set) to avoid the deploy-timestamp anti-pattern. The index/child split
+is `@astrojs/sitemap`'s default output shape; it is protocol-valid and harmless
+at this scale. See [sitemap-philosophy.md](.omc/plans/sitemap-philosophy.md)
+for the full decision record including research citations and the astro#16838
+resolution.
+
+### `/llms.txt` — backend-composed live
+
+The only runtime-composed metadata file. The `ComposeLlmContent` Lambda writes
+it to CloudFront on each EventBridge data-change trigger (30-minute safety-net
+schedule). `functions/llms.txt.ts` is a Cloudflare Pages Function that proxies
+the CloudFront-hosted canonical with edge caching (`s-maxage=3600,
+stale-while-revalidate=86400`). See [LLM-Content-Spec.md](LLM-Content-Spec.md)
+for the full inventory, content-granularity rules, and freshness expectations.
+
+### `/humans.txt` — build-time endpoint
+
+Managed in `src/pages/humans.txt.ts`. Follows the humanstxt.org three-section
+convention (`/* TEAM */`, `/* SITE */`, `/* THANKS */`). All data values
+(`Name:`, `From:`, `Contact:`, `Software:`, `Hosting:`, `Standards:`,
+`/* THANKS */` credits) are sourced from `@lifegames/copy`; section delimiters
+and field labels are endpoint scaffolding. `Contact:` points to the LinkedIn
+URL (`identity.person.sameAs[0]`), not an email address. `Last update:` is
+derived from the build timestamp (honest, because the endpoint is prerendered
+on every deploy).
+
+### `/.well-known/api-catalog` — static RFC 9727
+
+Static JSON file at `public/.well-known/api-catalog`, copied to `dist/` by
+Astro at build time. RFC 9727 linkset format — advertises the CloudFront data
+API to agent clients. `Content-Type: application/linkset+json` is set by the
+middleware override (not by `_headers`).
+
+### `/.well-known/security.txt` — future (RFC 9116)
+
+Not yet implemented. When added, it will be a static file at
+`public/.well-known/security.txt` using `Contact: https://...` (URL, not
+`mailto:`). The `Link` header and HTML `<link>` discovery wiring should be
+added at the same time as the file. Do not pre-wire the Link header with no
+backing file (dangling 404).
+
+## Cross-References
+
+- [sitemap-philosophy.md](.omc/plans/sitemap-philosophy.md) — Full ADR for
+  the sitemap decision: `@astrojs/sitemap` vs hand-authored, `lastmod` stance,
+  host-scoping principle, and astro#16838 resolution.
+- [LLM-Content-Spec.md](LLM-Content-Spec.md) — `/llms.txt` content rules,
+  freshness model, agent-readiness inventory, and middleware header spec.
+- [Copy-Package-Spec.md](Copy-Package-Spec.md) — `@lifegames/copy` authoring
+  model, build pipeline, and zero-duplication invariant.

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -30,6 +30,7 @@ const LINK_HEADER = [
   '</llms.txt>; rel="describedby"; type="text/plain"',
   '</.well-known/api-catalog>; rel="api-catalog"',
   '</sitemap-index.xml>; rel="sitemap"',
+  '</humans.txt>; rel="author"',
 ].join(', ');
 
 // Minimal Cloudflare Pages Function context — only the fields this middleware reads.

--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -37,6 +37,7 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
   <link rel="apple-touch-icon" href="/assets/icon-192.png">
   <link rel="manifest" href="/manifest.webmanifest">
   <link rel="sitemap" href="/sitemap-index.xml">
+  <link rel="author" href="/humans.txt">
 
   <meta property="og:title" content={title}>
   <meta property="og:description" content={ogDescription}>

--- a/src/pages/humans.txt.ts
+++ b/src/pages/humans.txt.ts
@@ -1,0 +1,31 @@
+// Section delimiters and field labels are presentational scaffolding for the
+// humanstxt.org format — they live here, not in the copy package. All
+// customer-facing string values (name, title, location, URLs, stack, etc.)
+// are sourced from @lifegames/copy to honour the zero-duplication invariant.
+import identity from '@lifegames/copy/identity.flat.json';
+
+export const prerender = true;
+
+export function GET(): Response {
+  const lastUpdate = new Date().toISOString().slice(0, 10);
+
+  const body = `/* TEAM */
+Name: ${identity.person.name}
+Role: ${identity.person.jobTitle}
+From: ${identity.person.location}
+Contact: ${identity.person.sameAs[0]}
+
+/* THANKS */
+${identity.humansTxt.thanks.map((credit: string) => `Name: ${credit}`).join('\n')}
+
+/* SITE */
+Last update: ${lastUpdate}
+Software: ${identity.humansTxt.stack.join(', ')}
+Hosting: ${identity.humansTxt.hosting}
+Standards: ${identity.humansTxt.standards}
+`.trimStart();
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/tests/build/humans-txt.test.ts
+++ b/tests/build/humans-txt.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+const distDir = path.resolve(process.cwd(), 'dist');
+const humansTxtPath = path.join(distDir, 'humans.txt');
+
+let content: string;
+
+beforeAll(() => {
+  content = readFileSync(humansTxtPath, 'utf-8');
+});
+
+describe('humans.txt build output', () => {
+  it('dist/humans.txt exists and is non-empty', () => {
+    expect(existsSync(humansTxtPath)).toBe(true);
+    expect(content.length).toBeGreaterThan(0);
+  });
+
+  it('contains /* TEAM */ section header', () => {
+    expect(content).toContain('/* TEAM */');
+  });
+
+  it('contains /* SITE */ section header', () => {
+    expect(content).toContain('/* SITE */');
+  });
+
+  it('contains /* THANKS */ section header', () => {
+    expect(content).toContain('/* THANKS */');
+  });
+
+  it('contains Name: Jonathan Lloyd', () => {
+    expect(content).toContain('Name: Jonathan Lloyd');
+  });
+
+  it('contains no @ character (email privacy guard)', () => {
+    expect(content).not.toContain('@');
+  });
+});

--- a/tests/smoke/home.smoke.ts
+++ b/tests/smoke/home.smoke.ts
@@ -151,6 +151,13 @@ test.describe('production home dashboard', () => {
     expect(swScriptUrl).toMatch(/\/sw\.js$/);
   });
 
+  test('humans.txt is reachable and plain text', async ({ page }) => {
+    const res = await page.request.get('/humans.txt');
+    expect(res.status(), '/humans.txt did not return 200').toBe(200);
+    const contentType = res.headers()['content-type'] || '';
+    expect(contentType, '/humans.txt wrong content-type').toContain('text/plain');
+  });
+
   test('version.json reports the deployed build', async ({ page }) => {
     const res = await page.request.get('/version.json');
     expect(res.status(), '/version.json did not return HTTP 200').toBe(200);


### PR DESCRIPTION
## Summary

- Adds a prerendered `/humans.txt` endpoint (`src/pages/humans.txt.ts`) mirroring the `robots.txt.ts` pattern, with `export const prerender = true` and `Content-Type: text/plain; charset=utf-8`
- All customer-facing strings (name, title, location, contact URL, stack, hosting, standards, thanks) sourced from `@lifegames/copy` identity namespace (`humansTxt.*` fields) — zero duplication invariant preserved
- Discovery wired via `<link rel="author" href="/humans.txt">` in `Dashboard.astro` `<head>` (after `<link rel="sitemap">`) and `</humans.txt>; rel="author"` entry in `_middleware.ts` `LINK_HEADER` array
- No email in the output (privacy guard asserted by build test)

## Test plan

- [x] `npm run build` succeeds; `dist/humans.txt` generated with `/* TEAM */`, `/* THANKS */`, `/* SITE */` sections
- [x] `dist/index.html` contains `<link rel="author" href="/humans.txt">`
- [x] `npm run test:build` passes (63 tests, 7 files) including new `tests/build/humans-txt.test.ts`
- [x] `npx tsc --noEmit` passes with no type errors
- [x] Visual regression suite passes (140 passed, 16 skipped) via pre-push Docker hook
- [x] Smoke test assertion added to `tests/smoke/home.smoke.ts` (uses `page.request.get`, asserts HTTP 200 + `text/plain` content-type)
- [x] `docs/wiki/Metadata-Files-Spec.md` philosophy doc added covering all root metadata files

🤖 Generated with [Claude Code](https://claude.com/claude-code)