### PR TITLE
ci(deploy): revert prod deploy runner to self-hosted (after fleet recovery)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    # TEMP (2026-06-24): self-hosted Linux fleet down (vmnet wedge, reboot-gated) --
-    # routed to GitHub-hosted to unblock the queued production deploy without a host
-    # reboot. REVERT to [self-hosted, linux, arm64, node] once recovered.
-    # See j0nathan-ll0yd/ci-runners-private#26.
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, node]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -68,11 +64,7 @@ jobs:
             -d "{\"build\":\"${GITHUB_SHA}\"}"
 
   check-images:
-    # TEMP (2026-06-24): self-hosted Linux fleet down (vmnet wedge, reboot-gated) --
-    # routed to GitHub-hosted to unblock the queued production deploy without a host
-    # reboot. REVERT to [self-hosted, linux, arm64, node] once recovered.
-    # See j0nathan-ll0yd/ci-runners-private#26.
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, node]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Reverts the temporary `ubuntu-latest` reroute of `deploy.yml` (both jobs) back to `[self-hosted, linux, arm64, node]`.

**Context:** during the 2026-06-24 self-hosted runner outage (see j0nathan-ll0yd/ci-runners-private#26), the production deploy was temporarily routed to a GitHub-hosted runner so the merged `main` could ship without a host reboot. This PR restores the cost-optimized self-hosted deploy.

**Merge ONLY after the self-hosted Linux fleet is recovered** (reboot + `/var/db/dhcpd_leases` flush + `scripts/reenable-units.sh` per ci-runners-private#26). Until then, leave the deploy on `ubuntu-latest`.

CI on this PR will stay red while the fleet is down (its self-hosted checks can't run) — expected; merge on recovery.