### PR TITLE
feat(feed): /feed.xml + /feed.json endpoints, discovery, and Feed-Spec doc

### DIFF
--- a/docs/wiki/Feed-Spec.md
+++ b/docs/wiki/Feed-Spec.md
@@ -1,0 +1,195 @@
+# Feed Spec
+
+## Purpose
+
+`jonathanlloyd.me` publishes a syndication feed in two formats — RSS 2.0
+(`/feed.xml`) and JSON Feed 1.1 (`/feed.json`) — expressing the thesis:
+**what Jonathan produces and completes**, not what he consumes or measures.
+The live dashboard is the firehose; the feed is the durable record.
+
+The guiding framing mirrors the metadata-files philosophy: every feed item
+has a real event behind it. A published theatre review, a shipped PR, a
+finished book. No synthetic entries, no aggregated-metric rows, no health
+snapshots. Feed consumers (RSS readers, AI agents, archival tools) should
+be able to rely on the feed as a faithful record of creative and intellectual
+output.
+
+## Format Choice: RSS 2.0 + JSON Feed 1.1
+
+Two formats are published, identical in content:
+
+| Format | Path | Content-Type |
+| --- | --- | --- |
+| RSS 2.0 | `/feed.xml` | `application/rss+xml; charset=utf-8` |
+| JSON Feed 1.1 | `/feed.json` | `application/feed+json; charset=utf-8` |
+
+**RSS 2.0** is the universal baseline — supported by every reader, every
+aggregator, every crawler. **JSON Feed 1.1** is the modern complement —
+native JSON parsing, richer metadata, favoured by developer-oriented
+tooling and AI agents. Publishing both means no consumer is excluded.
+
+Both formats carry identical items with the same guids, pubDates, and
+content. The guid is a tag-URI (RFC 4151): `tag:jonathanlloyd.me,YYYY:domain/slug`.
+
+## Composition Model: Backend-Composed (llms.txt Pattern)
+
+The feed is composed by the `ComposeFeed` Lambda on every `BroadcastUpdate`
+EventBridge trigger (plus a 30-minute safety-net schedule), writing
+`feed.xml` and `feed.json` to CloudFront. The Cloudflare Pages Functions
+`functions/feed.xml.ts` and `functions/feed.json.ts` proxy those
+CloudFront artifacts with edge caching (`s-maxage=3600,
+stale-while-revalidate=86400`), exposing them at the canonical root paths.
+
+This mirrors the `llms.txt` composition pattern exactly. The alternative —
+build-time composition — was rejected because the feed's freshness
+proposition depends on live source data: a theatre review published two
+days after the deploy, a PR merged an hour ago. Static build-time
+composition would make the feed stale by definition.
+
+**Freshness model:**
+
+- Backend composes on EventBridge trigger (any source update) + 30-minute schedule
+- CloudFront edge TTL: 5 minutes (`max-age=300`)
+- Pages Function edge TTL: 1 hour (`s-maxage=3600`) with `stale-while-revalidate=86400`
+- Expected staleness for a live event: 0–35 minutes
+
+## Included Domains
+
+Five domains are included. Each has a rationale for inclusion and a
+per-domain item cap that prevents any single high-volume source from
+flooding the feed and burying lower-volume, higher-signal domains.
+
+### Theatre Reviews (cap: 10)
+
+**Source:** Coast to Coast Reviews (`coasttocoastreviews.com`), first-party.
+
+Theatre reviews are the highest-signal content in the feed: original
+editorial work, published under Jonathan's byline, with a star rating and
+a written excerpt. The feed surfaces the full review text in
+`<content:encoded>` / `content_html` so consumers see the complete review
+without following the link.
+
+**pubDate:** `publishedAt` from the review record. Honest: reflects when
+the review was published, not when it was exported.
+
+### GitHub Activity (cap: 12)
+
+**Source:** GitHub Events API, filtered to meaningful-only events.
+
+**Included:** `pr_merged`, `issue_opened`, `release`, and other non-commit
+event types.
+
+**Excluded:**
+- `commit` — too granular; a single feature generates dozens of commits
+  that would dominate the feed. The merged PR is the meaningful unit.
+- `pr_opened` — a PR that isn't merged yet may never be. Reporting the
+  merge is the completion signal.
+
+The guid discriminator includes the event type (`{repo}-{type}-{number}`)
+to prevent a merged PR #N and an issue_opened #N from sharing a guid.
+
+**pubDate:** `githubCreatedAt` (the event date). Honest: reflects when the
+event occurred on GitHub.
+
+### Starred Repositories (cap: 10)
+
+**Source:** GitHub starred repos, ordered by `starredAt` descending.
+
+Starred repositories signal what Jonathan finds technically interesting —
+tools he's evaluated, libraries he intends to use, projects he admires.
+Each item links to the repository with its description and primary
+language.
+
+**pubDate:** `starredAt`. Honest: reflects when Jonathan starred it.
+
+### Finished Books (cap: 10)
+
+**Source:** Bookshelf, filtered to `status = finished`.
+
+Books Jonathan has finished reading. Each item includes title, author, and
+(where available) cover image and description.
+
+**pubDate:** `updatedAt` — an approximation of when the book was finished.
+This is **disclosed** in the feed item and in this spec: `updatedAt` is the
+last database write for the record, which correlates with finishing the
+book but is not a precise finish date. The imprecision is acknowledged
+rather than papered over (R1/D4 honest-timestamps principle).
+
+### Saved Articles (cap: 12)
+
+**Source:** Reading feed (Raindrop.io export), filtered by `savedAt`.
+
+Articles Jonathan has saved, with source attribution and (where available)
+a highlight or note. This reflects his reading breadth — what he found
+worth preserving.
+
+**pubDate:** `savedAt`. Honest: reflects when the article was saved.
+
+## Excluded Domains
+
+The following data categories are **structurally excluded** — they are not
+parameters to `buildFeedView` and therefore cannot appear in the feed by
+accident.
+
+| Domain | Rationale |
+| --- | --- |
+| Health metrics | Point-in-time biometric data (HR, HRV, steps, calories, sleep stages). Not a completion/production signal; the 7-day aggregate in `llms.txt` is the appropriate surface. |
+| Sleep | Same as health: continuous biometric stream, not a completion event. |
+| Workouts | Individual workout rows are too granular and too personal. Weekly aggregate in `llms.txt` is appropriate. |
+| Focus sessions | Granular time-tracking data; no meaningful completion signal per row. |
+| Location | Six-layer privacy framework on the backend; location data requires suppression, delay, and broadening before any public surface. A feed is the wrong surface for this data at any granularity. |
+
+The exclusion is **structural**: `buildFeedView(sources: FeedSources)` is
+typed to accept only the five allowed domains. Passing health, sleep,
+workout, focus, or location data is a compile-time error, not a runtime
+check (C-PRIV-1).
+
+## Privacy Stance
+
+**No email.** RSS's `<managingEditor>` element requires an email address;
+this site omits it. Instead, `<atom:author><atom:name>` carries the
+author name without an email.
+
+**No location data** in any feed item. See Excluded Domains above.
+
+**Content escaping.** All dynamic values are entity-escaped via `escHtml()`
+before assembly into HTML content. The RSS `<description>` field (parsed
+as HTML by W3C validators) receives an escaped summary. The JSON Feed
+`content_text` carries raw plain text (literal `&` is correct there).
+
+## Discovery
+
+Feed discovery follows the two-signal pattern established for other
+metadata files:
+
+- **HTML `<link>` in `<head>`** (`src/layouts/Dashboard.astro`) — two
+  `<link rel="alternate">` elements, one per format.
+- **HTTP `Link` response header** (`functions/_middleware.ts`) — two
+  entries in the `LINK_HEADER` array on the homepage (`/`).
+
+| Signal | RSS 2.0 | JSON Feed 1.1 |
+| --- | --- | --- |
+| `<link rel="alternate">` | `type="application/rss+xml" href="/feed.xml"` | `type="application/feed+json" href="/feed.json"` |
+| `Link` header | `</feed.xml>; rel="alternate"; type="application/rss+xml"` | `</feed.json>; rel="alternate"; type="application/feed+json"` |
+
+## Honest Timestamps
+
+Every `pubDate` / `date_published` reflects the real event date — not the
+compose timestamp, not the export timestamp. The compose timestamp is
+recorded in the `lastBuildDate` channel field and in the S3 object
+metadata, but never imputed to individual items.
+
+The one exception — book `updatedAt` as a proxy for finish date — is
+disclosed in the feed item's `content:encoded` commentary and in this
+spec. See D4 in the honest-timestamps principle.
+
+## Cross-References
+
+- [Metadata-Files-Spec.md](Metadata-Files-Spec.md) — inventory of all
+  root-level metadata files; discovery wiring conventions.
+- [LLM-Content-Spec.md](LLM-Content-Spec.md) — `/llms.txt` content rules
+  and freshness model (the composition pattern this feed mirrors).
+- Backend: `mantle-LifegamesPortal/src/lib/feed-content/` — `view.ts`
+  (domain builders, privacy exclusion, per-domain caps), `compose.ts`
+  (RSS + JSON Feed serialization), `types.ts` (FeedSources allowlist).
+- Backend Lambda: `mantle-LifegamesPortal/src/lambdas/eventbridge/ComposeFeed/index.ts`

