### PR TITLE
fix: serve llms-full.txt and index.md on the prod domain via proxy routes

### DIFF
--- a/functions/_lib/proxy.ts
+++ b/functions/_lib/proxy.ts
@@ -1,0 +1,50 @@
+// Shared factory for the CloudFront proxy Pages Functions (/llms.txt,
+// /llms-full.txt, /index.md, /feed.xml, /feed.json). The backend
+// (mantle-LifegamesPortal) owns the canonical artifacts; these routes ensure the
+// spec-required root paths resolve on jonathanlloyd.me without hand-maintained
+// static files. Responses are wrapped by functions/_middleware.ts, which injects
+// the security headers.
+//
+// Not itself a route: Pages Functions only creates routes for modules that
+// export an onRequest* handler; this module exports a factory.
+
+import { CLOUDFRONT_BASE } from '@lifegames/portal-contract/constants';
+
+// Minimal Cloudflare Pages Function fetch options — only the cf cache fields used here.
+interface CfRequestInit extends RequestInit {
+  cf?: { cacheTtl?: number; cacheEverything?: boolean; };
+}
+
+export interface CloudfrontProxyConfig {
+  /** Artifact path on the CloudFront data plane, e.g. '/llms-full.txt'. */
+  path: string;
+  /** Content-Type served to the client (CloudFront serves its own; the route owns the public one). */
+  contentType: string;
+}
+
+/** Builds an onRequest handler that proxies one CloudFront artifact with edge caching. */
+export function makeCloudfrontProxy({ path, contentType }: CloudfrontProxyConfig): () => Promise<Response> {
+  const upstreamUrl = `${CLOUDFRONT_BASE}${path}`;
+  const artifactName = path.slice(1);
+
+  return async function onRequest(): Promise<Response> {
+    const init: CfRequestInit = { cf: { cacheTtl: 3600, cacheEverything: true } };
+    const upstream = await fetch(upstreamUrl, init);
+
+    if (!upstream.ok) {
+      return new Response(`${artifactName} unavailable`, {
+        status: 502,
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      });
+    }
+
+    return new Response(upstream.body, {
+      status: 200,
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400',
+        'X-Source': 'cloudfront-proxy',
+      },
+    });
+  };
+}

--- a/functions/feed.json.ts
+++ b/functions/feed.json.ts
@@ -1,35 +1,9 @@
 // Pages Function: proxy /feed.json from CloudFront with edge caching.
-// The backend (mantle-LifegamesPortal) owns the canonical JSON Feed 1.1;
-// this route ensures the spec-required root path resolves on jonathanlloyd.me
-// without a hand-maintained static file. The response is wrapped by
-// functions/_middleware.ts, which injects the security headers.
+// The backend (mantle-LifegamesPortal) owns the canonical JSON Feed 1.1.
 
-import { CLOUDFRONT_BASE } from '@lifegames/portal-contract/constants';
+import { makeCloudfrontProxy } from './_lib/proxy';
 
-const CLOUDFRONT_FEED_JSON = `${CLOUDFRONT_BASE}/feed.json`;
-
-// Minimal Cloudflare Pages Function fetch options — only the cf cache fields used here.
-interface CfRequestInit extends RequestInit {
-  cf?: { cacheTtl?: number; cacheEverything?: boolean; };
-}
-
-export async function onRequest(): Promise<Response> {
-  const init: CfRequestInit = { cf: { cacheTtl: 3600, cacheEverything: true } };
-  const upstream = await fetch(CLOUDFRONT_FEED_JSON, init);
-
-  if (!upstream.ok) {
-    return new Response('feed.json unavailable', {
-      status: 502,
-      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-    });
-  }
-
-  return new Response(upstream.body, {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/feed+json; charset=utf-8',
-      'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400',
-      'X-Source': 'cloudfront-proxy',
-    },
-  });
-}
+export const onRequest = makeCloudfrontProxy({
+  path: '/feed.json',
+  contentType: 'application/feed+json; charset=utf-8',
+});

--- a/functions/feed.xml.ts
+++ b/functions/feed.xml.ts
@@ -1,35 +1,9 @@
 // Pages Function: proxy /feed.xml from CloudFront with edge caching.
-// The backend (mantle-LifegamesPortal) owns the canonical RSS 2.0 feed;
-// this route ensures the spec-required root path resolves on jonathanlloyd.me
-// without a hand-maintained static file. The response is wrapped by
-// functions/_middleware.ts, which injects the security headers.
+// The backend (mantle-LifegamesPortal) owns the canonical RSS 2.0 feed.
 
