### PR TITLE
feat(analytics): keep Cloudflare Web Analytics first-party (no Safari banner)

### DIFF
--- a/functions/cf-insights.js.ts
+++ b/functions/cf-insights.js.ts
@@ -1,0 +1,59 @@
+// Pages Function: serve the Cloudflare Web Analytics beacon first-party at
+// /cf-insights.js (Cloudflare Pages strips the .ts extension, so
+// functions/cf-insights.js.ts → route /cf-insights.js).
+//
+// Why: Safari's Advanced Tracking & Fingerprinting Protection triggers the
+// "reduce protections" banner on a *domain* blocklist match — static.cloudflare
+// insights.com / cloudflareinsights.com are classified trackers. Re-serving
+// beacon.min.js same-origin removes the third-party script load; the beacon is
+// configured in the page markup (data-cf-beacon send.to) to POST RUM data to the
+// first-party /cdn-cgi/rum endpoint, which Cloudflare handles natively for
+// proxied (orange-clouded) zones. Net result: zero cloudflareinsights.com
+// requests, so no blocklist match and no banner — while keeping full Web
+// Analytics (page views + Core Web Vitals).
+//
+// On upstream failure: returns a harmless empty 200 JS no-op so the page is
+// never affected — never a 5xx (which would trip the smoke console-error check).
+// Mirrors functions/sa.ts (the Simple Analytics first-party proxy).
+
+const BEACON_URL = 'https://static.cloudflareinsights.com/beacon.min.js';
+
+// Minimal Cloudflare Pages Function fetch options — only the cf cache fields used here.
+interface CfRequestInit extends RequestInit {
+  cf?: { cacheTtl?: number; cacheEverything?: boolean; };
+}
+
+function unavailable(): Response {
+  return new Response('/* cf-insights unavailable */', {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/javascript; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function onRequest(): Promise<Response> {
+  const init: CfRequestInit = {
+    cf: { cacheTtl: 86400, cacheEverything: true },
+  };
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(BEACON_URL, init);
+  } catch {
+    return unavailable();
+  }
+
+  if (!upstream.ok) {
+    return unavailable();
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/javascript; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/functions/cf-rum.ts
+++ b/functions/cf-rum.ts
@@ -1,0 +1,74 @@
+// Pages Function: first-party collector for Cloudflare Web Analytics RUM data.
+// The beacon (loaded first-party via /cf-insights.js) is configured with
+// data-cf-beacon send.to="/cf-rum", so the browser POSTs RUM payloads here —
+// same-origin, so Safari's tracker blocklist never sees a cloudflareinsights.com
+// request. This Function forwards the payload SERVER-SIDE to the real collector
+// at https://cloudflareinsights.com/cdn-cgi/rum. Mirrors the Simple Analytics
+// collector proxy (functions/simple/[[path]].ts).
+//
+// Response contract: ALWAYS a clean 2xx to the browser (upstream status when 2xx,
+// else 204) and Cache-Control: no-store — never a 4xx/5xx, which would surface as
+// a console error and trip the post-deploy smoke check.
+
+const RUM_UPSTREAM = 'https://cloudflareinsights.com/cdn-cgi/rum';
+
+// Minimal Cloudflare Pages Function context — only the field used here.
+interface PagesContext {
+  request: Request;
+}
+
+// Minimal CF fetch extensions. `duplex` is required by undici (Node) when
+// streaming a request body; it is a no-op on the Cloudflare Workers runtime.
+interface CfRequestInit extends RequestInit {
+  duplex?: 'half';
+}
+
+function noContent(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: { 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store' },
+  });
+}
+
+export async function onRequest(context: PagesContext): Promise<Response> {
+  const { request } = context;
+
+  // The beacon only POSTs; anything else is a no-op.
+  if (request.method !== 'POST') {
+    return noContent();
+  }
+
+  const outboundHeaders: Record<string, string> = {};
+  const contentType = request.headers.get('Content-Type');
+  if (contentType) {
+    outboundHeaders['Content-Type'] = contentType;
+  }
+  const clientIp = request.headers.get('CF-Connecting-IP');
+  if (clientIp) {
+    outboundHeaders['X-Forwarded-For'] = clientIp;
+  }
+
+  let upstream: Response;
+  try {
+    const init: CfRequestInit = {
+      method: 'POST',
+      headers: outboundHeaders,
+      body: request.body,
+      duplex: 'half',
+    };
+    upstream = await fetch(RUM_UPSTREAM, init);
+  } catch {
+    // Network failure — swallow so the page stays clean (data best-effort).
+    return noContent();
+  }
+
+  // Forward a 2xx through; collapse any non-2xx to 204 so the browser never
+  // logs an error (RUM data is best-effort telemetry).
+  if (upstream.ok) {
+    return new Response(null, {
+      status: 204,
+      headers: { 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store' },
+    });
+  }
+  return noContent();
+}

--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -299,18 +299,19 @@ html { overflow-y: scroll; }
       <noscript><img src="/simple/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade" /></noscript>
     </Fragment>
   )}
-  {/* Cloudflare Web Analytics: beacon served first-party (/cf-insights.js proxies
-      static.cloudflareinsights.com) with RUM data POSTed to the first-party
-      /cdn-cgi/rum endpoint — so Safari's tracker blocklist sees no cloudflareinsights
-      domain and the "reduce protections" banner is not triggered. Renders only when
-      PUBLIC_CF_BEACON_TOKEN is set (disable Cloudflare's auto-injection so the
-      third-party beacon is not also added). */}
+  {/* Cloudflare Web Analytics, fully first-party: the beacon is served via
+      /cf-insights.js (proxies static.cloudflareinsights.com) and POSTs RUM data to
+      /cf-rum (which forwards to Cloudflare server-side). The browser therefore makes
+      zero cloudflareinsights.com requests, so Safari's tracker blocklist has nothing
+      to match and the "reduce protections" banner is not triggered. Auto-injection
+      must be disabled at the Pages project (manual/JS-snippet mode) so the
+      third-party beacon is not also added. Token is public (rendered in markup). */}
   {import.meta.env.PROD && (
     <script
       is:inline
       defer
       src="/cf-insights.js"
-      data-cf-beacon={JSON.stringify({ token: CF_BEACON_TOKEN, send: { to: '/cdn-cgi/rum' } })}
+      data-cf-beacon={JSON.stringify({ token: CF_BEACON_TOKEN, send: { to: '/cf-rum' } })}
     />
   )}
 </body>

--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -296,5 +296,22 @@ html { overflow-y: scroll; }
       <noscript><img src="/simple/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade" /></noscript>
     </Fragment>
   )}