--- a/docs/wiki/Feed-Spec.md
+++ b/docs/wiki/Feed-Spec.md
@@ -117,7 +117,7 @@ rather than papered over (R1/D4 honest-timestamps principle).
 
 ### Saved Articles (cap: 12)
 
-**Source:** Reading feed (Raindrop.io export), filtered by `savedAt`.
+**Source:** Feedly via IFTTT, filtered by `savedAt`.
 
 Articles Jonathan has saved, with source attribution and (where available)
 a highlight or note. This reflects his reading breadth — what he found

--- a/docs/wiki/Metadata-Files-Spec.md
+++ b/docs/wiki/Metadata-Files-Spec.md
@@ -21,6 +21,8 @@ by the mechanism best suited to that audience's freshness requirements.
 | `/sitemap-index.xml`        | Machines (search engines) | `@astrojs/sitemap` integration                                       | sitemaps.org     |
 | `/llms.txt`                 | AI agents                 | Backend-composed live (CloudFront proxy via `functions/llms.txt.ts`) | llmstxt.org      |
 | `/humans.txt`               | Humans                    | Build-time endpoint (`src/pages/humans.txt.ts`)                      | humanstxt.org    |
+| `/feed.xml`                 | RSS readers, aggregators  | Backend-composed live (CloudFront proxy via `functions/feed.xml.ts`) | RSS 2.0          |
+| `/feed.json`                | Feed readers, AI agents   | Backend-composed live (CloudFront proxy via `functions/feed.json.ts`)| JSON Feed 1.1    |
 | `/.well-known/api-catalog`  | Machines (API clients)    | Static file (`public/.well-known/api-catalog`)                       | RFC 9727         |
 | `/.well-known/security.txt` | Machines + humans         | (Future) Static file at `/.well-known/security.txt`                  | RFC 9116         |
 