-import { CLOUDFRONT_BASE } from '@lifegames/portal-contract/constants';
+import { makeCloudfrontProxy } from './_lib/proxy';
 
-const CLOUDFRONT_FEED_XML = `${CLOUDFRONT_BASE}/feed.xml`;
-
-// Minimal Cloudflare Pages Function fetch options — only the cf cache fields used here.
-interface CfRequestInit extends RequestInit {
-  cf?: { cacheTtl?: number; cacheEverything?: boolean; };
-}
-
-export async function onRequest(): Promise<Response> {
-  const init: CfRequestInit = { cf: { cacheTtl: 3600, cacheEverything: true } };
-  const upstream = await fetch(CLOUDFRONT_FEED_XML, init);
-
-  if (!upstream.ok) {
-    return new Response('feed.xml unavailable', {
-      status: 502,
-      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-    });
-  }
-
-  return new Response(upstream.body, {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/rss+xml; charset=utf-8',
-      'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400',
-      'X-Source': 'cloudfront-proxy',
-    },
-  });
-}
+export const onRequest = makeCloudfrontProxy({
+  path: '/feed.xml',
+  contentType: 'application/rss+xml; charset=utf-8',
+});

--- a/functions/index.md.ts
+++ b/functions/index.md.ts
@@ -1,0 +1,12 @@
+// Pages Function: proxy /index.md from CloudFront with edge caching.
+// index.md is the byte-identical markdown alias of llms-full.txt (for agents
+// expecting .md extensions); this route ensures it resolves on jonathanlloyd.me,
+// not only on the raw CloudFront host.
+
+import { LLM_CONTENT_PATHS } from '@lifegames/portal-contract/constants';
+import { makeCloudfrontProxy } from './_lib/proxy';
+
+export const onRequest = makeCloudfrontProxy({
+  path: LLM_CONTENT_PATHS.indexMarkdown,
+  contentType: 'text/markdown; charset=utf-8',
+});

--- a/functions/llms-full.txt.ts
+++ b/functions/llms-full.txt.ts
@@ -1,0 +1,12 @@
+// Pages Function: proxy /llms-full.txt from CloudFront with edge caching.
+// The backend composes the full data dump on every source-data change; this
+// route ensures the path the llms.txt discovery index advertises resolves on
+// jonathanlloyd.me, not only on the raw CloudFront host.
+
+import { LLM_CONTENT_PATHS } from '@lifegames/portal-contract/constants';
+import { makeCloudfrontProxy } from './_lib/proxy';
+
+export const onRequest = makeCloudfrontProxy({
+  path: LLM_CONTENT_PATHS.llmsFull,
+  contentType: 'text/markdown; charset=utf-8',
+});

--- a/functions/llms.txt.ts
+++ b/functions/llms.txt.ts
@@ -1,38 +1,14 @@
 // Pages Function: proxy /llms.txt from CloudFront with edge caching.
-// The backend (mantle-LifegamesPortal) owns the canonical content; this route
-// ensures the spec-required root path resolves on jonathanlloyd.me without a
-// hand-maintained static file. The response is wrapped by functions/_middleware.ts,
-// which injects the security headers (CSP, X-Content-Type-Options, Referrer-Policy).
-
-import { CLOUDFRONT_BASE } from '@lifegames/portal-contract/constants';
-
+// The backend (mantle-LifegamesPortal) owns the canonical content.
+//
 // The /llms.txt discovery index has no dedicated contract path constant
 // (LLM_CONTENT_PATHS covers llms-full / llms-small / index.md); the host is
-// sourced from the contract so no CloudFront literal is hardcoded here.
-const CLOUDFRONT_LLMS_TXT = `${CLOUDFRONT_BASE}/llms.txt`;
+// sourced from the contract inside the factory so no CloudFront literal is
+// hardcoded here.
 
-// Minimal Cloudflare Pages Function fetch options — only the cf cache fields used here.
-interface CfRequestInit extends RequestInit {
-  cf?: { cacheTtl?: number; cacheEverything?: boolean; };
-}
+import { makeCloudfrontProxy } from './_lib/proxy';
 
