### PR TITLE
feat(layout): wire view-transitions.css (consumer for DS #81)

### DIFF
--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -153,6 +153,7 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
     @import '@lifegames/tokens/effects';
     @import '@lifegames/tokens/reset';
     @import '@lifegames/web/styles/a11y.css';
+    @import '@lifegames/web/styles/view-transitions.css';
   </style>
   {/* @font-face rules (Space Grotesk + Fallback) are provided by @lifegames/tokens/preamble
       (imported in the <style is:global> block above) — no duplication needed here. */}


### PR DESCRIPTION
Consumer wiring for design-system-Lifegames PR #81 (same-document View Transitions).

Adds `@import '@lifegames/web/styles/view-transitions.css'` to the dashboard head (next to a11y.css) so the per-name crossfade timing + reduced-motion safety net ship. The behavior (book modal open/close + dev-activity content swap) comes from the DS runtime in #81.

Verified locally: build clean, 69 build-tests pass, VT CSS confirmed in dist, Docker visual suite **144 passed / 0 diffs** (resting state unchanged — transitions are interaction-only).

Cross-repo: DS #81 must merge to main first (web CI rebuilds the producer from main). Graceful no-op on browsers without the View Transition API and for prefers-reduced-motion users.