### PR TITLE
feat(bg): SVG particle-network background on mobile (banner-safe, keeps motion)

### DIFF
--- a/src/lib/mobile-bg.ts
+++ b/src/lib/mobile-bg.ts
@@ -19,9 +19,9 @@
 type Mode = 'lite' | 'svg';
 
 const COLORS = ['#ff006e', '#3a86ff', '#06d6a0', '#e5e5f0'];
-const LINE_DIST = 90;
+const LINE_DIST = 72;
 const FRAME_MS = 1000 / 30; // throttle to 30fps
-const MAX_LINES = 60;
+const MAX_LINES = 110;
 
 interface P {
   x: number;
@@ -33,7 +33,7 @@ interface P {
 }
 
 function countFor(w: number, h: number): number {
-  return Math.max(10, Math.min(26, Math.floor((w * h) / 16000)));
+  return Math.max(26, Math.min(48, Math.floor((w * h) / 9000)));
 }
 
 function makeParticles(w: number, h: number, count: number): P[] {
@@ -46,7 +46,7 @@ function makeParticles(w: number, h: number, count: number): P[] {
       y: Math.random() * h,
       vx: Math.cos(angle) * speed,
       vy: Math.sin(angle) * speed,
-      r: 0.8 + Math.random() * 1.4,
+      r: 1.3 + Math.random() * 1.7,
       c: COLORS[(Math.random() * COLORS.length) | 0],
     });
   }
@@ -155,29 +155,45 @@ function initSvg(canvas: HTMLCanvasElement): void {
   const lines: SVGLineElement[] = [];
   for (let i = 0; i < MAX_LINES; i++) {
     const l = document.createElementNS(NS, 'line');
-    l.setAttribute('stroke-width', '0.6');
+    l.setAttribute('stroke-width', '0.8');
     l.style.visibility = 'hidden';
     svg.appendChild(l);
     lines.push(l);
   }
-  const dots: SVGCircleElement[] = [];
+  // Each dot = a translucent glow halo + a bright core (GPU-cheap neon look,
+  // no SVG filter). Halos drawn under cores; both above the lines.
+  const glows: SVGCircleElement[] = [];
+  const cores: SVGCircleElement[] = [];
   for (const p of ps) {
-    const c = document.createElementNS(NS, 'circle');
-    c.setAttribute('r', String(p.r + 0.4));
-    c.setAttribute('fill', p.c);
-    svg.appendChild(c);
-    dots.push(c);
+    const glow = document.createElementNS(NS, 'circle');
+    glow.setAttribute('r', ((p.r + 0.5) * 2.6).toFixed(1));
+    glow.setAttribute('fill', p.c);
+    glow.setAttribute('fill-opacity', '0.22');
+    svg.appendChild(glow);
+    glows.push(glow);
+  }
+  for (const p of ps) {
+    const core = document.createElementNS(NS, 'circle');
+    core.setAttribute('r', (p.r + 0.5).toFixed(1));
+    core.setAttribute('fill', p.c);
+    svg.appendChild(core);
+    cores.push(core);
   }
 
   let last = 0;
+  let rafId = 0;
   function frame(ts: number): void {
-    requestAnimationFrame(frame);
+    rafId = requestAnimationFrame(frame);
     if (ts - last < FRAME_MS) return;
     last = ts;
     step(ps, w, h);
     for (let i = 0; i < ps.length; i++) {
-      dots[i].setAttribute('cx', ps[i].x.toFixed(1));
-      dots[i].setAttribute('cy', ps[i].y.toFixed(1));
+      const x = ps[i].x.toFixed(1);
+      const y = ps[i].y.toFixed(1);
+      glows[i].setAttribute('cx', x);
+      glows[i].setAttribute('cy', y);
+      cores[i].setAttribute('cx', x);
+      cores[i].setAttribute('cy', y);
     }
     let li = 0;
     const d2 = LINE_DIST * LINE_DIST;
@@ -196,7 +212,7 @@ function initSvg(canvas: HTMLCanvasElement): void {
         l.setAttribute('x2', b.x.toFixed(1));
         l.setAttribute('y2', b.y.toFixed(1));
         l.setAttribute('stroke', a.c);
-        l.setAttribute('stroke-opacity', ((1 - Math.sqrt(dd) / LINE_DIST) * 0.2).toFixed(2));
+        l.setAttribute('stroke-opacity', ((1 - Math.sqrt(dd) / LINE_DIST) * 0.3).toFixed(2));
         l.style.visibility = 'visible';
       }
     }
@@ -207,5 +223,17 @@ function initSvg(canvas: HTMLCanvasElement): void {
     w = window.innerWidth;
     h = window.innerHeight;
   });
