### PR TITLE
fix(runtime): make page BFCache-eligible by tearing down WS on pagehide

### DIFF
--- a/src/lib/runtime/live-data.ts
+++ b/src/lib/runtime/live-data.ts
@@ -60,6 +60,9 @@ let lastHealth: HealthExport | undefined;
 let lastSleep: SleepExport | undefined;
 const timestamps: Record<string, string | null> = {};
 let engine: PollEngine | null = null;
+// ws is hoisted to module scope so pagehide/pageshow lifecycle handlers can
+// reach it. It is null until startFetch() completes (null-guard before use).
+let ws: WSClient | null = null;
 
 // ── Resource type map for discriminated validation ───────────────────
 type ResourceTypeMap = {
@@ -296,7 +299,7 @@ const startFetch = async () => {
   };
 
   // ── WebSocket push notifications (additive — polling continues if WS fails) ──
-  const ws = new WSClient({
+  ws = new WSClient({
     url: WEBSOCKET_URL,
     onUpdate: (resource) => {
       const key = resource as ResourceKey;
@@ -322,9 +325,29 @@ if ('requestIdleCallback' in window) {
   setTimeout(startFetch, 200);
 }
 
-// ── bfcache restoration — refresh data without full page reload ──────
+// ── BFCache lifecycle handlers ────────────────────────────────────────
+// pagehide(persisted=true): browser is freezing the page into BFCache.
+// Close the WebSocket and stop polling so the page is BFCache-eligible
+// (an open WebSocket is a hard Chromium BFCache blocker).
+window.addEventListener('pagehide', (event) => {
+  if ((event as PageTransitionEvent).persisted) {
+    if (engine) engine.stop();
+    if (ws) ws.disconnect();
+  }
+});
+
+// pageshow(persisted=true): browser is restoring the page from BFCache.
+// Restart poll timers + reconnect the WebSocket, then trigger an immediate
+// refresh. engine.start() is idempotent (no-op if already running); after a
+// pagehide teardown it restarts the interval timers and visibilitychange
+// listener. engine.pollNow() fetches fresh data without waiting for the next
+// tick. The WS was silently lost on restore before this fix.
 window.addEventListener('pageshow', (event) => {
-  if ((event as PageTransitionEvent).persisted && engine) {
-    engine.pollNow();
+  if ((event as PageTransitionEvent).persisted) {
+    if (engine) {
+      engine.start();
+      engine.pollNow();
+    }
+    if (ws) ws.connect();
   }
 });


### PR DESCRIPTION
## Summary

- **Root cause fixed**: an open WebSocket is a hard Chromium BFCache blocker. Previously the page was ineligible for BFCache because `ws.connect()` ran on every page load with no corresponding teardown on navigation away.
- **Asymmetry fixed**: the existing `pageshow(persisted)` handler only called `engine.pollNow()` -- polling resumed on BFCache restore but the WebSocket push channel was silently lost until the next `visibilitychange`. This caused a window where WS-pushed updates were missed.
- **One file changed**: `src/lib/runtime/live-data.ts` (~27 lines net).

### Changes in detail

1. **Hoist `ws` to module scope** (was `const` inside `startFetch`): mirrors how `engine` is held. Null-guarded in all lifecycle handlers -- `ws` is null until `startFetch()` completes.
2. **`pagehide(persisted=true)` handler**: calls `engine.stop()` + `ws.disconnect()`. `stop()` clears poll timers and removes the `visibilitychange` listener; `disconnect()` closes the WebSocket and clears reconnect timers. Removes the hard BFCache blocker.
3. **`pageshow(persisted=true)` handler** (extended from the existing handler): calls `engine.start()` (restarts timers + visibilitychange listener, idempotent), `engine.pollNow()` (immediate data refresh), and `ws.connect()` (restores push channel). Previously only `engine.pollNow()` was called.

### Cache header note

`CDN-Cache-Control: no-store` in `_middleware.ts` is an edge-only directive stripped before the browser -- it is NOT a BFCache blocker. `No-Vary-Search` is already set for BFCache. No header changes needed.

### Limitations

Final "BFCache Eligible" confirmation requires a manual Chrome DevTools Application -> Back/Forward Cache -> "Test back/forward cache" check post-deploy. This cannot be verified headlessly -- Chromium BFCache eligibility is not exposed via the Playwright API.

## Test plan

- [x] `npm run build` passes (all prebuild gates)
- [x] `npm run test:build` passes (69/69 tests)
- [ ] Post-deploy: Chrome DevTools Application -> Back/Forward Cache -> "Test back/forward cache" reports "Eligible" (or documents any remaining unavoidable reason)
- [ ] Post-deploy: back-nav restores instantly; polling and WS push both resume correctly after restore (verify WS connection re-established in DevTools Network tab)
- [ ] Post-deploy: smoke check passes
