### PR TITLE
feat(security): CSP violation reporting + A2A/ARD agent-discovery files

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -26,18 +26,28 @@ const CSP = [
   "form-action 'self'",
   "frame-ancestors 'none'",
   "upgrade-insecure-requests",
+  // Violation reporting: report-to (Reporting API, modern) + report-uri (legacy fallback).
+  // The named endpoint matches the Reporting-Endpoints header set below.
+  "report-uri /api/csp-report; report-to csp-endpoint",
 ].join('; ') + ';';
+
+// CSP violation reports are collected at /api/csp-report (functions/api/csp-report.ts).
+// The Reporting-Endpoints header names the endpoint; the CSP report-to directive references
+// that name. report-uri is retained as a fallback for older browsers (Firefox <130, Safari <17).
+const REPORTING_ENDPOINTS = 'csp-endpoint="https://jonathanlloyd.me/api/csp-report"';
 
 const LINK_HEADER = [
   '</llms.txt>; rel="describedby"; type="text/plain"',
   '</.well-known/api-catalog>; rel="api-catalog"',
+  '</.well-known/agent-card.json>; rel="https://www.agentcard.org/rel"',
+  '</.well-known/ai-catalog.json>; rel="ai-catalog"',
   '</sitemap-index.xml>; rel="sitemap"',
   '</humans.txt>; rel="author"',
   '</feed.xml>; rel="alternate"; type="application/rss+xml"',
   '</feed.json>; rel="alternate"; type="application/feed+json"',
 ].join(', ');
 