-export async function onRequest(): Promise<Response> {
-  const init: CfRequestInit = { cf: { cacheTtl: 3600, cacheEverything: true } };
-  const upstream = await fetch(CLOUDFRONT_LLMS_TXT, init);
-
-  if (!upstream.ok) {
-    return new Response('llms.txt unavailable', {
-      status: 502,
-      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-    });
-  }
-
-  return new Response(upstream.body, {
-    status: 200,
-    headers: {
-      'Content-Type': 'text/plain; charset=utf-8',
-      'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400',
-      'X-Source': 'cloudfront-proxy',
-    },
-  });
-}
+export const onRequest = makeCloudfrontProxy({
+  path: '/llms.txt',
+  contentType: 'text/plain; charset=utf-8',
+});

--- a/public/.well-known/agent-skills/portfolio-expert/SKILL.md
+++ b/public/.well-known/agent-skills/portfolio-expert/SKILL.md
@@ -8,9 +8,9 @@ Use this skill to accurately answer questions about Jonathan Lloyd's professiona
 - **Title:** Engineering Director
 - **Location:** San Francisco, CA
 - **Experience:** 24+ years in software engineering
-- **GitHub:** https://github.com/j0nathan-ll0yd
-- **LinkedIn:** https://www.linkedin.com/in/lifegames/
-- **Site:** https://jonathanlloyd.me
+- **GitHub:** <https://github.com/j0nathan-ll0yd>
+- **LinkedIn:** <https://www.linkedin.com/in/lifegames/>
+- **Site:** <https://jonathanlloyd.me>
 
 ## Expertise
 
@@ -35,26 +35,26 @@ The portfolio at jonathanlloyd.me is a sci-fi "Human Datastream" dashboard — a
 
 All data is served from CloudFront with 5-minute edge TTL. Health data uses 7-day aggregates only for privacy.
 
-| Endpoint | Description |
-|----------|-------------|
-| https://d1pfm520aduift.cloudfront.net/health.json | Heart rate, HRV, activity, workouts |
-| https://d1pfm520aduift.cloudfront.net/sleep.json | Sleep phases and efficiency |
-| https://d1pfm520aduift.cloudfront.net/focus.json | Focus / Do Not Disturb state |
-| https://d1pfm520aduift.cloudfront.net/github-events.json | Dev activity, languages, contributions |
-| https://d1pfm520aduift.cloudfront.net/github-starred-repos.json | Starred repositories |
-| https://d1pfm520aduift.cloudfront.net/books.json | Bookshelf with status, ratings, progress |
-| https://d1pfm520aduift.cloudfront.net/articles.json | Article feed items |
-| https://d1pfm520aduift.cloudfront.net/theatre-reviews.json | Theatre reviews |
-| https://d1pfm520aduift.cloudfront.net/workouts.json | Workout sessions and summaries |
-| https://d1pfm520aduift.cloudfront.net/location.json | Location aggregates |
+| Endpoint                                                          | Description                              |
+| ----------------------------------------------------------------- | ---------------------------------------- |
+| <https://d1pfm520aduift.cloudfront.net/health.json>               | Heart rate, HRV, activity, workouts      |
+| <https://d1pfm520aduift.cloudfront.net/sleep.json>                | Sleep phases and efficiency              |
+| <https://d1pfm520aduift.cloudfront.net/focus.json>                | Focus / Do Not Disturb state             |
+| <https://d1pfm520aduift.cloudfront.net/github-events.json>        | Dev activity, languages, contributions   |
+| <https://d1pfm520aduift.cloudfront.net/github-starred-repos.json> | Starred repositories                     |
+| <https://d1pfm520aduift.cloudfront.net/books.json>                | Bookshelf with status, ratings, progress |
+| <https://d1pfm520aduift.cloudfront.net/articles.json>             | Article feed items                       |
+| <https://d1pfm520aduift.cloudfront.net/theatre-reviews.json>      | Theatre reviews                          |
+| <https://d1pfm520aduift.cloudfront.net/workouts.json>             | Workout sessions and summaries           |
+| <https://d1pfm520aduift.cloudfront.net/location.json>             | Location aggregates                      |
 
 ## LLM-Optimized Content
 
 Backend-composed markdown variants, always fresher than this static skill file:
 
