### PR TITLE
feat(discovery): conform agent-card (A2A v1.0) + ai-catalog (ARD 1.0) + document surface

### DIFF
--- a/docs/discovery-surface.md
+++ b/docs/discovery-surface.md
@@ -1,0 +1,86 @@
+# Discovery & Well-Known Surface
+
+How `jonathanlloyd.me` makes itself discoverable to humans, search engines, and AI
+agents. Every file below is **generated or route-emitted** (never hand-maintained as a
+static blob), and every agent-facing file is **pinned to a named spec version** with the
+date it was last verified — so drift from a moving spec is detectable rather than silent.
+
+## At a glance
+
+| File                                               | Purpose                                                     | Produced by                                                             | Spec / version (verified)              |
+| -------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------- |
+| `/robots.txt`                                      | Crawl policy incl. per-AI-bot rules + Content-Signal        | `src/pages/robots.txt.ts`                                               | robots.txt + Content-Signal            |
+| `/sitemap-index.xml`                               | URL discovery for search engines                            | `@astrojs/sitemap` (`astro.config.mjs`)                                 | Sitemaps 0.9                           |
+| `/humans.txt`                                      | Human authorship credits                                    | `src/pages/humans.txt.ts`                                               | humanstxt.org                          |
+| `/feed.xml`, `/feed.json`                          | Content feeds                                               | `functions/feed.xml.ts`, `functions/feed.json.ts`                       | RSS 2.0 / JSON Feed 1.1                |
+| `/llms.txt`, `/llms-full.txt`, per-page `index.md` | LLM-ingestible corpus + `Accept: text/markdown` negotiation | `functions/llms.txt.ts`, CloudFront compose, `functions/_middleware.ts` | llms.txt convention                    |
+| `/.well-known/security.txt`                        | Security contact                                            | static                                                                  | RFC 9116                               |
+| `/.well-known/api-catalog`                         | API linkset                                                 | `functions/_middleware.ts` (content-type)                               | RFC 9727                               |
+| `/.well-known/webfinger`                           | Fediverse alias (JRD)                                       | static + `_middleware.ts`                                               | RFC 7033                               |
+| `/.well-known/mcp/server-card.json`                | MCP server descriptor                                       | `scripts/generate-webmcp.mjs`                                           | MCP server card                        |
+| `/.well-known/agent-skills/index.json`             | Agent Skills discovery index                                | `scripts/generate-webmcp.mjs`                                           | agentskills.io discovery 0.2.0         |
+| `/.well-known/agent-card.json`                     | A2A agent card                                              | `scripts/generate-webmcp.mjs`                                           | **A2A v1.0** (2026-07-07)              |
+| `/.well-known/ai-catalog.json`                     | ARD capability catalog                                      | `scripts/generate-webmcp.mjs`                                           | **ARD `specVersion` 1.0** (2026-07-07) |
+
+## Source of truth
+
+The agent-discovery JSON files (`mcp/server-card.json`, `agent-skills/index.json`,
+`agent-card.json`, `ai-catalog.json`) and `public/js/webmcp.js` are all emitted by
+**`scripts/generate-webmcp.mjs`**, wired into `prebuild`. Do **not** hand-edit the static
+files — they are overwritten on the next build. Change the generator instead.
+
+- **Prose** (names, descriptions, representative queries) comes from `@lifegames/copy`
+  (`identity` + `llm` namespaces) — zero wording is duplicated in the repo.
+- **URLs / identifiers** come from `@lifegames/portal-contract` (`SITE_URL`,
+  `CLOUDFRONT_BASE`, `ENDPOINTS`) so the CDN host never drifts.
+
+Regenerate + verify:
+
+```bash
+npm run generate:webmcp
+# then validate agent-card.json against a2aproject/A2A specification/a2a.proto
+# and ai-catalog.json against agenticresourcediscovery/ard-spec spec/schemas/ai-catalog.schema.json
+```
+
+## Agent-discovery conformance notes
+
+### `agent-card.json` — A2A v1.0
+
+Conforms to the A2A `AgentCard` message in `a2aproject/A2A` `specification/a2a.proto`.
+Required fields present: `name`, `description`, `supportedInterfaces`, `version`,
+`capabilities`, `defaultInputModes`, `defaultOutputModes`, `skills`. There is **no
+top-level `url`** in v1.0 — the endpoint lives inside `supportedInterfaces[]`
+(`url` + `protocolBinding` + `protocolVersion`).
+
+> **Caveat — discovery-only card.** This site is a **read-only data source**, not a live
+> A2A JSON-RPC/gRPC agent. To satisfy the required `supportedInterfaces`, the single
+> interface points at the machine-readable **MCP server-card** (`HTTP+JSON`). Integrators
+> should consume data via the MCP server-card, not by sending A2A tasks. If A2A ever grows
+> a real endpoint, replace this interface entry.
+
+### `ai-catalog.json` — ARD `specVersion` 1.0
+
+Conforms to `agenticresourcediscovery/ard-spec` `spec/schemas/ai-catalog.schema.json`.
+Required: top-level `specVersion` + `entries`; each entry has `identifier` (RFC 8141
+`urn:air:<publisher>:<namespace>:<name>`), `displayName`, `type` (IANA media type), and
+exactly one of `url`/`data`. `host` and each entry are `additionalProperties: false` — no
+stray fields (e.g. the pre-2026-07 files used `name` instead of `displayName`).
+
+> **Caveat — agent-skills entry type.** ARD defines no dedicated media type for an
+> agent-skills index, so that entry is typed `application/json`. The MCP and A2A entries use
+> `application/mcp-server-card+json` and `application/a2a-agent-card+json` respectively.
+
+## Spec-drift watch
+
+These agent-discovery specs are young and moving. Conformance above is **point-in-time
+(2026-07-07)**, not permanent:
+
+- **A2A** cut v1.0 in 2026 (restructured the card into `supportedInterfaces`). Re-check the
+  proto for further field changes.
+- **ARD** is a v0.9 draft whose manifest `specVersion` is `1.0`; field names "may still
+  change," and adoption is near-zero (a 2026-06-18 census found 0/39 major sites serving a
+  discoverable `ai-catalog.json`). This is a first-mover bet.
+- **DNS-AID** and **NLWeb** remain on the _watch_ list — not adopted (individual IETF draft;
+  requires a live LLM endpoint on a paid, non-GA Cloudflare product, respectively).
+
+A recurring issue tracks re-verification of all of the above on a monthly cadence.

