### PR TITLE
feat(security): Trusted Types report-only telemetry

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -32,6 +32,14 @@ const CSP = [
 // that name. report-uri is retained as a fallback for older browsers (Firefox <130, Safari <17).
 const REPORTING_ENDPOINTS = 'csp-endpoint="https://jonathanlloyd.me/api/csp-report"';
 
+// Trusted Types telemetry, REPORT-ONLY (non-enforcing). Every script is first-party
+// (script-src 'self') with no user-input XSS surface, so this does NOT enforce
+// require-trusted-types-for -- it drains DOM injection-sink violations to the same
+// /api/csp-report collector to scope a possible future enforcement. Review the reports,
+// then remove this or promote the directive into the enforced CSP. Expect roughly one
+// report per innerHTML sink while it runs.
+const CSP_REPORT_ONLY = "require-trusted-types-for 'script'; report-uri /api/csp-report; report-to csp-endpoint";
+
 const LINK_HEADER = [
   '</llms.txt>; rel="describedby"; type="text/plain"',
   '</.well-known/api-catalog>; rel="api-catalog"',
@@ -77,6 +85,7 @@ export async function onRequest(context: PagesContext): Promise<Response> {
   // Security headers
   headers.set('Content-Security-Policy', CSP);
   headers.set('Reporting-Endpoints', REPORTING_ENDPOINTS);
+  headers.set('Content-Security-Policy-Report-Only', CSP_REPORT_ONLY);
   headers.set('X-Content-Type-Options', 'nosniff');
   headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   // HSTS: 2-year max-age + subdomains. Preload intentionally omitted -- owner-gated process.

--- a/tests/smoke/home.smoke.ts
+++ b/tests/smoke/home.smoke.ts
@@ -201,6 +201,18 @@ test.describe('production home dashboard', () => {
     expect(contentType, 'api-catalog wrong content-type').toContain('application/linkset+json');
   });
 
+  test('Trusted Types telemetry ships as a report-only header', async ({ page }) => {
+    // The report-only policy is non-enforcing; it only drains DOM injection-sink
+    // violations to /api/csp-report. Assert it reaches the browser on the live path
+    // (set unconditionally in functions/_middleware.ts alongside the enforced CSP).
+    const res = await page.request.get('/');
+    expect(res.status(), 'home page did not return 200').toBe(200);
+    const reportOnly = res.headers()['content-security-policy-report-only'] || '';
+    expect(reportOnly, 'Trusted Types report-only header missing').toContain(
+      "require-trusted-types-for 'script'",
+    );
+  });
+
   test('version.json reports the deployed build', async ({ page }) => {
     const res = await page.request.get('/version.json');
     expect(res.status(), '/version.json did not return HTTP 200').toBe(200);


### PR DESCRIPTION
## What

Adds a non-enforcing `Content-Security-Policy-Report-Only: require-trusted-types-for 'script'` header to the Pages middleware, plus a smoke assertion that it ships.

## Why

The 2026-06-24 specification.website checklist audit deferred Trusted Types as a "free follow-up once the CSP report endpoint exists." That endpoint (`/api/csp-report`, added in the same round) is now live, so this report-only probe costs nothing and surfaces exactly which DOM injection sinks would break under a future enforcing policy.

It is **non-enforcing** by design: all scripts are first-party (`script-src 'self'`) with no user-input XSS surface, so enforcement stays declined. This only gathers telemetry.

## Changes

- `functions/_middleware.ts` — new `CSP_REPORT_ONLY` policy, set on every response; drains to the existing `/api/csp-report` collector via the already-present `Reporting-Endpoints` header.
- `tests/smoke/home.smoke.ts` — assert the report-only header reaches the browser on `/` (matches the repo's post-deploy live-smoke philosophy).

## Testing

- `dprint check` clean on both files.
- Type-trivial (`Headers.set(string, string)`); no existing test asserts the security-header set, so nothing regresses.
- The new smoke assertion runs against the deployed preview/prod after this lands.

## Deploy / operational notes

- Opening this PR triggers a **Cloudflare Pages preview** deploy; production deploys only on merge to `main`.
- The report-only policy is intentionally noisy (~one report per `innerHTML` sink), viewable via `wrangler pages deployment tail`. Treat it as a **time-boxed telemetry probe** — review the reports, then remove it or promote `require-trusted-types-for` into the enforced CSP.
