### PR TITLE
feat(well-known): add WebFinger alias for jonathan@jonathanlloyd.me

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -108,6 +108,13 @@ export async function onRequest(context: PagesContext): Promise<Response> {
     );
   }
 
+  // WebFinger (RFC 7033) Content-Type + permissive CORS for the static JRD at
+  // public/.well-known/webfinger. Mirrors the api-catalog override above.
+  if (url.pathname === '/.well-known/webfinger') {
+    headers.set('Content-Type', 'application/jrd+json');
+    headers.set('Access-Control-Allow-Origin', '*');
+  }
+
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/public/.well-known/webfinger
+++ b/public/.well-known/webfinger
@@ -1,0 +1,23 @@
+{
+  "subject": "acct:jonathan@jonathanlloyd.me",
+  "aliases": [
+    "https://mastodon.social/@j0nathan",
+    "https://mastodon.social/ap/users/116794886250734590"
+  ],
+  "links": [
+    {
+      "rel": "http://webfinger.net/rel/profile-page",
+      "type": "text/html",
+      "href": "https://mastodon.social/@j0nathan"
+    },
+    {
+      "rel": "self",
+      "type": "application/activity+json",
+      "href": "https://mastodon.social/ap/users/116794886250734590"
+    },
+    {
+      "rel": "http://ostatus.org/schema/1.0/subscribe",
+      "template": "https://mastodon.social/authorize_interaction?uri={uri}"
+    }
+  ]
+}

--- a/tests/build/webfinger.test.ts
+++ b/tests/build/webfinger.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+const distDir = path.resolve(process.cwd(), 'dist');
+const webfingerPath = path.join(distDir, '.well-known', 'webfinger');
+
+interface JrdLink {
+  rel: string;
+  type?: string;
+  href?: string;
+  template?: string;
+}
+interface Jrd {
+  subject: string;
+  aliases?: string[];
+  links: JrdLink[];
+}
+
+let jrd: Jrd;
+
+beforeAll(() => {
+  jrd = JSON.parse(readFileSync(webfingerPath, 'utf-8')) as Jrd;
+});
+
+describe('webfinger build output', () => {
+  it('dist/.well-known/webfinger exists', () => {
+    expect(existsSync(webfingerPath)).toBe(true);
+  });
+
+  it('subject is the custom-domain alias handle', () => {
+    expect(jrd.subject).toBe('acct:jonathan@jonathanlloyd.me');
+  });
+
+  it('exposes a self link to the ActivityPub actor', () => {
+    const self = jrd.links.find((l) => l.rel === 'self');
+    expect(self, 'missing rel=self link').toBeDefined();
+    expect(self?.type).toBe('application/activity+json');
+    expect(self?.href).toBe('https://mastodon.social/ap/users/116794886250734590');
+  });
+
+  it('exposes an html profile-page link to the real account', () => {
+    const profile = jrd.links.find(
+      (l) => l.rel === 'http://webfinger.net/rel/profile-page'
+    );
+    expect(profile?.type).toBe('text/html');
+    expect(profile?.href).toBe('https://mastodon.social/@j0nathan');
+  });
+});

--- a/tests/smoke/home.smoke.ts
+++ b/tests/smoke/home.smoke.ts
@@ -172,6 +172,35 @@ test.describe('production home dashboard', () => {
     expect(contentType, '/feed.json wrong content-type').toContain('application/feed+json');
   });
 