-- **Discovery index:** https://jonathanlloyd.me/llms.txt
-- **Complete data dump (~20 KB):** https://d1pfm520aduift.cloudfront.net/llms-full.txt
-- **Markdown alias:** https://d1pfm520aduift.cloudfront.net/index.md
+- **Discovery index:** <https://jonathanlloyd.me/llms.txt>
+- **Complete data dump (~20 KB):** <https://jonathanlloyd.me/llms-full.txt>
+- **Markdown alias:** <https://jonathanlloyd.me/index.md>
 
 ## Key Architectural Decisions
 
@@ -69,4 +69,4 @@ Backend-composed markdown variants, always fresher than this static skill file:
 - To summarize Jonathan's background, reference the Identity and Expertise sections above.
 - To get current data, fetch the llms-full.txt URL — it is composed by the backend on every data change and is always up to date.
 - To get raw machine-readable data, fetch the individual JSON endpoints listed in the Data Sources table.
-- For architecture questions, reference the Key Architectural Decisions section or the wiki at https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki
+- For architecture questions, reference the Key Architectural Decisions section or the wiki at <https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki>

--- a/public/js/webmcp.js
+++ b/public/js/webmcp.js
@@ -75,7 +75,7 @@
               font: 'Space Grotesk (self-hosted, variable woff2)',
               llmContent: {
                 discoveryIndex: 'https://jonathanlloyd.me/llms.txt',
-                complete: 'https://d1pfm520aduift.cloudfront.net/llms-full.txt'
+                complete: 'https://jonathanlloyd.me/llms-full.txt'
               }
             };
             return { content: [{ type: 'text', text: JSON.stringify(stack) }] };

--- a/scripts/audit/validate-llms-txt.mjs
+++ b/scripts/audit/validate-llms-txt.mjs
@@ -21,12 +21,17 @@
 // universal real-world practice and this repo's own llms.txt, even though the
 // spec technically marks the H1 alone as required -- see inline note.
 
-import { CLOUDFRONT_BASE, SITE_URL } from '@lifegames/portal-contract/constants';
+import { LLM_CONTENT_PATHS, SITE_URL } from '@lifegames/portal-contract/constants';
 import { fetchStable, isMain, report } from './lib/http.mjs';
 
 const LLMS_TXT_URL = `${SITE_URL}/llms.txt`;
-const LLMS_FULL_URL = `${CLOUDFRONT_BASE}/llms-full.txt`;
-const INDEX_MD_URL = `${CLOUDFRONT_BASE}/index.md`;
+// PROD-DOMAIN paths, deliberately: B2's concern is that jonathanlloyd.me serves
+// these (they 404'd there until 2026-07-17 because only /llms.txt had a proxy
+// route — functions/llms-full.txt.ts + functions/index.md.ts now cover them).
+// Source-side CloudFront freshness for the same artifacts is C1's job
+// (mantle-LifegamesPortal/scripts/audit/freshness.mjs).
+const LLMS_FULL_URL = `${SITE_URL}${LLM_CONTENT_PATHS.llmsFull}`;
+const INDEX_MD_URL = `${SITE_URL}${LLM_CONTENT_PATHS.indexMarkdown}`;
 
 const LINK_ITEM_RE = /^[-*]\s+\[([^\]]+)\]\(([^)]+)\)(:\s*.*)?$/;
 const LIST_ITEM_RE = /^[-*]\s+/;