+  {/* Cloudflare Web Analytics: beacon served first-party (/cf-insights.js proxies
+      static.cloudflareinsights.com) with RUM data POSTed to the first-party
+      /cdn-cgi/rum endpoint — so Safari's tracker blocklist sees no cloudflareinsights
+      domain and the "reduce protections" banner is not triggered. Renders only when
+      PUBLIC_CF_BEACON_TOKEN is set (disable Cloudflare's auto-injection so the
+      third-party beacon is not also added). */}
+  {import.meta.env.PROD && import.meta.env.PUBLIC_CF_BEACON_TOKEN && (
+    <script
+      is:inline
+      defer
+      src="/cf-insights.js"
+      data-cf-beacon={JSON.stringify({
+        token: import.meta.env.PUBLIC_CF_BEACON_TOKEN,
+        send: { to: '/cdn-cgi/rum' },
+      })}
+    />
+  )}
 </body>
 </html>

--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -14,6 +14,9 @@ const {
 const siteUrl = Astro.site?.toString().replace(/\/$/, '');
 const canonicalURL = siteUrl + (Astro.url.pathname === '/' ? '' : Astro.url.pathname);
 const ogImage = new URL('/assets/og-image.png', Astro.site);
+// Cloudflare Web Analytics site token (public — appears in the page markup). The
+// beacon is served first-party via /cf-insights.js; see the tag before </body>.
+const CF_BEACON_TOKEN = '4816323971ac433eb5450e8b0534acfc';
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -302,15 +305,12 @@ html { overflow-y: scroll; }
       domain and the "reduce protections" banner is not triggered. Renders only when
       PUBLIC_CF_BEACON_TOKEN is set (disable Cloudflare's auto-injection so the
       third-party beacon is not also added). */}