--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -2,7 +2,13 @@
   "name": "Human Datastream",
   "description": "Read-only data interface for Jonathan Lloyd's personal dashboard. Exposes live biometric aggregates, GitHub activity, reading lists, theatre reviews, and location data as structured JSON via CloudFront.",
   "version": "1.0.0",
-  "url": "https://jonathanlloyd.me/.well-known/mcp/server-card.json",
+  "supportedInterfaces": [
+    {
+      "url": "https://jonathanlloyd.me/.well-known/mcp/server-card.json",
+      "protocolBinding": "HTTP+JSON",
+      "protocolVersion": "1.0"
+    }
+  ],
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/public/.well-known/ai-catalog.json
+++ b/public/.well-known/ai-catalog.json
@@ -1,14 +1,16 @@
 {
+  "specVersion": "1.0",
   "host": {
     "displayName": "Jonathan Lloyd — Human Datastream",
-    "identifier": "jonathanlloyd.me",
+    "identifier": "did:web:jonathanlloyd.me",
     "documentationUrl": "https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec"
   },
   "entries": [
     {
-      "type": "mcp-server",
+      "identifier": "urn:air:jonathanlloyd.me:server:human-datastream",
+      "displayName": "Human Datastream MCP Server",
+      "type": "application/mcp-server-card+json",
       "url": "https://jonathanlloyd.me/.well-known/mcp/server-card.json",
-      "name": "Human Datastream MCP Server",
       "description": "MCP server card describing read-only access to Jonathan Lloyd's live personal data: biometrics, GitHub activity, reading lists, theatre reviews, and location aggregates.",
       "representativeQueries": [
         "What is Jonathan Lloyd's current heart rate?",
@@ -17,9 +19,10 @@
       ]
     },
     {
-      "type": "agent-skills",
+      "identifier": "urn:air:jonathanlloyd.me:skills:portfolio-expert",
+      "displayName": "Agent Skills Index",
+      "type": "application/json",
       "url": "https://jonathanlloyd.me/.well-known/agent-skills/index.json",
-      "name": "Agent Skills Index",
       "description": "Agent skills discovery index. Includes a portfolio-expert skill with deep technical context about Jonathan Lloyd's engineering background, live data sources, and architectural decisions.",
       "representativeQueries": [
         "Tell me about Jonathan Lloyd's technical background.",
@@ -28,9 +31,10 @@
       ]
     },
     {
-      "type": "a2a-agent",
+      "identifier": "urn:air:jonathanlloyd.me:agent:human-datastream",
+      "displayName": "Human Datastream Agent Card",
+      "type": "application/a2a-agent-card+json",
       "url": "https://jonathanlloyd.me/.well-known/agent-card.json",
-      "name": "Human Datastream Agent Card",
       "description": "A2A agent card for the Human Datastream interface. Declares agent capabilities and the personal-profile skill for agent-to-agent discovery.",
       "representativeQueries": [
         "What can the Human Datastream agent do?",

--- a/scripts/generate-webmcp.mjs
+++ b/scripts/generate-webmcp.mjs
@@ -267,13 +267,24 @@ const agentSkillsPath = join(publicDir, '.well-known', 'agent-skills', 'index.js
 writeFileSync(agentSkillsPath, JSON.stringify(agentSkills, null, 2) + '\n');
 console.log(`Generated ${agentSkillsPath}`);
 
-// Generate agent-card.json — prose from @lifegames/copy; structure/URLs from portal-contract.
-// Replaces the prior hand-authored static file; shape is preserved exactly.
+// Generate agent-card.json — A2A v1.0 AgentCard (normative source: a2aproject/A2A
+// specification/a2a.proto). Prose from @lifegames/copy; structure/URLs from portal-contract.
+// REQUIRED per the proto: name, description, supportedInterfaces, version, capabilities,
+// defaultInputModes, defaultOutputModes, skills. NB: this is a discovery-only card for a
+// READ-ONLY data source — there is no live A2A JSON-RPC endpoint, so the single interface
+// points at the machine-readable MCP server-card. Pinned to A2A v1.0, verified 2026-07-07.
+// See docs/discovery-surface.md.
 const agentCard = {
   name: copyIdentity.site.name,
   description: copyLlm.agentDiscovery.agentCardDescription,
   version: '1.0.0',
-  url: `${SITE_URL}/.well-known/mcp/server-card.json`,
+  supportedInterfaces: [
+    {
+      url: `${SITE_URL}/.well-known/mcp/server-card.json`,
+      protocolBinding: 'HTTP+JSON',
+      protocolVersion: '1.0',
+    },
+  ],
   capabilities: {
     streaming: false,
     pushNotifications: false,
@@ -295,33 +306,43 @@ const agentCardPath = join(publicDir, '.well-known', 'agent-card.json');
 writeFileSync(agentCardPath, JSON.stringify(agentCard, null, 2) + '\n');
 console.log(`Generated ${agentCardPath}`);
 
-// Generate ai-catalog.json — prose from @lifegames/copy; URLs/identifiers from portal-contract.
-// Replaces the prior hand-authored static file; shape is preserved exactly.
+// Generate ai-catalog.json — ARD AI Catalog v1.0 (normative source: agenticresourcediscovery/
+// ard-spec spec/schemas/ai-catalog.schema.json). Prose from @lifegames/copy; URLs/identifiers
+// from portal-contract. REQUIRED: top-level specVersion + entries; each entry needs identifier
+// (RFC 8141 urn:air:<publisher>:<namespace>:<name>), displayName, type (IANA media type), and
+// exactly one of url/data. host + entries are additionalProperties:false — no stray fields.
+// Pinned to ARD specVersion 1.0, verified 2026-07-07. See docs/discovery-surface.md.
+const air = (namespace, name) => `urn:air:jonathanlloyd.me:${namespace}:${name}`;
 const aiCatalog = {
+  specVersion: '1.0',
   host: {
     displayName: copyIdentity.site.fullName,
-    identifier: 'jonathanlloyd.me',
+    identifier: 'did:web:jonathanlloyd.me',
     documentationUrl: 'https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec',
   },
   entries: [
     {
-      type: 'mcp-server',
+      identifier: air('server', 'human-datastream'),
+      displayName: copyLlm.agentDiscovery.aiCatalogMcpName,
+      type: 'application/mcp-server-card+json',
       url: `${SITE_URL}/.well-known/mcp/server-card.json`,
-      name: copyLlm.agentDiscovery.aiCatalogMcpName,
       description: copyLlm.agentDiscovery.aiCatalogMcpDescription,
       representativeQueries: copyLlm.agentDiscovery.aiCatalogMcpQueries,
     },
     {
-      type: 'agent-skills',
+      // ARD defines no dedicated media type for an agent-skills index; typed as generic JSON.
+      identifier: air('skills', 'portfolio-expert'),
+      displayName: copyLlm.agentDiscovery.aiCatalogSkillsName,
+      type: 'application/json',
       url: `${SITE_URL}/.well-known/agent-skills/index.json`,
-      name: copyLlm.agentDiscovery.aiCatalogSkillsName,
       description: copyLlm.agentDiscovery.aiCatalogSkillsDescription,
       representativeQueries: copyLlm.agentDiscovery.aiCatalogSkillsQueries,
     },
     {
-      type: 'a2a-agent',
+      identifier: air('agent', 'human-datastream'),
+      displayName: copyLlm.agentDiscovery.aiCatalogA2aName,
+      type: 'application/a2a-agent-card+json',
       url: `${SITE_URL}/.well-known/agent-card.json`,
-      name: copyLlm.agentDiscovery.aiCatalogA2aName,
       description: copyLlm.agentDiscovery.aiCatalogA2aDescription,
       representativeQueries: copyLlm.agentDiscovery.aiCatalogA2aQueries,
     },


### PR DESCRIPTION
## What

Brings the two agent-discovery well-known files to current-spec conformance, and adds documentation for the whole discovery surface.

## Why

A browser-driven audit found both files were valid JSON but **non-conformant to the current specs** (drift since they were authored June 2026):

- `agent-card.json` used a top-level `url` (not an A2A v1.0 field) and lacked the required `supportedInterfaces` / `protocolVersion`.
- `ai-catalog.json` lacked top-level `specVersion` and per-entry `identifier` (URN) + `displayName`, and used non-IANA `type` values.

## Changes

The static well-known files are **generated**, so the change is in the generator, not the JSON:

- **`scripts/generate-webmcp.mjs`**:
  - **A2A v1.0** (`a2aproject/A2A` → `specification/a2a.proto`): `supportedInterfaces: [{url, protocolBinding, protocolVersion}]`; no top-level `url`.
  - **ARD 1.0** (`agenticresourcediscovery/ard-spec` → `spec/schemas/ai-catalog.schema.json`): `specVersion`, `urn:air:` identifiers, `displayName`, IANA media types (`application/mcp-server-card+json`, `application/a2a-agent-card+json`), `did:web` host identifier.
- Regenerated `public/.well-known/agent-card.json` + `ai-catalog.json`.
- **`docs/discovery-surface.md`**: documents every discovery/well-known file (robots, sitemap, feeds, llms.txt, security.txt, api-catalog, webfinger, MCP, agent-skills, A2A, ARD) with pinned spec versions + a drift-watch note.

## Caveats (documented in the doc)

- The site has **no live A2A endpoint** — it's a read-only data source. The required `supportedInterfaces` points at the MCP server-card (`HTTP+JSON`); it's a discovery-only card.
- ARD defines no media type for an agent-skills index, so that entry is typed `application/json`.

## Testing

- `npm run generate:webmcp` → regenerates; diff limited to the two target files + generator + doc (server-card/agent-skills/webmcp byte-identical).
- Conformance validated against `a2a.proto` (AgentCard + AgentInterface REQUIRED fields) and `ai-catalog.schema.json` (required fields + `urn:air` pattern + `oneOf` url/data + `additionalProperties:false`) — pass.
- Prose unchanged (still `@lifegames/copy`).

## Notes

- Non-visual change (generator + JSON + docs); CI re-runs the visual suite regardless.
- Conformance is **point-in-time (2026-07-07)**; a companion issue tracks monthly re-verification.