@@ -78,10 +80,12 @@ when a root Pages Function middleware is present. Any header change must go in
 
 Discovery `<link>` relations in use:
 
-| Relation        | File                 | Standard             |
-| --------------- | -------------------- | -------------------- |
-| `rel="sitemap"` | `/sitemap-index.xml` | HTML Living Standard |
-| `rel="author"`  | `/humans.txt`        | HTML Living Standard |
+| Relation                                          | File                 | Standard             |
+| ------------------------------------------------- | -------------------- | -------------------- |
+| `rel="sitemap"`                                   | `/sitemap-index.xml` | HTML Living Standard |
+| `rel="author"`                                    | `/humans.txt`        | HTML Living Standard |
+| `rel="alternate" type="application/rss+xml"`      | `/feed.xml`          | RSS 2.0 / HTML5      |
+| `rel="alternate" type="application/feed+json"`    | `/feed.json`         | JSON Feed 1.1        |
 
 ### Honest metadata
 
@@ -151,6 +155,24 @@ the CloudFront-hosted canonical with edge caching (`s-maxage=3600,
 stale-while-revalidate=86400`). See [LLM-Content-Spec.md](LLM-Content-Spec.md)
 for the full inventory, content-granularity rules, and freshness expectations.
 
+### `/feed.xml` and `/feed.json` — backend-composed live
+
+The syndication feed in two formats: RSS 2.0 (`/feed.xml`) and JSON Feed
+1.1 (`/feed.json`). Both express the same thesis — what Jonathan produces
+and completes — and carry identical items with the same guids and pubDates.
+Backend-composed by the `ComposeFeed` Lambda on EventBridge triggers (plus
+a 30-minute safety-net schedule); the Cloudflare Pages Functions
+`functions/feed.xml.ts` and `functions/feed.json.ts` proxy the
+CloudFront-hosted canonicals with edge caching (`s-maxage=3600,
+stale-while-revalidate=86400`).
+
+Five included domains: theatre reviews (first-party, cap 10), meaningful
+GitHub activity (merged PRs + issues, cap 12), starred repositories (cap
+10), finished books (cap 10, pubDate = `updatedAt` disclosed as approximate),
+and saved articles (cap 12). Health, sleep, workouts, focus, and location
+are structurally excluded. See [Feed-Spec.md](Feed-Spec.md) for the full
+content philosophy, domain rationales, privacy stance, and composition model.
+
 ### `/humans.txt` — build-time endpoint
 
 Managed in `src/pages/humans.txt.ts`. Follows the humanstxt.org three-section
