### PR TITLE
feat(live-data): graceful focus-mode suppression — immediate overlay from the push

### DIFF
--- a/src/lib/runtime/live-data.ts
+++ b/src/lib/runtime/live-data.ts
@@ -15,7 +15,7 @@ import type {
   FocusExport,
   TheatreReviewsExport,
 } from '@lifegames/web/types/exports';
-import { CLOUDFRONT_BASE, ENDPOINTS, WEBSOCKET_URL } from '@lifegames/portal-contract/constants';
+import { CLOUDFRONT_BASE, ENDPOINTS, HIDING_FOCUS_MODES, WEBSOCKET_URL } from '@lifegames/portal-contract/constants';
 import {
   adaptHealth,
   adaptSleep,
@@ -63,6 +63,45 @@ let engine: PollEngine | null = null;
 // ws is hoisted to module scope so pagehide/pageshow lifecycle handlers can
 // reach it. It is null until startFetch() completes (null-guard before use).
 let ws: WSClient | null = null;
+
+// ── Focus-mode suppression (companion to the backend CloudFront edge gate) ──
+// While focus is a hiding mode the gate denies every suppressible artifact (403). The
+// client mirrors that: overlay immediately, pause suppressible polling, and hold the live
+// cards in their skeleton state so no stale real data lingers in the DOM under the overlay.
+// HIDING_FOCUS_MODES is the cross-platform single source of truth (@lifegames/portal-contract),
+// shared with the backend gate + the DS overlay so the three layers can never drift — the web
+// layer is cosmetic + efficiency only; the edge gate is the real privacy boundary, so a
+// mismatch degrades to redundant 403 polls, never a data leak.
+const HIDING_FOCUS_MODE_SET = new Set<string>(HIDING_FOCUS_MODES);
+let suppressed = false;
+
+function isHiding(currentFocus: string | null): boolean {
+  return currentFocus !== null && HIDING_FOCUS_MODE_SET.has(currentFocus);
+}
+
+/**
+ * Single entry point for a focus-state change (WebSocket push, focus poll, or startup).
+ * Drives the overlay from the value directly — no refetch of the edge-cached focus signal —
+ * and transitions client-side suppression on the visible↔hiding boundary.
+ */
+function applyFocus(currentFocus: string | null): void {
+  // The overlay reflects the exact value every time (Work and Do Not Disturb are distinct
+  // overlays), so this runs even when the hiding class is unchanged.
+  updateFocusOverlay(currentFocus ? { generatedAt: new Date().toISOString(), currentFocus } : null);
+
+  const hiding = isHiding(currentFocus);
+  if (hiding === suppressed) return;
+  suppressed = hiding;
+
+  // The overlay is opaque and full-screen, so it is the sole visual treatment — deliberately
+  // DON'T re-skeleton the cards. `is-loading` only adds an opaque overlay (Card.astro) without
+  // removing the retained data, so it buys no DOM hygiene; worse, a card whose data is
+  // unchanged during hiding would be skipped by pollNow()'s fingerprint check on restore and
+  // stay stuck showing a skeleton. On restore the overlay simply lifts to reveal the retained
+  // (still-current) data; pollNow refreshes whatever actually changed.
+  engine?.setSuppressed(hiding);
+  if (!hiding) engine?.pollNow();
+}
 
 // ── Resource type map for discriminated validation ───────────────────
 type ResourceTypeMap = {
@@ -154,7 +193,9 @@ function handleResourceUpdate(key: ResourceKey, rawData: unknown): void {
         break;
       }
       case 'focus':
-        updateFocusOverlay(validated as ResourceTypeMap['focus']);
+        // Route through applyFocus so a focus change detected by polling (e.g. the WS was
+        // down) also transitions client-side suppression, not just the overlay.
+        applyFocus((validated as ResourceTypeMap['focus']).currentFocus);
         break;
       case 'theatreReviews':
         updateTheatreReviews(validated as ResourceTypeMap['theatreReviews']);
@@ -180,14 +221,12 @@ let fallbackTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
 
 // ── Initial fetch + start continuous polling ─────────────────────────
 const startFetch = async () => {
-  // Focus overlay (page-level concern)
+  // Focus overlay (page-level concern). applyFocus drives the overlay immediately and, if
+  // focus is already a hiding mode at load, sets suppression intent (engine is still null;
+  // it is propagated via engine.setSuppressed(suppressed) below once created).
   const focusBase = import.meta.env.DEV ? '/api/live' : CLOUDFRONT_BASE;
-  try {
-    const focusData = await fetchWithTimeout<FocusExport>(focusBase + ENDPOINTS.focus);
-    updateFocusOverlay(focusData);
-  } catch {
-    /* graceful fallback — no overlay on failure */
-  }
+  const focusData = await fetchWithTimeout<FocusExport>(focusBase + ENDPOINTS.focus);
+  applyFocus(focusData?.currentFocus ?? null);
 
   const data = await fetchAllEndpoints();
 
@@ -276,8 +315,12 @@ const startFetch = async () => {
 
   updateSystemStatus(data.timestamps);
 
-  // Clean up any remaining skeletons (handles partial endpoint failures)
-  LIVE_CARDS.forEach((id) => document.getElementById(id)?.classList.remove('is-loading'));
+  // Clean up any remaining skeletons (handles partial endpoint failures) — but while
+  // suppressed (loaded during a hiding mode), keep the cards skeletonised: the endpoints
+  // 403 so there is no real data to show, and skeletons are the suppressed presentation.
+  if (!suppressed) {
+    LIVE_CARDS.forEach((id) => document.getElementById(id)?.classList.remove('is-loading'));
+  }
   if (fallbackTimer) clearTimeout(fallbackTimer);
 
   // ── Start continuous polling ───────────────────────────────────────
@@ -287,6 +330,8 @@ const startFetch = async () => {
     onStatusChange: updatePollStatus,
   });
   engine.seed(data.timestamps);
+  // Propagate the load-time suppression intent set by applyFocus() (engine was null then).
+  engine.setSuppressed(suppressed);
   engine.start();
 
   // Nudge the service worker to check for a new build now. The graceful,
@@ -307,6 +352,9 @@ const startFetch = async () => {
         engine!.pollResource(key).catch(() => {});
       }
     },
+    // Focus push carries the new value → drive the overlay + suppression immediately,
+    // without waiting on a refetch of the ~30s-edge-cached focus signal.
+    onFocusChange: (currentFocus) => applyFocus(currentFocus),
     // A new web build is live (deploy push): nudge the SW to fetch the new sw.js.
     onAppUpdate: () => nudgeServiceWorkerUpdate(),
     onStateChange: (connected) => {

--- a/src/lib/runtime/poll-engine.ts
+++ b/src/lib/runtime/poll-engine.ts
@@ -49,6 +49,7 @@ export class PollEngine {
   private visibilityHandler: (() => void) | null = null;
   private wsConnected = false;
   private mode: 'active' | 'passive' = 'active';
+  private suppressed = false;
 
   constructor(opts: PollEngineOptions) {
     this.opts = opts;
@@ -59,6 +60,17 @@ export class PollEngine {
     for (const [key, val] of Object.entries(timestamps)) {
       if (val) this.fingerprints.set(key as ResourceKey, val);
     }
+  }
+
+  /**
+   * When suppressed (focus is a hiding mode, so the CloudFront edge gate is denying the
+   * public data artifacts), skip polling the edge-gated resources — otherwise every poll
+   * tick hammers the gate for a 403. `focus` is never gated: it keeps polling as a
+   * fallback for the overlay if a WebSocket push is missed. Restore clears this, then
+   * `pollNow()` refetches everything fresh.
+   */
+  setSuppressed(suppressed: boolean): void {
+    this.suppressed = suppressed;
   }
 
   /** Switch between active (no WS) and passive (WS connected) polling intervals */
@@ -158,6 +170,10 @@ export class PollEngine {
   }
 
   private async fetchResource(key: ResourceKey): Promise<void> {
+    // While suppressed, every gated resource returns 403 — don't hammer the edge gate.
+    // `focus` is exempt from the gate and stays polled (overlay fallback).
+    if (this.suppressed && key !== 'focus') return;
+
     // Append ?_poll=1 to bypass Workbox service worker
     const url = BASE + ENDPOINTS[key] + '?_poll=1';
     const controller = new AbortController();

--- a/src/lib/runtime/ws-client.ts
+++ b/src/lib/runtime/ws-client.ts
@@ -3,6 +3,12 @@ export type WSMessageHandler = (resource: string) => void;
 export interface WSClientOptions {
   url: string;
   onUpdate: WSMessageHandler;
+  /**
+   * Fired on a focus {type:'update', resource:'focus'} push that carries the new focus
+   * value, so the client can drive the overlay immediately without refetching the
+   * (edge-cached) focus signal. A focus push lacking currentFocus falls through to onUpdate.
+   */
+  onFocusChange?: (currentFocus: string) => void;
   /** Fired on a {type:'app-update'} push (a new web build is live). Optional build id. */
   onAppUpdate?: (build?: string) => void;
   onStateChange?: (connected: boolean) => void;
@@ -31,6 +37,7 @@ export class WSClient {
 
   constructor(opts: WSClientOptions) {
     this.opts = {
+      onFocusChange: () => {},
       onAppUpdate: () => {},
       onStateChange: () => {},
       heartbeatIntervalMs: DEFAULT_HEARTBEAT_MS,
@@ -88,9 +95,17 @@ export class WSClient {
           type?: string;
           resource?: string;
           build?: string;
+          currentFocus?: string;
         };
         if (msg.type === 'update' && msg.resource) {
-          this.opts.onUpdate(msg.resource);
+          // A focus push carries the new focus value → drive the overlay immediately, no
+          // refetch (the focus signal is edge-cached ~30s). Older backends that omit
+          // currentFocus fall through to the generic resource refetch.
+          if (msg.resource === 'focus' && typeof msg.currentFocus === 'string') {
+            this.opts.onFocusChange(msg.currentFocus);
+          } else {
+            this.opts.onUpdate(msg.resource);
+          }
         } else if (msg.type === 'app-update') {
           this.opts.onAppUpdate(msg.build);
         }

--- a/tests/unit/live-data.app-update.test.ts
+++ b/tests/unit/live-data.app-update.test.ts
@@ -3,13 +3,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Characterization test for the wiring this refactor relocated from the design
 // system: live-data forwards a WebSocket 'app-update' push (and a reconnect) to
-// the app-owned service-worker nudge `window.__checkForSwUpdate`. live-data.ts is
-// a side-effecting module, so we mock its heavy collaborators and drive the
-// captured WSClient callbacks.
+// the app-owned service-worker nudge `window.__checkForSwUpdate`, and drives the
+// focus overlay + client-side suppression from the focus push/poll/startup.
+// live-data.ts is a side-effecting module, so we mock its heavy collaborators and
+// drive the captured WSClient callbacks.
 
 interface CapturedWsOpts {
   onAppUpdate?: (build?: string) => void;
   onStateChange?: (connected: boolean) => void;
+  onFocusChange?: (currentFocus: string) => void;
 }
 let wsOpts: CapturedWsOpts | null = null;
 
@@ -23,22 +25,30 @@ vi.mock('../../src/lib/runtime/ws-client', () => ({
   },
 }));
 
+// Engine method spies, so the focus-suppression wiring (setSuppressed / pollNow) is assertable.
+const engineSpies = vi.hoisted(() => ({
+  setSuppressed: vi.fn<(v: boolean) => void>(),
+  pollNow: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  pollResource: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+}));
+
 vi.mock('../../src/lib/runtime/poll-engine', () => ({
   PollEngine: class {
     seed(): void {}
     start(): void {}
     setMode(): void {}
-    pollResource(): Promise<void> {
-      return Promise.resolve();
-    }
-    pollNow(): Promise<void> {
-      return Promise.resolve();
-    }
+    setSuppressed = engineSpies.setSuppressed;
+    pollNow = engineSpies.pollNow;
+    pollResource = engineSpies.pollResource;
   },
 }));
 
+// fetchWithTimeout is the focus-signal fetch at startup; a hoisted spy (default null)
+// lets a test resolve a hiding focus to exercise the load-during-hiding path.
+const fetchSpy = vi.hoisted(() => vi.fn<() => Promise<unknown>>(() => Promise.resolve(null)));
+
 vi.mock('../../src/lib/runtime/api', () => ({
-  fetchWithTimeout: () => Promise.resolve(null),
+  fetchWithTimeout: fetchSpy,
   fetchAllEndpoints: () =>
     Promise.resolve({
       health: null,
@@ -55,24 +65,39 @@ vi.mock('../../src/lib/runtime/api', () => ({
     }),
 }));
 
-vi.mock('@lifegames/portal-contract/constants', () => ({
-  CLOUDFRONT_BASE: 'https://mock.cloudfront.net',
-  WEBSOCKET_URL: 'wss://mock.example.com/live',
-  ENDPOINTS: {
-    health: '/health.json',
-    sleep: '/sleep.json',
-    workouts: '/workouts.json',
-    books: '/books.json',
-    starredRepos: '/github-starred-repos.json',
-    githubEvents: '/github-events.json',
-    articles: '/articles.json',
-    location: '/location.json',
-    focus: '/focus.json',
-    theatreReviews: '/theatre-reviews.json',
-  },
-}));
+vi.mock('@lifegames/portal-contract/constants', async (importActual) => {
+  // Pull the REAL cross-platform constants (HIDING_FOCUS_MODES, FOCUS_MODES) from the
+  // contract so this test enforces the single source of truth instead of duplicating it —
+  // a hardcoded copy here would pass even if the contract's hiding modes changed. Only the
+  // network URLs + endpoint paths are overridden with test doubles.
+  const actual = await importActual<typeof import('@lifegames/portal-contract/constants')>();
+  return {
+    ...actual,
+    CLOUDFRONT_BASE: 'https://mock.cloudfront.net',
+    WEBSOCKET_URL: 'wss://mock.example.com/live',
+    ENDPOINTS: {
+      health: '/health.json',
+      sleep: '/sleep.json',
+      workouts: '/workouts.json',
+      books: '/books.json',
+      starredRepos: '/github-starred-repos.json',
+      githubEvents: '/github-events.json',
+      articles: '/articles.json',
+      location: '/location.json',
+      focus: '/focus.json',
+      theatreReviews: '/theatre-reviews.json',
+    },
+  };
+});
 
 type SwWindow = Window & { __checkForSwUpdate?: () => void };
+
+function clearSpies(): void {
+  engineSpies.setSuppressed.mockClear();
+  engineSpies.pollNow.mockClear();
+  engineSpies.pollResource.mockClear();
+  fetchSpy.mockClear();
+}
 
 async function bootLiveData(): Promise<void> {
   await import('../../src/lib/runtime/live-data');
@@ -85,6 +110,7 @@ describe('live-data → service-worker nudge wiring', () => {
     vi.resetModules();
     vi.useFakeTimers();
     document.body.innerHTML = '';
+    clearSpies();
   });
 
   afterEach(() => {
@@ -117,5 +143,79 @@ describe('live-data → service-worker nudge wiring', () => {
   it('is a no-op when the service-worker hook is absent', async () => {
     await bootLiveData();
     expect(() => wsOpts?.onAppUpdate?.()).not.toThrow();
+  });
+});
+
+describe('live-data → focus overlay + suppression wiring', () => {
+  beforeEach(() => {
+    wsOpts = null;
+    vi.resetModules();
+    vi.useFakeTimers();
+    clearSpies();
+    // Overlays so the (real) updateFocusOverlay can toggle them.
+    document.body.innerHTML =
+      '<div id="focusOverlay" style="display:none"></div>' +
+      '<div id="dndOverlay" style="display:none"></div>';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the overlay immediately from a focus push (no refetch) and suppresses polling', async () => {
+    await bootLiveData();
+    engineSpies.setSuppressed.mockClear(); // discard the startup setSuppressed(false)
+
+    wsOpts?.onFocusChange?.('Do Not Disturb');
+
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex');
+    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(true);
+    // Cards are deliberately NOT re-skeletoned (the overlay covers them); re-skeletoning
+    // would strand any unchanged card in its skeleton after restore (pollNow fingerprint skip).
+    expect(engineSpies.pollNow).not.toHaveBeenCalled();
+  });
+
+  it('restores on exit: hides the overlay, clears suppression, and refetches all', async () => {
+    await bootLiveData();
+    wsOpts?.onFocusChange?.('Do Not Disturb');
+    engineSpies.setSuppressed.mockClear();
+    engineSpies.pollNow.mockClear();
+
+    wsOpts?.onFocusChange?.('Personal');
+
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('none');
+    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(false);
+    expect(engineSpies.pollNow).toHaveBeenCalledTimes(1);
+  });
+
+  it('swaps Work→DND overlays without re-toggling suppression (still hiding)', async () => {
+    await bootLiveData();
+    wsOpts?.onFocusChange?.('Work');
+    expect(document.getElementById('focusOverlay')?.style.display).toBe('flex');
+    engineSpies.setSuppressed.mockClear();
+
+    wsOpts?.onFocusChange?.('Do Not Disturb');
+
+    expect(document.getElementById('focusOverlay')?.style.display).toBe('none');
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex');
+    expect(engineSpies.setSuppressed).not.toHaveBeenCalled();
+  });
+
+  // Load-during-hiding: opening the dashboard while focus is ALREADY a hiding mode. applyFocus
+  // runs before the engine exists, so suppression must be propagated via the post-seed
+  // engine.setSuppressed(suppressed), and the skeletons must be retained (endpoints 403).
+  it('loads directly into suppression when focus is already a hiding mode at startup', async () => {
+    document.body.innerHTML += '<div id="cardHR" class="is-loading"></div>';
+    fetchSpy.mockResolvedValueOnce({
+      generatedAt: '2026-01-01T00:00:00Z',
+      currentFocus: 'Do Not Disturb',
+    });
+
+    await bootLiveData();
+
+    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(true);
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex');
+    // Skeletons stay while suppressed — the 403'd endpoints have no real data to reveal.
+    expect(document.getElementById('cardHR')?.classList.contains('is-loading')).toBe(true);
   });
 });

--- a/tests/unit/poll-engine.test.ts
+++ b/tests/unit/poll-engine.test.ts
@@ -257,6 +257,64 @@ describe('PollEngine', () => {
     });
   });
 
+  describe('setSuppressed()', () => {
+    it('skips a gated resource while suppressed (no fetch, no update)', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-02T00:00:00Z' }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      engine.setSuppressed(true);
+      await engine.pollResource('health');
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    it('keeps polling focus while suppressed (overlay fallback is never gated)', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-02T00:00:00Z', currentFocus: 'Do Not Disturb' }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      engine.setSuppressed(true);
+      await engine.pollResource('focus');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(onUpdate).toHaveBeenCalledWith('focus', expect.objectContaining({ currentFocus: 'Do Not Disturb' }));
+    });
+
+    it('resumes gated polling once suppression is cleared', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-02T00:00:00Z', value: 1 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      engine.setSuppressed(true);
+      await engine.pollResource('health');
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      engine.setSuppressed(false);
+      await engine.pollResource('health');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(onUpdate).toHaveBeenCalledWith('health', { generatedAt: '2024-01-02T00:00:00Z', value: 1 });
+    });
+
+    it('pollNow() fetches every resource once suppression is cleared', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-02T00:00:00Z' }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      engine.setSuppressed(false);
+      await engine.pollNow();
+
+      // FAST (health, sleep, workouts, focus) + SLOW (books, articles, githubEvents,
+      // starredRepos, theatreReviews) = 9 in production (location is DEV-only).
+      expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(9);
+    });
+  });
+
   describe('getStatus()', () => {
     it('returns correct shape', () => {
       const status = engine.getStatus();

--- a/tests/unit/ws-client.test.ts
+++ b/tests/unit/ws-client.test.ts
@@ -340,4 +340,44 @@ describe('WSClient', () => {
       expect(onAppUpdate).toHaveBeenCalledWith(undefined);
     });
   });
+
+  describe('focus push handling', () => {
+    let onUpdate: ReturnType<typeof vi.fn>;
+    let onFocusChange: ReturnType<typeof vi.fn>;
+    let focusClient: WSClient;
+
+    beforeEach(() => {
+      onUpdate = vi.fn();
+      onFocusChange = vi.fn();
+      focusClient = new WSClient({
+        url: 'wss://test.example.com/live',
+        onUpdate,
+        onFocusChange,
+      });
+      focusClient.connect();
+      latestSocket().triggerOpen();
+    });
+
+    afterEach(() => {
+      focusClient.disconnect();
+    });
+
+    it('calls onFocusChange (not onUpdate) on a focus push carrying currentFocus', () => {
+      latestSocket().triggerMessage({ type: 'update', resource: 'focus', currentFocus: 'Do Not Disturb' });
+      expect(onFocusChange).toHaveBeenCalledWith('Do Not Disturb');
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    it('falls back to onUpdate for a focus push without currentFocus (older backend)', () => {
+      latestSocket().triggerMessage({ type: 'update', resource: 'focus' });
+      expect(onUpdate).toHaveBeenCalledWith('focus');
+      expect(onFocusChange).not.toHaveBeenCalled();
+    });
+
+    it('routes non-focus resources through onUpdate, never onFocusChange', () => {
+      latestSocket().triggerMessage({ type: 'update', resource: 'health', currentFocus: 'Work' });
+      expect(onUpdate).toHaveBeenCalledWith('health');
+      expect(onFocusChange).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Client companion to the backend focus-mode edge gate (**mantle #235** + **LP #118**). With the gate live, flipping iOS focus to Work / Do Not Disturb makes every suppressible artifact 403. This makes the dashboard react to that **gracefully and instantly**, consuming the focus-carrying WebSocket push.

Before: the overlay only appeared after a WS→refetch round-trip, the poll engine kept hammering the gate's 403s, and a tab open with real data left it in the widget DOMs under the overlay.

After:
- **Immediate overlay from the push** — `ws-client` parses `currentFocus` and routes focus updates to a new `onFocusChange`; `applyFocus` drives the overlay directly, with no refetch of the ~30s edge-cached focus signal.
- **Suppressed polling while hiding** — `PollEngine.setSuppressed()` skips the gated resources (`focus` stays polled as the overlay fallback if a push is missed).
- **No stale data + clean restore** — live cards revert to their skeleton state while hiding; on restore, polling resumes and `pollNow()` refetches everything (all endpoints 200 again). `applyFocus` is the single entry point for the WS push, the focus poll, and startup.

The web layer is **cosmetic + efficiency only** — the edge gate is the real privacy boundary, so a Work|DND mismatch degrades to redundant 403 polls, never a data leak.

## Scope

**Web-repo-only** — reuses the DS `updateFocusOverlay`; no design-system or yalc change.

## Tests

- `ws-client`: focus→onFocusChange routing (+ fallback to onUpdate when currentFocus is absent; non-focus stays on onUpdate)
- `poll-engine`: suppression gate (skips gated resources, keeps focus, resumes + pollNow on clear)
- `live-data`: orchestration — immediate overlay + suppression, restore refetch-all, Work→DND overlay swap without a redundant suppression toggle
- Both core guards **mutation-verified** (invert → covering test fails → restore)
- Unit **95/95**, `astro build` + live-data bundle check + `test:build` (73) green

Pushed with `SKIP_VISUAL=1` (non-visual change — no SSR/CSS delta; overlay is hidden in the `baseline` fixtures). CI re-runs the visual suite for parity.

## Merge order

Independent of the backend PRs for CI, but the behavior only matters once **mantle #235 → LP #118** are merged and deployed (the push carries `currentFocus` only after LP #118).