-// Minimal Cloudflare Pages Function context — only the fields this middleware reads.
+// Minimal Cloudflare Pages Function context -- only the fields this middleware reads.
 // Avoids pulling in @cloudflare/workers-types just for one signature.
 interface PagesContext {
   request: Request;
@@ -70,13 +80,14 @@ export async function onRequest(context: PagesContext): Promise<Response> {
 
   // Security headers
   headers.set('Content-Security-Policy', CSP);
+  headers.set('Reporting-Endpoints', REPORTING_ENDPOINTS);
   headers.set('X-Content-Type-Options', 'nosniff');
   headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-  // HSTS: 2-year max-age + subdomains. Preload intentionally omitted — owner-gated process.
+  // HSTS: 2-year max-age + subdomains. Preload intentionally omitted -- owner-gated process.
   headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
   headers.set('X-Frame-Options', 'DENY');
   // COOP: same-origin-allow-popups permits OAuth/payment popups while isolating the browsing context.
-  // COEP/CORP omitted — would break cross-origin Amazon, Carto, and SimpleAnalytics resources.
+  // COEP/CORP omitted -- would break cross-origin Amazon, Carto, and SimpleAnalytics resources.
   headers.set('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
   headers.set('Permissions-Policy', 'accelerometer=(), ambient-light-sensor=(), autoplay=(), bluetooth=(), camera=(), compute-pressure=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-create=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()');
 

--- a/functions/api/csp-report.ts
+++ b/functions/api/csp-report.ts
@@ -1,0 +1,51 @@
+// Pages Function: CSP violation report collector.
+// Accepts reports from the browser Reporting API (application/reports+json)
+// and the legacy report-uri mechanism (application/csp-report). Always returns
+// 204 so the browser does not retry. Logs a single structured line per invocation
+// visible in `wrangler pages deployment tail`.
+
+// Minimal Cloudflare Pages Function context -- only the fields this handler reads.
+interface PagesContext {
+  request: Request;
+}
+
+const ACCEPTED_CONTENT_TYPES = [
+  'application/csp-report',
+  'application/reports+json',
+];
+
+export async function onRequestPost(context: PagesContext): Promise<Response> {
+  const { request } = context;
+
+  const contentType = request.headers.get('Content-Type') ?? '';
+  const accepted = ACCEPTED_CONTENT_TYPES.some((t) => contentType.includes(t));
+  if (!accepted) {
+    return new Response(null, { status: 415 });
+  }
+
+  const userAgent = request.headers.get('User-Agent') ?? '';
+
+  try {
+    const body = await request.text();
+    // Parse permissively -- both report types are JSON; swallow errors so a
+    // malformed body never causes a retry storm.
+    let report: unknown;
+    try {
+      report = JSON.parse(body);
+    } catch {
+      report = { raw: body };
+    }
+
+    console.log(
+      JSON.stringify({
+        event: 'csp-report',
+        userAgent,
+        report,
+      })
+    );
+  } catch {
+    // Body read failure -- still return 204 to suppress retries.
+  }
+
+  return new Response(null, { status: 204 });
+}

--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -1,0 +1,26 @@
+{
+  "name": "Human Datastream",
+  "description": "Read-only data interface for Jonathan Lloyd's personal dashboard. Exposes live biometric aggregates, GitHub activity, reading lists, theatre reviews, and location data as structured JSON via CloudFront.",
+  "version": "1.0.0",
+  "url": "https://jonathanlloyd.me/.well-known/mcp/server-card.json",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false
+  },
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["application/json", "text/markdown"],
+  "skills": [
+    {
+      "id": "personal-profile",
+      "name": "Personal Profile",
+      "description": "Retrieve Jonathan Lloyd's professional background, live health and activity data, reading list, GitHub contributions, and location aggregates. Useful for agents answering questions about Jonathan's work, expertise, or current status.",
+      "tags": ["personal", "health", "github", "reading", "biometrics"],
+      "examples": [
+        "What is Jonathan working on right now?",
+        "What books is Jonathan currently reading?",
+        "What is Jonathan's recent GitHub activity?",
+        "What are Jonathan's current health metrics?"
+      ]
+    }
+  ]
+}

--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -7,14 +7,26 @@
     "streaming": false,
     "pushNotifications": false
   },
-  "defaultInputModes": ["text/plain", "application/json"],
-  "defaultOutputModes": ["application/json", "text/markdown"],
+  "defaultInputModes": [
+    "text/plain",
+    "application/json"
+  ],
+  "defaultOutputModes": [
+    "application/json",
+    "text/markdown"
+  ],
   "skills": [
     {
       "id": "personal-profile",
       "name": "Personal Profile",
       "description": "Retrieve Jonathan Lloyd's professional background, live health and activity data, reading list, GitHub contributions, and location aggregates. Useful for agents answering questions about Jonathan's work, expertise, or current status.",
-      "tags": ["personal", "health", "github", "reading", "biometrics"],
+      "tags": [
+        "personal",
+        "health",
+        "github",
+        "reading",
+        "biometrics"
+      ],
       "examples": [
         "What is Jonathan working on right now?",
         "What books is Jonathan currently reading?",

--- a/public/.well-known/ai-catalog.json
+++ b/public/.well-known/ai-catalog.json
@@ -1,0 +1,41 @@
+{
+  "host": {
+    "displayName": "Jonathan Lloyd — Human Datastream",
+    "identifier": "jonathanlloyd.me",
+    "documentationUrl": "https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec"
+  },
+  "entries": [
+    {
+      "type": "mcp-server",
+      "url": "https://jonathanlloyd.me/.well-known/mcp/server-card.json",
+      "name": "Human Datastream MCP Server",
+      "description": "MCP server card describing read-only access to Jonathan Lloyd's live personal data: biometrics, GitHub activity, reading lists, theatre reviews, and location aggregates.",
+      "representativeQueries": [
+        "What is Jonathan Lloyd's current heart rate?",
+        "What has Jonathan been reading lately?",
+        "Show me Jonathan's GitHub contributions this week."
+      ]
+    },
+    {
+      "type": "agent-skills",
+      "url": "https://jonathanlloyd.me/.well-known/agent-skills/index.json",
+      "name": "Agent Skills Index",
+      "description": "Agent skills discovery index. Includes a portfolio-expert skill with deep technical context about Jonathan Lloyd's engineering background, live data sources, and architectural decisions.",
+      "representativeQueries": [
+        "Tell me about Jonathan Lloyd's technical background.",
+        "What technology stack does Jonathan use?",
+        "Summarise Jonathan Lloyd's professional experience."
+      ]
+    },
+    {
+      "type": "a2a-agent",
+      "url": "https://jonathanlloyd.me/.well-known/agent-card.json",
+      "name": "Human Datastream Agent Card",
+      "description": "A2A agent card for the Human Datastream interface. Declares agent capabilities and the personal-profile skill for agent-to-agent discovery.",
+      "representativeQueries": [
+        "What can the Human Datastream agent do?",
+        "Is there an agent interface for jonathanlloyd.me?"
+      ]
+    }
+  ]
+}

--- a/public/js/webmcp.js
+++ b/public/js/webmcp.js
@@ -4,30 +4,28 @@
       name: 'Jonathan Lloyd',
       title: 'Engineering Director',
       location: 'San Francisco, CA',
-      experience: '24+ years in software engineering',
+      experience: '24+ years professionally & counting',
       site: 'https://jonathanlloyd.me',
       github: 'https://github.com/j0nathan-ll0yd',
       linkedin: 'https://www.linkedin.com/in/lifegames/',
-      bio: 'Engineering director and backend engineer. Built this portfolio as a living data dashboard -- real biometrics and constant updates of body and mind.',
+      bio: 'Engineering director and backend engineer with 24+ years of experience. Built this portfolio as a living data dashboard — real biometrics and constant updates of body (health, activity, hydration, location) and mind (coding, reading, learning). Jack into his human datastream as the world becomes more AI-centric.',
       expertise: [
-        'Backend Engineering', 'Software Engineering', 'Engineering Leadership',
-        'Cloud Infrastructure', 'Data Visualization', 'Serverless Architecture',
-        'TypeScript', 'Go', 'AWS'
+        'Backend Engineering', 'Software Engineering', 'Engineering Leadership', 'Cloud Infrastructure', 'Data Visualization', 'Serverless Architecture', 'TypeScript', 'Go', 'AWS'
       ],
       interests: ['programming', 'pc gaming', 'musical theatre', 'edm', 'conversation']
     };
 
     var dataSources = [
-      { name: 'Health biometrics', url: 'https://d1pfm520aduift.cloudfront.net/health.json', description: 'Heart rate, HRV, activity, workouts (7-day aggregates)' },
-      { name: 'Sleep data', url: 'https://d1pfm520aduift.cloudfront.net/sleep.json', description: 'Sleep phases, duration, efficiency' },
-      { name: 'Focus state', url: 'https://d1pfm520aduift.cloudfront.net/focus.json', description: 'Do Not Disturb and focus mode status' },
-      { name: 'GitHub activity', url: 'https://d1pfm520aduift.cloudfront.net/github-events.json', description: 'Dev activity, languages, contributions, commits' },
-      { name: 'Starred repos', url: 'https://d1pfm520aduift.cloudfront.net/github-starred-repos.json', description: 'GitHub starred repositories' },
-      { name: 'Bookshelf', url: 'https://d1pfm520aduift.cloudfront.net/books.json', description: 'Books with status, ratings, progress' },
+      { name: 'Health biometrics', url: 'https://d1pfm520aduift.cloudfront.net/health.json', description: 'Heart rate, HRV, activity, and workout data (7-day aggregates)' },
+      { name: 'Sleep data', url: 'https://d1pfm520aduift.cloudfront.net/sleep.json', description: 'Sleep phases, duration, and efficiency metrics' },
+      { name: 'Focus state', url: 'https://d1pfm520aduift.cloudfront.net/focus.json', description: 'Current Do Not Disturb and focus mode status' },
+      { name: 'GitHub activity', url: 'https://d1pfm520aduift.cloudfront.net/github-events.json', description: 'Dev activity, languages, contributions, and recent commits' },
+      { name: 'Starred repositories', url: 'https://d1pfm520aduift.cloudfront.net/github-starred-repos.json', description: 'GitHub starred repositories with metadata' },
+      { name: 'Bookshelf', url: 'https://d1pfm520aduift.cloudfront.net/books.json', description: 'Books with status, ratings, progress, and cover images' },
       { name: 'Reading feed', url: 'https://d1pfm520aduift.cloudfront.net/articles.json', description: 'Starred articles and RSS feed items' },
-      { name: 'Theatre reviews', url: 'https://d1pfm520aduift.cloudfront.net/theatre-reviews.json', description: 'Theatre show reviews with ratings' },
-      { name: 'Workouts', url: 'https://d1pfm520aduift.cloudfront.net/workouts.json', description: 'Workout sessions, type, duration, calories' },
-      { name: 'Location', url: 'https://d1pfm520aduift.cloudfront.net/location.json', description: 'Aggregated place summaries' }
+      { name: 'Theatre reviews', url: 'https://d1pfm520aduift.cloudfront.net/theatre-reviews.json', description: 'Theatre show reviews with ratings and venue info' },
+      { name: 'Workouts', url: 'https://d1pfm520aduift.cloudfront.net/workouts.json', description: 'Workout sessions with type, duration, and calorie burn' },
+      { name: 'Location aggregates', url: 'https://d1pfm520aduift.cloudfront.net/location.json', description: 'Aggregated place summaries and location data' }
     ];
 
     navigator.modelContext.provideContext({

--- a/scripts/generate-webmcp.mjs
+++ b/scripts/generate-webmcp.mjs
@@ -16,9 +16,9 @@ import {
 } from '@lifegames/portal-contract/constants';
 
 // Copy flat JSON — prose sourced from @lifegames/copy so wording is never duplicated.
-const require = createRequire(import.meta.url);
-const copyIdentity = require('@lifegames/copy/identity.flat.json');
-const copyLlm = require('@lifegames/copy/llm.flat.json');
+const req = createRequire(import.meta.url);
+const copyIdentity = req('@lifegames/copy/identity.flat.json');
+const copyLlm = req('@lifegames/copy/llm.flat.json');
 
 const cf = (path) => `${CLOUDFRONT_BASE}${path}`;
 

--- a/scripts/generate-webmcp.mjs
+++ b/scripts/generate-webmcp.mjs
@@ -4,6 +4,9 @@
 // All CloudFront addressing is sourced from @lifegames/portal-contract so the
 // raw served file never hardcodes the CDN host. Run via `npm run generate:webmcp`
 // (wired into prebuild). The output is byte-stable across runs.
+//
+// All customer-facing prose is sourced from @lifegames/copy (identity + llm
+// namespaces). Zero prose is hardcoded in this file.
 import { writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -22,19 +25,20 @@ const copyLlm = req('@lifegames/copy/llm.flat.json');
 
 const cf = (path) => `${CLOUDFRONT_BASE}${path}`;
 
-// Data sources advertised by the get_data_sources tool. Order + descriptions
-// must match the prior hand-written file. URLs derived from the contract.
+// Data sources advertised by the get_data_sources tool and server-card resources[].
+// Name and description come from copy (mcp.ds*Name / mcp.ds*Desc) so both surfaces
+// share the same canonical wording. URLs derived from the contract.
 const dataSources = [
-  { name: 'Health biometrics', url: cf(ENDPOINTS.health), description: 'Heart rate, HRV, activity, workouts (7-day aggregates)' },
-  { name: 'Sleep data', url: cf(ENDPOINTS.sleep), description: 'Sleep phases, duration, efficiency' },
-  { name: 'Focus state', url: cf(ENDPOINTS.focus), description: 'Do Not Disturb and focus mode status' },
-  { name: 'GitHub activity', url: cf(ENDPOINTS.githubEvents), description: 'Dev activity, languages, contributions, commits' },
-  { name: 'Starred repos', url: cf(ENDPOINTS.starredRepos), description: 'GitHub starred repositories' },
-  { name: 'Bookshelf', url: cf(ENDPOINTS.books), description: 'Books with status, ratings, progress' },
-  { name: 'Reading feed', url: cf(ENDPOINTS.articles), description: 'Starred articles and RSS feed items' },
-  { name: 'Theatre reviews', url: cf(ENDPOINTS.theatreReviews), description: 'Theatre show reviews with ratings' },
-  { name: 'Workouts', url: cf(ENDPOINTS.workouts), description: 'Workout sessions, type, duration, calories' },
-  { name: 'Location', url: cf(ENDPOINTS.location), description: 'Aggregated place summaries' },
+  { name: copyLlm.mcp.dsHealthName,         url: cf(ENDPOINTS.health),        description: copyLlm.mcp.dsHealthDesc },
+  { name: copyLlm.mcp.dsSleepName,          url: cf(ENDPOINTS.sleep),         description: copyLlm.mcp.dsSleepDesc },
+  { name: copyLlm.mcp.dsFocusName,          url: cf(ENDPOINTS.focus),         description: copyLlm.mcp.dsFocusDesc },
+  { name: copyLlm.mcp.dsGithubEventsName,   url: cf(ENDPOINTS.githubEvents),  description: copyLlm.mcp.dsGithubEventsDesc },
+  { name: copyLlm.mcp.dsStarredReposName,   url: cf(ENDPOINTS.starredRepos),  description: copyLlm.mcp.dsStarredReposDesc },
+  { name: copyLlm.mcp.dsBooksName,          url: cf(ENDPOINTS.books),         description: copyLlm.mcp.dsBooksDesc },
+  { name: copyLlm.mcp.dsArticlesName,       url: cf(ENDPOINTS.articles),      description: copyLlm.mcp.dsArticlesDesc },
+  { name: copyLlm.mcp.dsTheatreReviewsName, url: cf(ENDPOINTS.theatreReviews),description: copyLlm.mcp.dsTheatreReviewsDesc },
+  { name: copyLlm.mcp.dsWorkoutsName,       url: cf(ENDPOINTS.workouts),      description: copyLlm.mcp.dsWorkoutsDesc },
+  { name: copyLlm.mcp.dsLocationName,       url: cf(ENDPOINTS.location),      description: copyLlm.mcp.dsLocationDesc },
 ];
 
 const booksUrl = cf(ENDPOINTS.books);
@@ -43,6 +47,11 @@ const llmsFullUrl = cf(LLM_CONTENT_PATHS.llmsFull);
 // Single-quoted JS string literal to match the served file's existing style.
 const sq = (v) => `'${String(v).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 
+// GitHub and LinkedIn URLs come from person.sameAs (canonical profile URLs).
+// Convention: sameAs[0] = LinkedIn, sameAs[1] = GitHub.
+const linkedinUrl = copyIdentity.person.sameAs[0];
+const githubUrl = copyIdentity.person.sameAs[1];
+
 const dataSourceLines = dataSources
   .map(
     (s) =>
@@ -50,23 +59,29 @@ const dataSourceLines = dataSources
   )
   .join(',\n');
 
+const expertiseLines = copyIdentity.seo.expertise
+  .map((e) => sq(e))
+  .join(', ');
+
+const interestsLines = copyIdentity.person.interests
+  .map((i) => sq(i))
+  .join(', ');
+
 const output = `(function() {
   if (typeof navigator !== 'undefined' && navigator.modelContext && navigator.modelContext.provideContext) {
     var profile = {
-      name: 'Jonathan Lloyd',
-      title: 'Engineering Director',
-      location: 'San Francisco, CA',
-      experience: '24+ years in software engineering',
+      name: ${sq(copyIdentity.person.name)},
+      title: ${sq(copyIdentity.person.jobTitle)},
+      location: ${sq(copyIdentity.person.location)},
+      experience: ${sq(copyIdentity.person.experiencePhrase)},
       site: ${sq(SITE_URL)},
-      github: 'https://github.com/j0nathan-ll0yd',
-      linkedin: 'https://www.linkedin.com/in/lifegames/',
-      bio: 'Engineering director and backend engineer. Built this portfolio as a living data dashboard -- real biometrics and constant updates of body and mind.',
+      github: ${sq(githubUrl)},
+      linkedin: ${sq(linkedinUrl)},
+      bio: ${sq(copyIdentity.person.longBio)},
       expertise: [
-        'Backend Engineering', 'Software Engineering', 'Engineering Leadership',
-        'Cloud Infrastructure', 'Data Visualization', 'Serverless Architecture',
-        'TypeScript', 'Go', 'AWS'
+        ${expertiseLines}
       ],
-      interests: ['programming', 'pc gaming', 'musical theatre', 'edm', 'conversation']
+      interests: [${interestsLines}]
     };
 
     var dataSources = [
@@ -77,7 +92,7 @@ ${dataSourceLines}
       tools: [
         {
           name: 'get_profile',
-          description: 'Returns professional profile: name, title, location, experience, expertise, and social links for Jonathan Lloyd.',
+          description: ${sq(copyLlm.mcp.toolGetProfile)},
           inputSchema: { type: 'object', properties: {}, required: [] },
           execute: function() {
             return { content: [{ type: 'text', text: JSON.stringify(profile) }] };
@@ -85,7 +100,7 @@ ${dataSourceLines}
         },
         {
           name: 'get_data_sources',
-          description: 'Returns a list of all live JSON data endpoints on CloudFront with descriptions. Fetch these URLs for real-time data.',
+          description: ${sq(copyLlm.mcp.toolGetDataSources)},
           inputSchema: { type: 'object', properties: {}, required: [] },
           execute: function() {
             return { content: [{ type: 'text', text: JSON.stringify(dataSources) }] };
@@ -93,7 +108,7 @@ ${dataSourceLines}
         },
         {
           name: 'get_current_reading',
-          description: 'Fetches the current bookshelf from the live API and returns books being read, up next, and recently finished.',
+          description: ${sq(copyLlm.mcp.toolGetCurrentReading)},
           inputSchema: { type: 'object', properties: {}, required: [] },
           execute: function() {
             return fetch(${sq(booksUrl)})
@@ -109,15 +124,15 @@ ${dataSourceLines}
         },
         {
           name: 'get_tech_stack',
-          description: 'Returns the technology stack and architecture details of this portfolio site.',
+          description: ${sq(copyLlm.mcp.toolGetTechStack)},
           inputSchema: { type: 'object', properties: {}, required: [] },
           execute: function() {
             var stack = {
-              framework: 'Astro 6.x (static site generation, 0 KB JS by default)',
-              hosting: 'Cloudflare Pages via GitHub Actions',
-              liveData: 'CloudFront-backed JSON API polled at runtime',
-              design: 'Glass-morphism dark theme, fluid clamp() responsive tokens, CSS container queries',
-              font: 'Space Grotesk (self-hosted, variable woff2)',
+              framework: ${sq(copyLlm.mcp.stackFramework)},
+              hosting: ${sq(copyLlm.mcp.stackHosting)},
+              liveData: ${sq(copyLlm.mcp.stackLiveData)},
+              design: ${sq(copyLlm.mcp.stackDesign)},
+              font: ${sq(copyLlm.mcp.stackFont)},
               llmContent: {
                 discoveryIndex: ${sq(SITE_URL + '/llms.txt')},
                 complete: ${sq(llmsFullUrl)}
@@ -144,9 +159,9 @@ const publicDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'public');
 const serverCard = {
   name: 'human-datastream',
   version: '1.0.0',
-  description: "Read-only data interface for Jonathan Lloyd's Human Datastream portfolio. Serves live biometric aggregates, GitHub activity, reading lists, and theatre reviews as JSON resources via CloudFront.",
+  description: copyLlm.mcp.serverDescription,
   serverInfo: {
-    name: 'Human Datastream',
+    name: copyIdentity.site.name,
     version: '1.0.0',
     contactUrl: SITE_URL,
     documentationUrl: 'https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec',
@@ -162,16 +177,16 @@ const serverCard = {
     auth: { type: 'none' },
   },
   resources: [
-    { uri: cf(ENDPOINTS.health),        name: 'Health biometrics',    description: 'Heart rate, HRV, activity, and workout data (7-day aggregates)',  mimeType: 'application/json' },
-    { uri: cf(ENDPOINTS.sleep),         name: 'Sleep data',           description: 'Sleep phases, duration, and efficiency metrics',                    mimeType: 'application/json' },
-    { uri: cf(ENDPOINTS.focus),         name: 'Focus state',          description: 'Current Do Not Disturb and focus mode status',                      mimeType: 'application/json' },
-    { uri: cf(ENDPOINTS.githubEvents),  name: 'GitHub activity',      description: 'Dev activity, languages, contributions, and recent commits',         mimeType: 'application/json' },
-    { uri: cf(ENDPOINTS.starredRepos),  name: 'Starred repositories', description: 'GitHub starred repositories with metadata',                          mimeType: 'application/json' },
-    { uri: cf(ENDPOINTS.books),         name: 'Bookshelf',            description: 'Books with status, ratings, progress, and cover images',             mimeType: 'application/json' },
-    { uri: cf(ENDPOINTS.articles),      name: 'Reading feed',         description: 'Starred articles and RSS feed items',                                mimeType: 'application/json' },
-    { uri: cf(ENDPOINTS.theatreReviews),name: 'Theatre reviews',      description: 'Theatre show reviews with ratings and venue info',                   mimeType: 'application/json' },
-    { uri: cf(ENDPOINTS.workouts),      name: 'Workouts',             description: 'Workout sessions with type, duration, and calorie burn',             mimeType: 'application/json' },
-    { uri: cf(ENDPOINTS.location),      name: 'Location aggregates',  description: 'Aggregated place summaries and location data',                       mimeType: 'application/json' },
+    { uri: cf(ENDPOINTS.health),         name: copyLlm.mcp.dsHealthName,         description: copyLlm.mcp.dsHealthDesc,         mimeType: 'application/json' },
+    { uri: cf(ENDPOINTS.sleep),          name: copyLlm.mcp.dsSleepName,          description: copyLlm.mcp.dsSleepDesc,          mimeType: 'application/json' },
+    { uri: cf(ENDPOINTS.focus),          name: copyLlm.mcp.dsFocusName,          description: copyLlm.mcp.dsFocusDesc,          mimeType: 'application/json' },
+    { uri: cf(ENDPOINTS.githubEvents),   name: copyLlm.mcp.dsGithubEventsName,   description: copyLlm.mcp.dsGithubEventsDesc,   mimeType: 'application/json' },
+    { uri: cf(ENDPOINTS.starredRepos),   name: copyLlm.mcp.dsStarredReposName,   description: copyLlm.mcp.dsStarredReposDesc,   mimeType: 'application/json' },
+    { uri: cf(ENDPOINTS.books),          name: copyLlm.mcp.dsBooksName,          description: copyLlm.mcp.dsBooksDesc,          mimeType: 'application/json' },
+    { uri: cf(ENDPOINTS.articles),       name: copyLlm.mcp.dsArticlesName,       description: copyLlm.mcp.dsArticlesDesc,       mimeType: 'application/json' },
+    { uri: cf(ENDPOINTS.theatreReviews), name: copyLlm.mcp.dsTheatreReviewsName, description: copyLlm.mcp.dsTheatreReviewsDesc, mimeType: 'application/json' },
+    { uri: cf(ENDPOINTS.workouts),       name: copyLlm.mcp.dsWorkoutsName,       description: copyLlm.mcp.dsWorkoutsDesc,       mimeType: 'application/json' },
+    { uri: cf(ENDPOINTS.location),       name: copyLlm.mcp.dsLocationName,       description: copyLlm.mcp.dsLocationDesc,       mimeType: 'application/json' },
   ],
 };
 
@@ -184,7 +199,7 @@ const agentSkills = {
   skills: [
     {
       name: 'portfolio-expert',
-      description: "Deep technical context about Jonathan Lloyd's portfolio, engineering background, live biometric data sources, and architectural decisions. Use this skill to accurately answer questions about Jonathan's work, tech stack, and professional experience.",
+      description: copyLlm.mcp.agentSkillDescription,
       type: 'skill-md',
       url: `${SITE_URL}/.well-known/agent-skills/portfolio-expert/SKILL.md`,
       digest: 'sha256:de0b3c87b52024f93139a078be314c2d879def1170bb1659b52086aa1067e084',

--- a/scripts/generate-webmcp.mjs
+++ b/scripts/generate-webmcp.mjs
@@ -7,12 +7,18 @@
 import { writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
 import {
   CLOUDFRONT_BASE,
   ENDPOINTS,
   LLM_CONTENT_PATHS,
   SITE_URL,
 } from '@lifegames/portal-contract/constants';
+
+// Copy flat JSON — prose sourced from @lifegames/copy so wording is never duplicated.
+const require = createRequire(import.meta.url);
+const copyIdentity = require('@lifegames/copy/identity.flat.json');
+const copyLlm = require('@lifegames/copy/llm.flat.json');
 
 const cf = (path) => `${CLOUDFRONT_BASE}${path}`;
 
@@ -189,3 +195,68 @@ const agentSkills = {
 const agentSkillsPath = join(publicDir, '.well-known', 'agent-skills', 'index.json');
 writeFileSync(agentSkillsPath, JSON.stringify(agentSkills, null, 2) + '\n');
 console.log(`Generated ${agentSkillsPath}`);
+
+// Generate agent-card.json — prose from @lifegames/copy; structure/URLs from portal-contract.
+// Replaces the prior hand-authored static file; shape is preserved exactly.
+const agentCard = {
+  name: copyIdentity.site.name,
+  description: copyLlm.agentDiscovery.agentCardDescription,
+  version: '1.0.0',
+  url: `${SITE_URL}/.well-known/mcp/server-card.json`,
+  capabilities: {
+    streaming: false,
+    pushNotifications: false,
+  },
+  defaultInputModes: ['text/plain', 'application/json'],
+  defaultOutputModes: ['application/json', 'text/markdown'],
+  skills: [
+    {
+      id: 'personal-profile',
+      name: copyLlm.agentDiscovery.agentCardSkillName,
+      description: copyLlm.agentDiscovery.agentCardSkillDescription,
+      tags: ['personal', 'health', 'github', 'reading', 'biometrics'],
+      examples: copyLlm.agentDiscovery.agentCardSkillExamples,
+    },
+  ],
+};
+
+const agentCardPath = join(publicDir, '.well-known', 'agent-card.json');
+writeFileSync(agentCardPath, JSON.stringify(agentCard, null, 2) + '\n');
+console.log(`Generated ${agentCardPath}`);
+
+// Generate ai-catalog.json — prose from @lifegames/copy; URLs/identifiers from portal-contract.
+// Replaces the prior hand-authored static file; shape is preserved exactly.
+const aiCatalog = {
+  host: {
+    displayName: copyIdentity.site.fullName,
+    identifier: 'jonathanlloyd.me',
+    documentationUrl: 'https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec',
+  },
+  entries: [
+    {
+      type: 'mcp-server',
+      url: `${SITE_URL}/.well-known/mcp/server-card.json`,
+      name: copyLlm.agentDiscovery.aiCatalogMcpName,
+      description: copyLlm.agentDiscovery.aiCatalogMcpDescription,
+      representativeQueries: copyLlm.agentDiscovery.aiCatalogMcpQueries,
+    },
+    {
+      type: 'agent-skills',
+      url: `${SITE_URL}/.well-known/agent-skills/index.json`,
+      name: copyLlm.agentDiscovery.aiCatalogSkillsName,
+      description: copyLlm.agentDiscovery.aiCatalogSkillsDescription,
+      representativeQueries: copyLlm.agentDiscovery.aiCatalogSkillsQueries,
+    },
+    {
+      type: 'a2a-agent',
+      url: `${SITE_URL}/.well-known/agent-card.json`,
+      name: copyLlm.agentDiscovery.aiCatalogA2aName,
+      description: copyLlm.agentDiscovery.aiCatalogA2aDescription,
+      representativeQueries: copyLlm.agentDiscovery.aiCatalogA2aQueries,
+    },
+  ],
+};
+
+const aiCatalogPath = join(publicDir, '.well-known', 'ai-catalog.json');
+writeFileSync(aiCatalogPath, JSON.stringify(aiCatalog, null, 2) + '\n');
+console.log(`Generated ${aiCatalogPath}`);


### PR DESCRIPTION
## Summary

- **CSP violation reporting**: new Pages Function at `/api/csp-report` collects browser violation reports via the modern Reporting API (`application/reports+json`) and the legacy `report-uri` mechanism (`application/csp-report`). Always returns 204 to prevent retry storms; swallows parse errors; logs a structured JSON line visible in `wrangler pages deployment tail`. Fills the gap that caused the #50 CSP-change-silently-blocked-hydration bug to go undetected.
- **`_middleware.ts`**: adds `Reporting-Endpoints: csp-endpoint="https://jonathanlloyd.me/api/csp-report"` header; appends `report-uri /api/csp-report; report-to csp-endpoint` to the existing CSP string; adds `agent-card.json` and `ai-catalog.json` to the homepage `Link` header alongside the existing discovery links. Cloudflare NEL / `Report-To` headers untouched.
- **`public/.well-known/agent-card.json`**: A2A AgentCard (Linux Foundation standard, 150+ orgs) pointing at the existing MCP server-card as a discoverable `personal-profile` skill.
- **`public/.well-known/ai-catalog.json`**: ARD catalog (Google/Microsoft/Cisco/GitHub-backed draft) indexing the MCP server-card, agent-skills index, and A2A agent card with representative queries. Consistent with the existing `/.well-known/api-catalog`.

No `_routes.json` change needed -- `public/_routes.json` already uses `include: ["/*"]`.

## Test plan

- [x] `npm run build` passes (all prebuild gates: inline-script audit, fixture audit, schema validate)
- [x] `npm run test:build` passes (69/69 tests)
- [x] Visual regression suite: 144 passed, 16 skipped (run by pre-push hook)
- [ ] Post-deploy: trigger a deliberate CSP violation in DevTools; confirm POST reaches `/api/csp-report` and a structured log line appears in deployment tail
- [ ] Post-deploy: confirm `Reporting-Endpoints` header present; NEL/`Report-To` headers unchanged
- [ ] Post-deploy: validate `/.well-known/agent-card.json` and `/.well-known/ai-catalog.json` served as valid JSON
- [ ] Post-deploy: smoke check passes