### PR TITLE
ci: pin setup-node to .nvmrc (node 24) in smoke + visual-tests

### DIFF
--- a/.github/workflows/smoke-check.yml
+++ b/.github/workflows/smoke-check.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version-file: '.nvmrc'
           cache: npm
 
       - name: Setup design-system + install dependencies

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version-file: '.nvmrc'
 
       - name: Resolve producer refs for parity with current branch
         id: producers


### PR DESCRIPTION
Normalizes the two CI jobs that hardcoded `node-version: 22` (smoke-check, visual-tests contract-check) to `node-version-file: '.nvmrc'` (24.16.0), matching local dev and the deploy/preview workflows. CI-only; no site content change.