### PR TITLE
test(bio-terminal): guard accurate ls -m interests command (consumer of DS#113)

### DIFF
--- a/tests/visual/widgets.spec.ts
+++ b/tests/visual/widgets.spec.ts
@@ -48,6 +48,18 @@ test.describe('Widgets - populated', () => {
 
   test('bio terminal', async () => {
     const widget = page.locator(WIDGET_SELECTORS.bioTerminal);
+
+    // Behavioral guard (non-screenshot, planning-protocol visual-state rule): the
+    // interests command is the accurate `ls -m interests/` (not the old, broken
+    // `wc -l interests/`), and the listing is alphabetical. Asserted on the SSR
+    // data-* attributes so it holds independent of the typewriter + pixel baseline.
+    const body = page.locator('#terminalBody');
+    await expect(body.locator('[data-cmd="ls -m interests/"]')).toHaveCount(1);
+    await expect(body.locator('[data-cmd="wc -l interests/"]')).toHaveCount(0);
+    await expect(
+      body.locator('[data-output="conversation, edm, musical theatre, pc gaming, programming"]'),
+    ).toHaveCount(1);
+
     await expect(widget).toHaveScreenshot('widget-bio-terminal.png', { stylePath });
   });
 


### PR DESCRIPTION
## What & why

Consumer half of the Bio-terminal command fix. The design-system PR replaces the inaccurate `$ wc -l interests/` (errors on a directory; never lists contents) with `$ ls -m interests/`, reordering the interests output alphabetically (`ls` sorts). See **design-system-Lifegames#113** (producer).

The interests render flows into this site purely through `@lifegames/fixtures` (`getDashboardFixture` → build-time SSR), so the only change here is the visual-gate guard:

- **Behavioral assertion** (`tests/visual/widgets.spec.ts`, non-screenshot — planning-protocol visual-state rule): asserts `#terminalBody` has `[data-cmd="ls -m interests/"]` (count 1), no `[data-cmd="wc -l interests/"]` (count 0), and the alphabetical `data-output`. This guards the render independent of the pixel baseline.

## Why no baseline changes

The pixel delta (command text `wc -l`→`ls -m` + reordered interests) is **below the suite's `0.006` maxDiffPixelRatio**. Verified empirically:

- `npm run test:visual:update` produces **no baseline delta** (5/5 bio viewports unchanged).
- A **compare run** of the new `ls -m` render against the committed `wc -l` baselines **passes** on all 5 viewports (within tolerance).
- Force-deleting one baseline and regenerating confirms the actual render **does** show `ls -m` + alphabetical order — it's just sub-threshold.

So the visual suite cannot distinguish this text change; the **DOM behavioral assertion is the guard**, with the built HTML + a force-regenerated screenshot as the inspected-render evidence (both show `ls -m interests/` → `conversation, edm, musical theatre, pc gaming, programming`).

## ⚠️ Merge order (producer-first) — this PR's CI is RED until DS#113 merges

Web CI rebuilds design-system from `main`, not local yalc. Until **DS#113** lands, CI renders the OLD `wc -l` terminal, so the new behavioral assertion (`[data-cmd="ls -m interests/"]`) **fails**. That red is **expected**. After DS#113 merges, re-run web CI → green. (Local pre-push was `SKIP_VISUAL=1`-skipped as redundant; bio was manually verified across all 5 viewports against the yalc-linked build.)

## ⚠️ Merging this PR deploys production (B5)

Merging to `main` auto-deploys the live site via Cloudflare Pages. Held for explicit review/merge — no auto-merge.

## Surface

`ds-web-widgets` (the only touched web surface). No schema/contract/type change; no `.contract-lock.json` impact.

Plan: `monorepo-LifegamesPortal/.omc/plans/bio-terminal-command-fix.md`.