-  {import.meta.env.PROD && import.meta.env.PUBLIC_CF_BEACON_TOKEN && (
+  {import.meta.env.PROD && (
     <script
       is:inline
       defer
       src="/cf-insights.js"
-      data-cf-beacon={JSON.stringify({
-        token: import.meta.env.PUBLIC_CF_BEACON_TOKEN,
-        send: { to: '/cdn-cgi/rum' },
-      })}
+      data-cf-beacon={JSON.stringify({ token: CF_BEACON_TOKEN, send: { to: '/cdn-cgi/rum' } })}
     />
   )}
 </body>


### PR DESCRIPTION
Restores Cloudflare Web Analytics (full RUM incl. Core Web Vitals) **without** re-triggering Safari's "Reduce Protections" banner, by serving the beacon **fully first-party**.

## Why

Safari's Advanced Tracking & Fingerprinting Protection fires the banner on a **domain blocklist** match — `static.cloudflareinsights.com` / `cloudflareinsights.com` are classified trackers. If the browser makes zero requests to those domains, there is no match and no banner.

## How (both the script AND the data POST are first-party)

- `functions/cf-insights.js.ts` → serves the beacon at **`/cf-insights.js`** by proxying `static.cloudflareinsights.com/beacon.min.js` (mirrors `functions/sa.ts`).
- `functions/cf-rum.ts` → **`/cf-rum`** receives the beacon's RUM POST and forwards it to `cloudflareinsights.com/cdn-cgi/rum` **server-side**, always returning a clean `204` (mirrors `functions/simple/[[path]].ts`). Server-side forwarding means the _browser_ never touches a cloudflareinsights domain, and the always-204 contract keeps the post-deploy smoke check green.
- `src/layouts/Dashboard.astro` → loads `/cf-insights.js` with `data-cf-beacon` pointing `send.to` at `/cf-rum`. Token `4816323971ac433eb5450e8b0534acfc` is public (rendered in markup, exactly like Cloudflare's own snippet) so it is baked in as a constant — no env var required.
- **No CSP change**: the beacon script and the RUM POST are both same-origin (`script-src 'self'`, `connect-src 'self'`).

## Verified on the preview deploy

- Beacon loads first-party from `/cf-insights.js` (200).
- RUM POST to `/cf-rum` returns **204** — no 404, no console error.
- **Zero** `cloudflareinsights.com` requests from the browser.
- No analytics-related console errors.

## Owner action (already done)

Cloudflare dashboard → Web Analytics → **manual / JS-snippet mode** (auto-injection disabled) so the third-party beacon is not also injected. ✅

## Confirm after production deploy

- Safari (iOS) no longer shows the "Reduce Protections" banner on jonathanlloyd.me.
- Data appears in the Cloudflare Web Analytics dashboard within ~24h (the one thing only confirmable with real production traffic).

## Caveats

- The `send.to` first-party config and the server-side forward to `/cdn-cgi/rum` are **reverse-engineered / not officially supported** by Cloudflare ("all requests should originate from our beacon JavaScript"). If a future beacon update or a collector-side origin check breaks recording, the page stays healthy and the banner stays gone, but RUM data could silently stop — worth an occasional "is data still flowing?" glance. If it does stop, the fallbacks are beaconless edge/Traffic analytics (no JS) or accepting the banner with the stock beacon.
