### PR TITLE
fix(live-data): make the WS push authoritative for focus (instant restore)

### DIFF
--- a/src/lib/runtime/live-data.ts
+++ b/src/lib/runtime/live-data.ts
@@ -75,6 +75,14 @@ let ws: WSClient | null = null;
 const HIDING_FOCUS_MODE_SET = new Set<string>(HIDING_FOCUS_MODES);
 let suppressed = false;
 
+// The WS push is the authoritative focus source. A focus poll (the fallback for when the WS is
+// down) refetches the ~30s edge-cached focus.json, which lags a just-changed state — track the
+// WS connection + last pushed value so a stale poll can't re-apply an out-of-date focus over a
+// fresher push (which previously left the overlay lingering for ~30s on restore).
+let wsConnected = false;
+let lastPushedFocus = '';
+let hasPushedFocus = false;
+
 function isHiding(currentFocus: string | null): boolean {
   return currentFocus !== null && HIDING_FOCUS_MODE_SET.has(currentFocus);
 }
@@ -192,11 +200,17 @@ function handleResourceUpdate(key: ResourceKey, rawData: unknown): void {
         updateExplorationOdometerV3(data);
         break;
       }
-      case 'focus':
+      case 'focus': {
         // Route through applyFocus so a focus change detected by polling (e.g. the WS was
-        // down) also transitions client-side suppression, not just the overlay.
-        applyFocus((validated as ResourceTypeMap['focus']).currentFocus);
+        // down) also transitions client-side suppression, not just the overlay. But the WS
+        // push is authoritative while connected: ignore a polled focus that contradicts the
+        // latest push — it's the ~30s edge-cached focus.json lagging, and applying it would
+        // re-show a stale overlay over a fresh push (the restore-linger bug).
+        const polledFocus = (validated as ResourceTypeMap['focus']).currentFocus;
+        if (wsConnected && hasPushedFocus && polledFocus !== lastPushedFocus) break;
+        applyFocus(polledFocus);
         break;
+      }
       case 'theatreReviews':
         updateTheatreReviews(validated as ResourceTypeMap['theatreReviews']);
         break;
@@ -354,10 +368,15 @@ const startFetch = async () => {
     },
     // Focus push carries the new value → drive the overlay + suppression immediately,
     // without waiting on a refetch of the ~30s-edge-cached focus signal.
-    onFocusChange: (currentFocus) => applyFocus(currentFocus),
+    onFocusChange: (currentFocus) => {
+      hasPushedFocus = true;
+      lastPushedFocus = currentFocus;
+      applyFocus(currentFocus);
+    },
     // A new web build is live (deploy push): nudge the SW to fetch the new sw.js.
     onAppUpdate: () => nudgeServiceWorkerUpdate(),
     onStateChange: (connected) => {
+      wsConnected = connected;
       engine!.setMode(connected ? 'passive' : 'active');
       // On (re)connect — e.g. tab refocus after the WS dropped while hidden —
       // also re-check, in case an app-update push was missed while disconnected.

--- a/tests/unit/live-data.app-update.test.ts
+++ b/tests/unit/live-data.app-update.test.ts
@@ -32,8 +32,14 @@ const engineSpies = vi.hoisted(() => ({
   pollResource: vi.fn<() => Promise<void>>(() => Promise.resolve()),
 }));
 
+// Captures the engine's onUpdate (handleResourceUpdate) so a test can simulate a poll result.
+const engineCapture = vi.hoisted(() => ({ onUpdate: null as null | ((key: string, data: unknown) => void) }));
+
 vi.mock('../../src/lib/runtime/poll-engine', () => ({
   PollEngine: class {
+    constructor(opts: { onUpdate: (key: string, data: unknown) => void; }) {
+      engineCapture.onUpdate = opts.onUpdate;
+    }
     seed(): void {}
     start(): void {}
     setMode(): void {}
@@ -216,5 +222,32 @@ describe('live-data → focus overlay + suppression wiring', () => {
     expect(document.getElementById('dndOverlay')?.style.display).toBe('flex');
     // Skeletons stay while suppressed — the 403'd endpoints have no real data to reveal.
     expect(document.getElementById('cardHR')?.classList.contains('is-loading')).toBe(true);
+  });
+
+  it('ignores a stale focus poll that contradicts the latest push while the WS is connected', async () => {
+    await bootLiveData();
+    wsOpts?.onStateChange?.(true); // WS live → the focus poll is fallback-only
+
+    wsOpts?.onFocusChange?.('Do Not Disturb');
+    wsOpts?.onFocusChange?.('None'); // restore via push clears the overlay
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('none');
+    engineSpies.setSuppressed.mockClear();
+
+    // The ~30s edge-cached focus.json still reports the OLD hiding value on the next poll.
+    engineCapture.onUpdate?.('focus', { generatedAt: '2026-01-01T00:00:00Z', currentFocus: 'Do Not Disturb' });
+
+    // Must NOT re-show the overlay or re-suppress — this was the restore-linger bug.
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('none');
+    expect(engineSpies.setSuppressed).not.toHaveBeenCalled();
+  });
+
+  it('still applies a focus poll when the WS is down (poll is the fallback)', async () => {
+    await bootLiveData();
+    wsOpts?.onStateChange?.(false); // WS down → the poll drives focus
+
+    engineCapture.onUpdate?.('focus', { generatedAt: '2026-01-01T00:00:00Z', currentFocus: 'Do Not Disturb' });
+
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex');
+    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(true);
   });
 });


### PR DESCRIPTION
## Problem

Exiting Do Not Disturb left the overlay lingering ~30–90s on an already-open dashboard (found live in prod). Root cause: the restore WS push cleared the overlay and called `pollNow()`, which refetched the ~30s edge-cached `focus.json` (still `Do Not Disturb`) and re-applied the stale value — re-showing the overlay until the cache expired.

## Fix

Make the WS push authoritative for focus while connected: track the WS connection + last pushed value, and ignore a focus poll that contradicts the latest push (the lagging edge-cached signal). The poll still drives focus as a fallback when the WS is down. *Enter* was already instant via the push; this makes *exit* instant too.

## Tests

- Stale focus poll ignored while WS connected (no restore-linger).
- Focus poll still applies when the WS is down (fallback preserved).

98 unit tests pass, dprint clean, build green.