@@ -184,5 +206,8 @@ backing file (dangling 404).
   host-scoping principle, and astro#16838 resolution.
 - [LLM-Content-Spec.md](LLM-Content-Spec.md) — `/llms.txt` content rules,
   freshness model, agent-readiness inventory, and middleware header spec.
+- [Feed-Spec.md](Feed-Spec.md) — `/feed.xml` and `/feed.json` content
+  philosophy, domain inclusion/exclusion rationales, privacy stance, honest
+  timestamps, and composition model.
 - [Copy-Package-Spec.md](Copy-Package-Spec.md) — `@lifegames/copy` authoring
   model, build pipeline, and zero-duplication invariant.

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -31,6 +31,8 @@ const LINK_HEADER = [
   '</.well-known/api-catalog>; rel="api-catalog"',
   '</sitemap-index.xml>; rel="sitemap"',
   '</humans.txt>; rel="author"',
+  '</feed.xml>; rel="alternate"; type="application/rss+xml"',
+  '</feed.json>; rel="alternate"; type="application/feed+json"',
 ].join(', ');
 
 // Minimal Cloudflare Pages Function context — only the fields this middleware reads.

--- a/functions/feed.json.ts
+++ b/functions/feed.json.ts
@@ -1,0 +1,35 @@
+// Pages Function: proxy /feed.json from CloudFront with edge caching.
+// The backend (mantle-LifegamesPortal) owns the canonical JSON Feed 1.1;
+// this route ensures the spec-required root path resolves on jonathanlloyd.me
+// without a hand-maintained static file. The response is wrapped by
+// functions/_middleware.ts, which injects the security headers.
+
+import { CLOUDFRONT_BASE } from '@lifegames/portal-contract/constants';
+
+const CLOUDFRONT_FEED_JSON = `${CLOUDFRONT_BASE}/feed.json`;
+
+// Minimal Cloudflare Pages Function fetch options — only the cf cache fields used here.
+interface CfRequestInit extends RequestInit {
+  cf?: { cacheTtl?: number; cacheEverything?: boolean };
+}
+
+export async function onRequest(): Promise<Response> {
+  const init: CfRequestInit = { cf: { cacheTtl: 3600, cacheEverything: true } };
+  const upstream = await fetch(CLOUDFRONT_FEED_JSON, init);
+
+  if (!upstream.ok) {
+    return new Response('feed.json unavailable', {
+      status: 502,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/feed+json; charset=utf-8',
+      'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400',
+      'X-Source': 'cloudfront-proxy',
+    },
+  });
+}

--- a/functions/feed.xml.ts
+++ b/functions/feed.xml.ts
@@ -1,0 +1,35 @@
+// Pages Function: proxy /feed.xml from CloudFront with edge caching.
+// The backend (mantle-LifegamesPortal) owns the canonical RSS 2.0 feed;
+// this route ensures the spec-required root path resolves on jonathanlloyd.me
+// without a hand-maintained static file. The response is wrapped by
+// functions/_middleware.ts, which injects the security headers.
+
+import { CLOUDFRONT_BASE } from '@lifegames/portal-contract/constants';
+
+const CLOUDFRONT_FEED_XML = `${CLOUDFRONT_BASE}/feed.xml`;
+
+// Minimal Cloudflare Pages Function fetch options — only the cf cache fields used here.
+interface CfRequestInit extends RequestInit {
+  cf?: { cacheTtl?: number; cacheEverything?: boolean };
+}
+
+export async function onRequest(): Promise<Response> {
+  const init: CfRequestInit = { cf: { cacheTtl: 3600, cacheEverything: true } };
+  const upstream = await fetch(CLOUDFRONT_FEED_XML, init);
+
+  if (!upstream.ok) {
+    return new Response('feed.xml unavailable', {
+      status: 502,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400',
+      'X-Source': 'cloudfront-proxy',
+    },
+  });
+}

--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -38,6 +38,9 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
   <link rel="manifest" href="/manifest.webmanifest">
   <link rel="sitemap" href="/sitemap-index.xml">
   <link rel="author" href="/humans.txt">
+  {/* Feed discovery — RSS 2.0 + JSON Feed 1.1 (backend-composed live on CloudFront) */}
+  <link rel="alternate" type="application/rss+xml" title={identity.feed.title} href="/feed.xml">
+  <link rel="alternate" type="application/feed+json" title={identity.feed.title} href="/feed.json">
 
   <meta property="og:title" content={title}>
   <meta property="og:description" content={ogDescription}>