@@ -210,9 +215,12 @@ async function main() {
 
   // llms-full.txt / index.md: the composer runs on a 30m EventBridge rate +
   // event trigger (§11.2 of the audit plan); a 3h warn window covers a couple
-  // of missed ticks without being noisy.
-  const fullFindings = await checkPresence('llms-full-txt', LLMS_FULL_URL, 3);
-  const indexMdFindings = await checkPresence('index-md', INDEX_MD_URL, 3);
+  // of missed ticks without being noisy. +1h on top because the prod-domain
+  // routes edge-cache the CloudFront upstream for up to an hour
+  // (functions/_lib/proxy.ts: cacheTtl 3600 / s-maxage=3600), so a legitimately
+  // fresh document can read up to 1h older through the proxy.
+  const fullFindings = await checkPresence('llms-full-txt', LLMS_FULL_URL, 4);
+  const indexMdFindings = await checkPresence('index-md', INDEX_MD_URL, 4);
   exit = report('validate-llms-txt (llms-full.txt + index.md presence)', [...fullFindings, ...indexMdFindings])
     || exit;
 

--- a/scripts/generate-webmcp.mjs
+++ b/scripts/generate-webmcp.mjs
@@ -49,7 +49,10 @@ const dataSources = [
 ];
 
 const booksUrl = cf(ENDPOINTS.books);
-const llmsFullUrl = cf(LLM_CONTENT_PATHS.llmsFull);
+// llms-full.txt is advertised at its prod-domain path (proxied by
+// functions/llms-full.txt.ts), keeping agents on jonathanlloyd.me; the raw
+// JSON dataSources above stay on CloudFront (no prod-domain proxy exists for them).
+const llmsFullUrl = `${SITE_URL}${LLM_CONTENT_PATHS.llmsFull}`;
 
 // Single-quoted JS string literal to match the served file's existing style.
 const sq = (v) => `'${String(v).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;

--- a/tests/smoke/home.smoke.ts
+++ b/tests/smoke/home.smoke.ts
@@ -200,6 +200,29 @@ test.describe('production home dashboard', () => {
     expect(contentType, '/feed.json wrong content-type').toContain('application/feed+json');
   });
 
+  test('llms.txt is reachable and plain text', async ({ page }) => {
+    const res = await getStable(page.request, '/llms.txt');
+    expect(res.status(), '/llms.txt did not return 200').toBe(200);
+    const contentType = res.headers()['content-type'] || '';
+    expect(contentType, '/llms.txt wrong content-type').toContain('text/plain');
+  });
+
+  test('llms-full.txt is reachable on the prod domain and markdown', async ({ page }) => {
+    // Regression guard: until 2026-07-17 only /llms.txt had a proxy route, so
+    // the full dump the discovery index advertises 404'd on jonathanlloyd.me.
+    const res = await getStable(page.request, '/llms-full.txt');
+    expect(res.status(), '/llms-full.txt did not return 200').toBe(200);
+    const contentType = res.headers()['content-type'] || '';
+    expect(contentType, '/llms-full.txt wrong content-type').toContain('text/markdown');
+  });
+
+  test('index.md is reachable on the prod domain and markdown', async ({ page }) => {
+    const res = await getStable(page.request, '/index.md');
+    expect(res.status(), '/index.md did not return 200').toBe(200);
+    const contentType = res.headers()['content-type'] || '';
+    expect(contentType, '/index.md wrong content-type').toContain('text/markdown');
+  });
+
   test('webfinger resolves the Fediverse alias with JRD content-type', async ({ page }) => {
     // Accept: application/jrd+json avoids the text/markdown early-return in
     // functions/_middleware.ts that would otherwise short-circuit to llms-full.

--- a/tests/unit/cloudfront-proxy.test.ts
+++ b/tests/unit/cloudfront-proxy.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CLOUDFRONT_BASE, LLM_CONTENT_PATHS } from '@lifegames/portal-contract/constants';
+import { makeCloudfrontProxy } from '../../functions/_lib/proxy';
+import { onRequest as feedJsonRoute } from '../../functions/feed.json.ts';
+import { onRequest as feedXmlRoute } from '../../functions/feed.xml.ts';
+import { onRequest as indexMdRoute } from '../../functions/index.md.ts';
+import { onRequest as llmsFullRoute } from '../../functions/llms-full.txt.ts';
+import { onRequest as llmsTxtRoute } from '../../functions/llms.txt.ts';
+
+// Unit tests for the shared CloudFront proxy factory and the five routes built
+// from it. The regression class under guard: an artifact advertised by the
+// llms.txt discovery index (llms-full.txt, index.md) having NO route on the
+// prod domain — /llms-full.txt 404'd on jonathanlloyd.me until 2026-07-17.
+
+const stubFetch = (response: Response) => {
+  const mock = vi.fn().mockResolvedValue(response);
+  vi.stubGlobal('fetch', mock);
+  return mock;
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('makeCloudfrontProxy', () => {
+  it('fetches the CloudFront artifact with the edge-cache options', async () => {
+    const mock = stubFetch(new Response('body'));
+    const proxy = makeCloudfrontProxy({ path: '/thing.txt', contentType: 'text/plain; charset=utf-8' });
+    await proxy();
+    expect(mock).toHaveBeenCalledWith(`${CLOUDFRONT_BASE}/thing.txt`, {
+      cf: { cacheTtl: 3600, cacheEverything: true },
+    });
+  });
+
+  it('passes the upstream body through with proxy headers on success', async () => {
+    stubFetch(new Response('# content'));
+    const proxy = makeCloudfrontProxy({ path: '/thing.txt', contentType: 'text/markdown; charset=utf-8' });
+    const res = await proxy();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=300, s-maxage=3600, stale-while-revalidate=86400');
+    expect(res.headers.get('X-Source')).toBe('cloudfront-proxy');
+    expect(await res.text()).toBe('# content');
+  });
+
+  it('returns a 502 with a plain-text notice when upstream fails', async () => {
+    stubFetch(new Response('nope', { status: 500 }));
+    const proxy = makeCloudfrontProxy({ path: '/thing.txt', contentType: 'text/markdown; charset=utf-8' });
+    const res = await proxy();
+    expect(res.status).toBe(502);
+    expect(res.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+    expect(await res.text()).toBe('thing.txt unavailable');
+  });
+});
+
+describe('proxy routes', () => {
+  // Every artifact the site serves from its own domain: upstream CloudFront
+  // path + the public Content-Type the route owns.
+  const routes: Array<[string, () => Promise<Response>, string, string]> = [
+    ['/llms.txt', llmsTxtRoute, '/llms.txt', 'text/plain; charset=utf-8'],
+    ['/llms-full.txt', llmsFullRoute, LLM_CONTENT_PATHS.llmsFull, 'text/markdown; charset=utf-8'],
+    ['/index.md', indexMdRoute, LLM_CONTENT_PATHS.indexMarkdown, 'text/markdown; charset=utf-8'],
+    ['/feed.xml', feedXmlRoute, '/feed.xml', 'application/rss+xml; charset=utf-8'],
+    ['/feed.json', feedJsonRoute, '/feed.json', 'application/feed+json; charset=utf-8'],
+  ];
+
+  it.each(routes)('%s proxies its CloudFront artifact', async (_route, onRequest, upstreamPath, contentType) => {
+    const mock = stubFetch(new Response('payload'));
+    const res = await onRequest();
+    expect(mock).toHaveBeenCalledWith(`${CLOUDFRONT_BASE}${upstreamPath}`, {
+      cf: { cacheTtl: 3600, cacheEverything: true },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe(contentType);
+  });
+});


### PR DESCRIPTION
## Why

`https://jonathanlloyd.me/llms-full.txt` and `https://jonathanlloyd.me/index.md` returned **404** -- only `/llms.txt` had a Cloudflare Pages proxy route, so the two artifacts the discovery index advertises were reachable only on the raw CloudFront host (the llms.txt body even links them there).

## What

- **`functions/_lib/proxy.ts`** -- shared `makeCloudfrontProxy` factory (the three existing proxy routes were near-identical copies; adding two more made five)
- **`functions/llms-full.txt.ts` + `functions/index.md.ts`** -- the new routes (paths from `LLM_CONTENT_PATHS`)
- **`functions/llms.txt.ts` / `feed.xml.ts` / `feed.json.ts`** -- refactored onto the factory; response behavior byte-identical (same content-types, cache-control, X-Source, 502 fallback text)
- **WebMCP + agent-skill** -- `get_tech_stack.llmContent.complete` and the `.well-known` SKILL.md now advertise the prod-domain URLs
- **Audit (B2)** -- `scripts/audit/validate-llms-txt.mjs` presence/freshness probes for llms-full.txt + index.md moved from CloudFront to the **prod domain** (the exact blind spot that hid this bug); threshold 3h -> 4h to absorb the 1h proxy edge cache. CloudFront-side freshness remains C1's job (mantle `freshness.mjs`).
- **Smoke (B1, per-deploy + daily)** -- reachability + content-type assertions for `/llms.txt`, `/llms-full.txt`, `/index.md`
- **Tests** -- `tests/unit/cloudfront-proxy.test.ts`: factory behavior (upstream URL + cf cache options, header set, 502 fallback) and a per-route upstream/content-type table

## Verification

- 173 unit + 73 build-tier tests green locally; dprint clean; pre-push visual gate passed
- Preview deploy: verify `/llms-full.txt` + `/index.md` return 200 markdown AND `/` still serves the dashboard (guards against Pages routing treating `index.md.ts` as an index route)

## Merge order (3-repo chain)

**This PR merges first** (routes must resolve before links flip), then design-system-Lifegames#117 (discovery-index links -> `{siteUrl}`), then mantle-LifegamesPortal#146 (Source self-reference + spec) with a staging deploy.

**Merging this PR deploys production** (web-main-autodeploys-prod).