+  test('webfinger resolves the Fediverse alias with JRD content-type', async ({ page }) => {
+    // Accept: application/jrd+json avoids the text/markdown early-return in
+    // functions/_middleware.ts that would otherwise short-circuit to llms-full.
+    const res = await page.request.get(
+      '/.well-known/webfinger?resource=acct:jonathan@jonathanlloyd.me',
+      { headers: { Accept: 'application/jrd+json' } }
+    );
+    expect(res.status(), '/.well-known/webfinger did not return 200').toBe(200);
+    const contentType = res.headers()['content-type'] || '';
+    expect(contentType, 'webfinger wrong content-type').toContain('application/jrd+json');
+    const body = await res.json();
+    expect(body.subject, 'webfinger subject mismatch').toBe('acct:jonathan@jonathanlloyd.me');
+    // The self link is what makes aliasing work; assert it on the LIVE path too,
+    // not just the build artifact, to catch a stale/edge-cached deploy.
+    const self = body.links?.find((l: { rel: string; href?: string }) => l.rel === 'self');
+    expect(self?.href, 'webfinger self link must target the canonical Mastodon actor').toBe(
+      'https://mastodon.social/ap/users/116794886250734590'
+    );
+  });
+
+  test('api-catalog is reachable and linkset content-type', async ({ page }) => {
+    // Regression guard for the adjacent middleware override edited alongside the
+    // webfinger block (currently otherwise untested).
+    const res = await page.request.get('/.well-known/api-catalog');
+    expect(res.status(), '/.well-known/api-catalog did not return 200').toBe(200);
+    const contentType = res.headers()['content-type'] || '';
+    expect(contentType, 'api-catalog wrong content-type').toContain('application/linkset+json');
+  });
+
   test('version.json reports the deployed build', async ({ page }) => {
     const res = await page.request.get('/version.json');
     expect(res.status(), '/version.json did not return HTTP 200').toBe(200);


### PR DESCRIPTION
## Summary

Implements #82. Serves a static `/.well-known/webfinger` JRD (RFC 7033) so the Fediverse handle `@jonathan@jonathanlloyd.me` resolves to the existing Mastodon account `@j0nathan@mastodon.social`. No email, DNS, or ActivityPub server -- one static file plus a content-type line.

## What changed

- **`public/.well-known/webfinger`** (new) -- static JRD. `subject` is the custom-domain alias; `self` / `profile-page` / `aliases` point at the verified canonical actor `https://mastodon.social/ap/users/116794886250734590`.
- **`functions/_middleware.ts`** -- adds an `application/jrd+json` + permissive-CORS override for the path, mirroring the existing `/.well-known/api-catalog` block (`public/_headers` is disabled by this middleware, so the content-type must be set here).
- **`tests/build/webfinger.test.ts`** (new) -- blocking build-output test for the JRD payload (subject + `self` link).
- **`tests/smoke/home.smoke.ts`** -- live smoke assertions (served headers + the `self` link), plus a regression guard for the adjacent, previously-untested api-catalog content-type.

## How it works

A remote server resolving `@jonathan@jonathanlloyd.me` fetches this WebFinger, reads `subject` as the queried handle, and follows `rel=self` to the real Mastodon actor. The actor URL was verified by live-fetching mastodon.social's own WebFinger -- not guessed.

## Honest scope

This makes the handle **findable** (search resolves to the account). It does **not** make `@jonathan@jonathanlloyd.me` the *canonical* handle -- the account still settles/displays as `@j0nathan@mastodon.social`, because mastodon.social is not self-hosted (canonical aliasing needs `WEB_DOMAIN`/`LOCAL_DOMAIN` control on the instance). The issue's two concrete acceptance checks (curl 200 + `application/jrd+json`; Mastodon search finds the account) are met.

## Verification

- `npm run test:build` -- 8 files / 69 tests pass (incl. the new webfinger payload test).
- `npm run test:unit` -- 5 files / 74 tests pass.
- `wrangler pages dev dist` (real Cloudflare runtime): `/.well-known/webfinger` -> `200` + `Content-Type: application/jrd+json` + `Access-Control-Allow-Origin: *` + correct body; `/.well-known/api-catalog` -> `200` + `application/linkset+json; profile="..."` (regression green). Middleware compiled cleanly.
- Live served headers + Mastodon resolution are confirmed by the post-deploy smoke check.

## Design note

Static file + middleware override was chosen over a Pages Function after a Planner / Architect / Critic consensus. Request-time `?resource=` validation (404 on mismatch) was deliberately rejected as gold-plating for a single-account alias; the upgrade trigger, if a second handle is ever needed, is a dedicated Function. Only 3 of the 5 link rels Mastodon advertises are included; the FEP-3b86 share templates are omitted as non-essential to identity resolution.

Closes #82