--- a/tests/build/seo-meta.test.ts
+++ b/tests/build/seo-meta.test.ts
@@ -93,4 +93,18 @@ describe('SEO Meta Tags', () => {
     const author = $('meta[name="author"]').attr('content');
     expect(author).toBeTruthy();
   });
+
+  it('RSS feed discovery link is present with correct type and href', () => {
+    const rssLink = $('link[rel="alternate"][type="application/rss+xml"]');
+    expect(rssLink.length, 'RSS <link rel="alternate"> is missing').toBeGreaterThan(0);
+    expect(rssLink.attr('href'), 'RSS feed href should be /feed.xml').toBe('/feed.xml');
+    expect(rssLink.attr('title'), 'RSS feed title should be non-empty').toBeTruthy();
+  });
+
+  it('JSON Feed discovery link is present with correct type and href', () => {
+    const jsonLink = $('link[rel="alternate"][type="application/feed+json"]');
+    expect(jsonLink.length, 'JSON Feed <link rel="alternate"> is missing').toBeGreaterThan(0);
+    expect(jsonLink.attr('href'), 'JSON Feed href should be /feed.json').toBe('/feed.json');
+    expect(jsonLink.attr('title'), 'JSON Feed title should be non-empty').toBeTruthy();
+  });
 });

--- a/tests/smoke/home.smoke.ts
+++ b/tests/smoke/home.smoke.ts
@@ -158,6 +158,20 @@ test.describe('production home dashboard', () => {
     expect(contentType, '/humans.txt wrong content-type').toContain('text/plain');
   });
 
+  test('feed.xml is reachable and RSS content-type', async ({ page }) => {
+    const res = await page.request.get('/feed.xml');
+    expect(res.status(), '/feed.xml did not return 200').toBe(200);
+    const contentType = res.headers()['content-type'] || '';
+    expect(contentType, '/feed.xml wrong content-type').toContain('application/rss+xml');
+  });
+
+  test('feed.json is reachable and JSON Feed content-type', async ({ page }) => {
+    const res = await page.request.get('/feed.json');
+    expect(res.status(), '/feed.json did not return 200').toBe(200);
+    const contentType = res.headers()['content-type'] || '';
+    expect(contentType, '/feed.json wrong content-type').toContain('application/feed+json');
+  });
+
   test('version.json reports the deployed build', async ({ page }) => {
     const res = await page.request.get('/version.json');
     expect(res.status(), '/version.json did not return HTTP 200').toBe(200);


### PR DESCRIPTION
## Summary

Adds the web surface for the syndication feed: `/feed.xml` (RSS 2.0) and `/feed.json` (JSON Feed 1.1) endpoints, discovery wiring, and a philosophy doc. Pairs with `mantle-LifegamesPortal#108` (the backend `ComposeFeed` Lambda that composes the feed).

## Changes

- `functions/feed.xml.ts` + `functions/feed.json.ts` — Cloudflare Pages Functions proxying the backend-composed feed from CloudFront with edge caching (mirrors `functions/llms.txt.ts`): correct content-types (`application/rss+xml`, `application/feed+json`), `stale-while-revalidate`, 502 fallback.
- `src/layouts/Dashboard.astro` — two `<link rel="alternate">` discovery elements (RSS + JSON Feed); title from `@lifegames/copy` `identity.feed.title`.
- `functions/_middleware.ts` — two `LINK_HEADER` entries for the feeds.
- `docs/wiki/Feed-Spec.md` (new) — feed philosophy: the "what Jonathan produces and completes" thesis; the 5 included domains (with per-domain caps + pubDate-honesty rationale); structurally-excluded domains (C-PRIV-1); composition model (backend-composed, mirrors the llms.txt pattern); format choice; privacy stance; discovery wiring.
- `docs/wiki/Metadata-Files-Spec.md` — feed inventory rows + discovery-relation rows.
- Tests: `tests/build/seo-meta.test.ts` discovery-link assertions; `tests/smoke/home.smoke.ts` `/feed.xml` + `/feed.json` reachability probes (post-deploy).

## Validation

- [x] `npm run build` clean; feed discovery `<link>`s confirmed in `dist/index.html`
- [x] `npm run test:build` 65/65 pass (incl. the new SEO discovery assertions)
- [x] `tsc --noEmit` 0 errors
- [x] Backend feed validated independently: **W3C "valid RSS feed"**, balanced 5 domains, **0 health/location leakage**

## Notes

- Depends on the backend PR (`mantle-LifegamesPortal#108`) for the composed feed on CloudFront; the smoke probes pass post-deploy.
- Production deploy held per the B5 protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
