### PR TITLE
fix(sa): CDN-Cache-Control no-store on /simple/* (edge-cache hardening, follow-up to #83)

### DIFF
--- a/functions/simple/[[path]].ts
+++ b/functions/simple/[[path]].ts
@@ -65,12 +65,18 @@ export async function onRequest(context: PagesContext): Promise<Response> {
 
   const isGif = suffix.endsWith('.gif');
 
+  // Collection endpoints must never be cached. `Cache-Control: no-store` covers
+  // the browser, but Cloudflare's edge overrides it and caches GET responses by
+  // default (observed: max-age=600 on the pixel), which would dedupe the static
+  // `noscript.gif` pageview across a 600s window. `CDN-Cache-Control: no-store`
+  // is the Cloudflare-honored directive that keeps the EDGE from caching too.
   const silentGif = () =>
     new Response(TRANSPARENT_GIF, {
       status: 200,
       headers: {
         'Content-Type': 'image/gif',
         'Cache-Control': 'no-store',
+        'CDN-Cache-Control': 'no-store',
       },
     });
 
@@ -79,7 +85,7 @@ export async function onRequest(context: PagesContext): Promise<Response> {
       ? silentGif()
       : new Response(null, {
           status: 204,
-          headers: { 'Cache-Control': 'no-store' },
+          headers: { 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store' },
         });
 
   let upstream: Response;
@@ -109,6 +115,7 @@ export async function onRequest(context: PagesContext): Promise<Response> {
   // For GIF paths, forward the upstream response; for others forward as-is or 204
   const responseHeaders = new Headers();
   responseHeaders.set('Cache-Control', 'no-store');
+  responseHeaders.set('CDN-Cache-Control', 'no-store');
 
   const upstreamContentType = upstream.headers.get('Content-Type');
   if (upstreamContentType) {

--- a/tests/unit/sa-collection.test.ts
+++ b/tests/unit/sa-collection.test.ts
@@ -87,10 +87,19 @@ describe('SA collection Function — upstream failure → silent 2xx', () => {
     expect(res.status).toBe(200);
   });
 
-  it('sets Cache-Control: no-store on all responses', async () => {
+  it('sets Cache-Control AND CDN-Cache-Control: no-store on the noop path', async () => {
     fetchMock.mockRejectedValueOnce(new Error('fail'));
     const res = await onRequest(makeContext('/simple/append'));
     expect(res.headers.get('Cache-Control')).toBe('no-store');
+    // CDN-Cache-Control is what Cloudflare's edge honors (it overrides the browser
+    // Cache-Control); without it GET /simple/* is edge-cached for ~600s.
+    expect(res.headers.get('CDN-Cache-Control')).toBe('no-store');
+  });
+
+  it('sets CDN-Cache-Control: no-store on the success path too', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 202 }));
+    const res = await onRequest(makeContext('/simple/simple.gif'));
+    expect(res.headers.get('CDN-Cache-Control')).toBe('no-store');
   });
 
   it('joins a multi-segment catch-all param array into the upstream path', async () => {


### PR DESCRIPTION
Follow-up hardening to #83 (SA reverse-proxy). Negligible-impact correctness fix surfaced during post-merge verification.

## Problem

The `/simple/*` collection Function sets `Cache-Control: no-store`, but **Cloudflare's edge overrides the browser `Cache-Control`** and caches GET responses (observed `max-age=600` + `cf-cache-status: MISS` on the pixel). Verified in production.

- **Real pageview pixel** — harmless: the SA script appends a unique `?…&time=<ms>` query, so every hit is a distinct cache key → always MISS → always reaches SA.
- **`noscript.gif`** (the `<noscript>` fallback for JS-disabled visitors) — has **no query string**, so all hits share one cache key and were edge-deduped across a ~600s window → **undercounting that (rare) cohort**. Pre-proxy this pixel went straight to SA, so it's a small regression for JS-disabled visitors only.

## Fix

Set **`CDN-Cache-Control: no-store`** on all collection responses (success + noop paths). That header controls Cloudflare's **edge** TTL independently of the browser `Cache-Control` — the same pattern `functions/_middleware.ts` already uses to keep `/` uncached. This makes the Function's `no-store` intent authoritative at the edge and eliminates the `noscript.gif` dedup.

## Scope

- `functions/simple/[[path]].ts` — add `CDN-Cache-Control: no-store` to `silentGif`, `silentNoOp` (204), and the success response.
- `tests/unit/sa-collection.test.ts` — assert the header on both the noop and success paths.

## Verification

`npm run build` ✓ · SA suites ✓ (15 tests). The end-to-end analytics chain was already proven working in prod via a real-browser (Playwright) run — `/sa` 200, pageview + event pixels `202`, `/append` `202`, zero CSP violations; this only tightens edge-cache behavior for the noscript path.

**Impact:** negligible (JS-disabled cohort only); shipping it because it makes the code behave as written. Merging → prod deploy on self-hosted.