-  requestAnimationFrame(frame);
+  // Pause the loop when the tab is hidden (battery).
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+        rafId = 0;
+      }
+    } else if (!rafId) {
+      last = 0;
+      rafId = requestAnimationFrame(frame);
+    }
+  });
+  rafId = requestAnimationFrame(frame);
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,17 +84,20 @@ const { profile, health, github, reading, books, system, starredRepos } = await 
   <script>
     window.addEventListener('load', () => {
       if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-      // iOS 26 Safari's Advanced Fingerprinting Protection reacts to the continuous
-      // full-viewport canvas redraw and surfaces the "reduce protections" banner on
-      // touch devices. Default to OFF on coarse-pointer devices; ?bg=canvas|lite|svg
-      // opts into experimental backgrounds for on-device banner testing (see
-      // src/lib/mobile-bg.ts). Desktop always gets the full particle canvas.
+      // iOS 26 Safari's Advanced Fingerprinting Protection surfaces the "reduce
+      // protections" banner when 2+ canvases animate at once (the particle canvas
+      // plus the live heart-rate canvas). On touch devices we render the particle
+      // network as SVG instead (no canvas → no banner), keeping the moving-network
+      // look. Escapes: ?bg=off disables it, ?bg=canvas forces the old full canvas,
+      // ?bg=lite forces a lighter canvas variant (see src/lib/mobile-bg.ts).
+      // Desktop (fine pointer) keeps the full particle canvas.
       if (window.matchMedia('(pointer: coarse)').matches) {
         const bg = new URLSearchParams(location.search).get('bg');
+        if (bg === 'off') return;
         if (bg === 'canvas') {
           import('@lifegames/web/runtime/particles').then(m => m.startParticles());
-        } else if (bg === 'lite' || bg === 'svg') {
-          import('../lib/mobile-bg').then(m => m.initMobileBg(bg));
+        } else {
+          import('../lib/mobile-bg').then(m => m.initMobileBg(bg === 'lite' ? 'lite' : 'svg'));
         }
         return;
       }


### PR DESCRIPTION
Restores a moving particle-network background on mobile without the iOS 26 Safari "reduce protections" banner.

## Root cause (finally pinned)

The banner is iOS 26 Safari's Advanced Fingerprinting Protection reacting to **2+ simultaneously-animating canvases** — the full-screen particle canvas **plus** the live heart-rate widget canvas. (On-device WebKit-list forensics confirmed zero classified trackers; the data-less preview never reproduced it because only one canvas runs there; Reduce Motion cleared it by stopping all canvases.) A draw-only canvas has no documented safe threshold, so the robust fix is to keep the mobile canvas count at 1.

## Change

On touch devices (`pointer: coarse`), render the particle network as **SVG** instead of a 2nd canvas — same drifting dots + proximity connection lines, brand colors, soft neon glow (halo + core, no SVG filter), 30fps, ~28 dots. Total animating canvases stays at 1 (heart-rate) → no banner. Desktop (fine pointer) keeps the full particle **canvas** unchanged.

- `src/lib/mobile-bg.ts` — SVG particle-network renderer (+ a `lite` canvas variant for `?bg=lite`). Pauses when the tab is hidden (battery). Respects `prefers-reduced-motion`.
- `src/pages/index.astro` — touch default = SVG. Escapes: `?bg=off` (none), `?bg=canvas` (force full canvas), `?bg=lite` (lighter canvas).

## Verification

Iterated in the iOS 26.5 simulator + WebKit at iPhone resolution (screenshots): dots + connection lines render with a subtle neon glow, matching the desktop field. SVG has no canvas so it cannot trigger the canvas-based banner by construction. Visual baselines unaffected (Playwright default pointer is `fine` → this path doesn't run in tests).
