### PR TITLE
test(behavioral): guard against lingering focus ring after BookModal dismiss

### DIFF
--- a/tests/behavioral/book-modal.spec.ts
+++ b/tests/behavioral/book-modal.spec.ts
@@ -304,6 +304,37 @@ test.describe('BookModal — native <dialog> behavior', () => {
   });
 
   // -----------------------------------------------------------------------
+  // 6b. Escape dismiss restores focus WITHOUT leaving a lingering focus ring
+  //     on the book tile (regression: the neon :focus-visible outline used to
+  //     persist on the trigger after a keyboard dismiss).
+  // -----------------------------------------------------------------------
+  test('6b. Escape dismiss leaves focus on the trigger but no visible focus ring', async () => {
+    const trigger = page.locator('#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]').first();
+    // Open via KEYBOARD so :focus-visible would naturally apply on focus restore.
+    await trigger.focus();
+    await page.keyboard.press('Enter');
+    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open');
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('dialog#bookDialog')).not.toHaveAttribute('open');
+
+    const state = await page.evaluate(() => {
+      const t = document.querySelector(
+        '#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]',
+      ) as HTMLElement | null;
+      if (!t) return null;
+      return {
+        focused: document.activeElement === t,
+        outlineStyle: getComputedStyle(t).outlineStyle,
+      };
+    });
+    // Focus is still restored to the trigger (accessibility / WCAG 2.4.7 intent)...
+    expect(state?.focused).toBe(true);
+    // ...but the visible focus ring is suppressed after the dismiss.
+    expect(state?.outlineStyle).toBe('none');
+  });
+
+  // -----------------------------------------------------------------------
   // 7. Focus containment: dialog is :modal → background is inert
   // -----------------------------------------------------------------------
   test('7. while dialog is open, background #main-content is not focusable (dialog :modal)', async () => {


### PR DESCRIPTION
## Summary

Consumer regression guard for the BookModal focus-ring fix (**design-system-Lifegames#76**). After the native `<dialog>` migration, dismissing the modal with Escape left a stray neon focus ring on the book tile; the DS PR suppresses it while preserving focus restoration.

This PR adds behavioral test **6b**: after a keyboard Escape, the `.shelf-book` trigger is still `document.activeElement` (accessibility preserved) but its computed `outline-style` is `none` (no lingering ring).

Merging this PR rebuilds the site against the fixed DS (the matching branch name makes CI resolve DS PR #76; after #76 merges it falls back to `main`) and redeploys, taking the fix live.

## Test plan

- Verified in the Docker parity image: `./scripts/run-in-docker.sh playwright.behavioral.config.ts` → **13 passed** (12 + new 6b), against the DS fix.
