### PR TITLE
fix(build): live-data bundle check follows code-split chunks (book Wave 5)

### DIFF
--- a/.contract-lock.json
+++ b/.contract-lock.json
@@ -1,14 +1,14 @@
 {
   "generatedFrom": {
     "repo": "j0nathan-ll0yd/design-system-Lifegames",
-    "sha": "96015b20049d132fef6db34e1174208e6ea0863e",
-    "checksum": "sha256:a9d51a9dcb1b19929f7c6c17c2aa3cb5036b05d285718b53a9fe9f499066e8a8"
+    "sha": "57999207092d7902a93bd2735b66dd211637f4fc",
+    "checksum": "sha256:f9067de01ccbc56cb111107e504abdfa0acfc4dc361aa7de145c68b750e0ff9a"
   },
-  "generatedAt": "2026-06-18T18:38:25.879Z",
+  "generatedAt": "2026-06-20T03:40:24.375Z",
   "generatorVersion": "1.0.0",
   "files": {
     "raw-schemas/articles-export.schema.json": "sha256:4a3d6514ab959b251ad88bef79020747bbddb865d0a7c913e71fe36f608ffd36",
-    "raw-schemas/books-export.schema.json": "sha256:5955ef504d2d4ec82e0823a3fc99121a8c16ec2844726973275056240f356421",
+    "raw-schemas/books-export.schema.json": "sha256:cae4120b21505d53810427be65ae98df6a64c71eed60894ea7c380a1e3c38772",
     "raw-schemas/focus-export.schema.json": "sha256:b9b8deaa9f427ece873937c251495dbf3a69e5d054f635d1ecb49b36679b6144",
     "raw-schemas/github-events-export.schema.json": "sha256:ff00a3474a0be17e9640407a7bc3d69dd437157ec10936ec5157932f07fec415",
     "raw-schemas/github-starred-repos-export.schema.json": "sha256:dab7effd7bb7fa6a5444d4e32b43fdfff4d8ae1721e6be69ccd0a88be159c33f",
@@ -17,7 +17,7 @@
     "raw-schemas/sleep-export.schema.json": "sha256:ab11c1abeb9cbb3dc327243eb50507dab31f843d9f2a8cea367522431f16b85d",
     "raw-schemas/theatre-reviews-export.schema.json": "sha256:22d3a138fad1007d00e19786c7368086b79e4465864b034ecc907ed5e2d1998d",
     "raw-schemas/workouts-export.schema.json": "sha256:1814cc3935a95c345eece02fb0f560c95ce8bca92a4b90705489c21c7182c67e",
-    "authored/dashboard-books.schema.json": "sha256:cf63a59f5fee6e3f04c023a1948ca4358cd10e7b71f4f86e54943d01c7cb209a",
+    "authored/dashboard-books.schema.json": "sha256:17716d6f5e7002d5de7e4488feffa60fc7ac93ad71c69b50c9f88850ca447d22",
     "authored/dashboard-github.schema.json": "sha256:d7fdeb50d02647aa214ae3e3cd25d6d3f78f63ec46c29e1e1470e0a9e6db0f04",
     "authored/dashboard-reading.schema.json": "sha256:1b14d2123d3e6b006e5c0c04d14c952f75830cf18c2cd0bddd0694ad143cd7de",
     "authored/profile.schema.json": "sha256:35bb5ba6f7457b6355c497fe49a5630ef075cbe07411b10db8762da166d1263b",

--- a/scripts/check-live-data-bundle.mjs
+++ b/scripts/check-live-data-bundle.mjs
@@ -6,16 +6,27 @@
 // The data runtime is app-local under src/lib/runtime/ — relocated out of the
 // @lifegames/web design-system package (see ADR 0005 in design-system-Lifegames).
 //
-// We assert that at least one bundled `index.astro_astro_type_script_index_*_lang.*.js`
-// chunk contains string literals that only live-data emits (DOM element IDs
-// plus the live-data dispatch table). Function identifiers are minified; DOM
-// IDs and dispatch keys survive minification because they're string literals.
+// We assert that the live-data runtime — reachable from the entry
+// `index.astro_astro_type_script_index_*_lang.*.js` chunk(s) — contains string
+// literals that only it emits (DOM element IDs plus the live-data dispatch
+// table). Function identifiers are minified; DOM IDs and dispatch keys survive
+// minification because they're string literals.
+//
+// The search follows Rollup's code-split imports transitively: the updaters live
+// in a shared `_astro/<name>.js` chunk that the entry imports, not necessarily
+// inlined into the entry chunk itself. Following the import graph keeps this
+// robust to chunking changes (e.g. when an updater grows past the inline
+// threshold) while still catching genuine tree-shaking (the token vanishing from
+// the whole reachable graph).
 import { readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const astroDir = resolve(process.cwd(), 'dist', '_astro');
 const BUNDLE_RE = /^index\.astro_astro_type_script_index_\d+_lang\.[A-Za-z0-9_-]+\.js$/;
 const REQUIRED = ['cardTheatreReviews', 'systemStatus', 'theatreReviews'];
+// Matches a relative chunk reference (`"./updaters.fDuJCGys.js"`) in minified output,
+// whether via static import, dynamic import, or re-export.
+const CHUNK_REF_RE = /\.\/([A-Za-z0-9_.-]+\.js)/g;
 
 let files;
 try {
@@ -25,14 +36,28 @@ try {
   process.exit(1);
 }
 
-const bundles = files.filter(f => BUNDLE_RE.test(f));
-if (bundles.length === 0) {
+const fileSet = new Set(files);
+const entryBundles = files.filter(f => BUNDLE_RE.test(f));
+if (entryBundles.length === 0) {
   console.error('[check-live-data-bundle] No index.astro module bundles found in', astroDir);
   process.exit(1);
 }
 
+// Transitively collect every chunk reachable from the entry bundle(s).
+const reachable = new Set();
+const queue = [...entryBundles];
+while (queue.length > 0) {
+  const file = queue.pop();
+  if (reachable.has(file) || !fileSet.has(file)) continue;
+  reachable.add(file);
+  const content = readFileSync(resolve(astroDir, file), 'utf-8');
+  for (const m of content.matchAll(CHUNK_REF_RE)) {
+    if (!reachable.has(m[1])) queue.push(m[1]);
+  }
+}
+
 const found = Object.fromEntries(REQUIRED.map(t => [t, null]));
-for (const file of bundles) {
+for (const file of reachable) {
   const content = readFileSync(resolve(astroDir, file), 'utf-8');
   for (const token of REQUIRED) {
     if (found[token] === null && content.includes(token)) found[token] = file;
@@ -47,7 +72,7 @@ if (missing.length > 0) {
   console.error('Likely cause: src/lib/runtime/live-data was tree-shaken or is no longer imported.');
   console.error("Verify src/pages/index.astro still has `import '../lib/runtime/live-data'` and");
   console.error('that the module retains its top-level side effects (skeleton removal, polling, WS).');
-  console.error('Inspected bundles:', bundles.join(', '));
+  console.error('Inspected', reachable.size, 'reachable chunk(s) from:', entryBundles.join(', '));
   process.exit(1);
 }
 
@@ -57,5 +82,7 @@ console.log(
   REQUIRED.length,
   'identifiers present across',
   uniqueFiles.size,
-  'bundle(s).',
+  'chunk(s), from',
+  reachable.size,
+  'reachable.',
 );


### PR DESCRIPTION
Web consumer wave (Wave 5) for the book reading-progress feature.

## What changed
The web has no source changes for the feature itself — it consumes the realigned status vocab + finishedAt rendering from the producers (design-system #73 + backend #111/#113, both merged to main), which CI rebuilds from main.

The one required change: the live-data bundle check now follows Rollup's code-split imports. The realigned @lifegames/web grew the updaters module past vite's inline threshold, so it's now emitted as a shared _astro/<name>.js chunk the entry imports rather than inlined — the old check only scanned the entry chunk and false-failed on "systemStatus".

## Verification
- Full astro build green (prebuild schema validation + postbuild bundle check).
- Visual-regression suite green: 140 passed, 0 baseline drift (the realigned producers render byte-identical to the committed baselines).
- Bookshelf widget renders finished status + "Finished {date}" (Bookshelf.astro shelf-book-finished-date) from the fixtures' finished books.

## Deploy
Cloudflare Pages auto-deploys on merge; the production smoke check runs post-deploy.
