### PR TITLE
feat(pages): add /privacy page with copy-driven content

### DIFF
--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -38,6 +38,7 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
   <link rel="manifest" href="/manifest.webmanifest">
   <link rel="sitemap" href="/sitemap-index.xml">
   <link rel="author" href="/humans.txt">
+  <link rel="privacy-policy" href="/privacy">
   {/* Feed discovery — RSS 2.0 + JSON Feed 1.1 (backend-composed live on CloudFront) */}
   <link rel="alternate" type="application/rss+xml" title={identity.feed.title} href="/feed.xml">
   <link rel="alternate" type="application/feed+json" title={identity.feed.title} href="/feed.json">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,142 @@
+---
+import { getEntry } from 'astro:content';
+import Dashboard from '../layouts/Dashboard.astro';
+
+const _identityEntry = await getEntry('copy', 'identity');
+if (!_identityEntry) throw new Error('[privacy.astro] @lifegames/copy identity entry missing');
+const id = _identityEntry.data;
+const p = id.privacy;
+
+const sections = [
+  { heading: 'Who runs this site', body: p.who },
+  { heading: 'Data displayed', body: p.dataDisplayed },
+  { heading: 'Data collected from visitors', body: p.dataCollected },
+  { heading: 'Analytics', body: p.analytics },
+  { heading: 'Your rights', body: p.rights },
+  { heading: 'Changes to this policy', body: p.changes },
+];
+---
+<Dashboard
+  title={p.title}
+  description={p.dataCollected}
+  robots="noindex, follow"
+>
+  <main id="main-content" class="privacy-page">
+    <article class="privacy-card" aria-labelledby="privacy-heading">
+      <header class="privacy-header">
+        <h1 id="privacy-heading" class="privacy-title">{p.title}</h1>
+        <p class="privacy-updated">
+          <time>{p.lastUpdated}</time>
+        </p>
+      </header>
+      {sections.map((s) => (
+        <section class="privacy-section" aria-label={s.heading}>
+          <h2 class="privacy-section-heading">{s.heading}</h2>
+          <p class="privacy-section-body">{s.body}</p>
+        </section>
+      ))}
+      <footer class="privacy-footer">
+        <a href="/" class="privacy-back-link">{id.a11y.skipToMain ? 'Back to dashboard' : 'Back'}</a>
+      </footer>
+    </article>
+  </main>
+</Dashboard>
+
+<style>
+  .privacy-page {
+    min-height: 100dvh;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: var(--space-40) var(--space-24);
+    background: var(--bg);
+  }
+
+  .privacy-card {
+    width: 100%;
+    max-width: 720px;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-40);
+    backdrop-filter: blur(var(--blur-md));
+    -webkit-backdrop-filter: blur(var(--blur-md));
+  }
+
+  .privacy-header {
+    margin-bottom: var(--space-28);
+    padding-bottom: var(--space-20);
+    border-bottom: 1px solid var(--glass-border);
+  }
+
+  .privacy-title {
+    font-size: var(--font-size-xl);
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1.2;
+    margin-bottom: var(--space-8);
+  }
+
+  .privacy-updated {
+    font-size: var(--font-size-sm);
+    color: var(--text-muted);
+  }
+
+  .privacy-updated time::before {
+    content: 'Last updated: ';
+  }
+
+  .privacy-section {
+    margin-bottom: var(--space-28);
+  }
+
+  .privacy-section-heading {
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--neon-cyan);
+    margin-bottom: var(--space-10);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .privacy-section-body {
+    font-size: var(--font-size-base);
+    color: var(--text);
+    line-height: 1.7;
+  }
+
+  .privacy-footer {
+    margin-top: var(--space-40);
+    padding-top: var(--space-20);
+    border-top: 1px solid var(--glass-border);
+  }
+
+  .privacy-back-link {
+    font-size: var(--font-size-sm);
+    color: var(--neon-cyan);
+    text-decoration: none;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .privacy-back-link:hover {
+    text-decoration: underline;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .privacy-card {
+      animation: fadeIn 0.4s ease;
+    }
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  @supports not (backdrop-filter: blur(1px)) {
+    .privacy-card {
+      background: rgba(6, 6, 15, 0.95);
+    }
+  }
+</style>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -8,12 +8,12 @@ const id = _identityEntry.data;
 const p = id.privacy;
 
 const sections = [
-  { heading: 'Who runs this site', body: p.who },
-  { heading: 'Data displayed', body: p.dataDisplayed },
-  { heading: 'Data collected from visitors', body: p.dataCollected },
-  { heading: 'Analytics', body: p.analytics },
-  { heading: 'Your rights', body: p.rights },
-  { heading: 'Changes to this policy', body: p.changes },
+  { heading: p.whoHeading, body: p.who },
+  { heading: p.dataDisplayedHeading, body: p.dataDisplayed },
+  { heading: p.dataCollectedHeading, body: p.dataCollected },
+  { heading: p.analyticsHeading, body: p.analytics },
+  { heading: p.rightsHeading, body: p.rights },
+  { heading: p.changesHeading, body: p.changes },
 ];
 ---
 <Dashboard
@@ -26,7 +26,7 @@ const sections = [
       <header class="privacy-header">
         <h1 id="privacy-heading" class="privacy-title">{p.title}</h1>
         <p class="privacy-updated">
-          <time>{p.lastUpdated}</time>
+          <span class="privacy-updated-label">{p.lastUpdatedLabel}</span> <time>{p.lastUpdated}</time>
         </p>
       </header>
       {sections.map((s) => (
@@ -36,7 +36,7 @@ const sections = [
         </section>
       ))}
       <footer class="privacy-footer">
-        <a href="/" class="privacy-back-link">{id.a11y.skipToMain ? 'Back to dashboard' : 'Back'}</a>
+        <a href="/" class="privacy-back-link">{p.backLink}</a>
       </footer>
     </article>
   </main>
@@ -82,8 +82,9 @@ const sections = [
     color: var(--text-muted);
   }
 
-  .privacy-updated time::before {
-    content: 'Last updated: ';
+  .privacy-updated-label {
+    font-size: var(--font-size-sm);
+    color: var(--text-muted);
   }
 
   .privacy-section {


### PR DESCRIPTION
## Summary

- New `src/pages/privacy.astro` rendering all 8 `privacy.*` copy keys from `@lifegames/copy` identity slice via the existing Content Collection (`getEntry('copy','identity')`)
- Six sections (who, dataDisplayed, dataCollected, analytics, rights, changes) rendered as scoped-styled article with `@lifegames/tokens` CSS vars throughout — no hardcoded strings, no hardcoded colors
- `<link rel="privacy-policy" href="/privacy">` added to `Dashboard.astro` head (appears on every page including homepage)
- `/privacy` auto-included in `sitemap-index.xml` by the Astro sitemap integration (verified in build output)

## Cross-repo dependency

**This PR depends on DS PR #80 (`feat/copy-privacy-identity-keys`) merging to `main` first.**

CI rebuilds `@lifegames/copy` from the DS `main` branch — the privacy keys do not exist on DS `main` yet, so CI will fail until DS PR #80 is merged. This is the documented cross-repo producer-first behaviour (see monorepo memory `project_cross_repo_producer_merges_first`).

**Reviewer action:** merge DS PR #80 first, then this PR.

## Verification

- Build: `npm run build` -> pass (3 pages built: index, 404, /privacy)
- Build tests: `npm run test:build` -> 8 files, 69 tests passed
- Visual regression (pre-push hook, Docker arm64): 144 passed, 16 skipped, 0 failed
- `/privacy/index.html` generated, contains all copy sections
- `sitemap-0.xml` contains `https://jonathanlloyd.me/privacy`
- `<link rel="privacy-policy" href="/privacy">` present in `dist/index.html` head

## Test plan

- [ ] Merge DS PR #80 first (privacy copy keys on `@lifegames/copy` main)
- [ ] Confirm CI passes on this PR after DS #80 merges
- [ ] Visit `/privacy` on the Pages preview — verify all 6 sections render, "Last updated: June 2026" dateline present, "Back to dashboard" link returns to `/`
- [ ] Confirm `<link rel="privacy-policy">` present in homepage `<head>` via DevTools
- [ ] Confirm `/privacy` appears in `sitemap-index.xml`