### PR TITLE
fix(csp): allow books.google.com in img-src for Google Books covers

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -18,7 +18,7 @@ const CSP = [
   "script-src 'self' https://scripts.simpleanalyticscdn.com https://static.cloudflareinsights.com",
   "style-src 'self' 'unsafe-inline'",
   "font-src 'self'",
-  `img-src 'self' data: https://*.basemaps.cartocdn.com https://m.media-amazon.com https://images.squarespace-cdn.com ${CLOUDFRONT_BASE} https://queue.simpleanalyticscdn.com`,
+  `img-src 'self' data: https://*.basemaps.cartocdn.com https://m.media-amazon.com https://images.squarespace-cdn.com https://books.google.com ${CLOUDFRONT_BASE} https://queue.simpleanalyticscdn.com`,
   `connect-src 'self' ${CLOUDFRONT_BASE} ${WEBSOCKET_ORIGIN} https://queue.simpleanalyticscdn.com https://cloudflareinsights.com`,
   "worker-src 'self'",
   "object-src 'none'",


### PR DESCRIPTION
## Why
The post-deploy live smoke check failed: book covers served from `https://books.google.com/books/content?...` are blocked by CSP `img-src` (covers don't render). Pre-existing `img-src` gap surfaced now that the current reading list includes Google Books covers.

## What
Add `https://books.google.com` to the `img-src` allowlist in `functions/_middleware.ts` (consistent with the existing `m.media-amazon.com` / `images.squarespace-cdn.com` cover sources). No `script-src` change.

## Verify
- `npm run build` (incl. `audit:inline-scripts`) passes.
- Post-deploy: `npm run test:smoke` should report zero CSP-blocked URLs.