### PR TITLE
fix(seo): gate ProfilePage/Dataset to home; harden JSON-LD @graph

### DIFF
--- a/docs/wiki/Sources-and-Acknowledgments.md
+++ b/docs/wiki/Sources-and-Acknowledgments.md
@@ -27,6 +27,71 @@ ultimately disagreed with it; the input still mattered.
 
 ## Log
 
+### 2026-07-20 -- JSON-LD Explained for Personal Websites
+
+- **Source:** [JSON-LD Explained for Personal Websites](https://hawksley.dev/blog/json-ld-explained-for-personal-websites/)
+- **Author:** Ethan Hawksley ([hawksley.dev](https://hawksley.dev))
+- **Status of source:** Published blog post, a practical walkthrough of the
+  structured-data setup on the author's own personal site.
+
+**What it recommends.** Serve one consolidated `@graph` block rather than several
+disconnected `<script type="application/ld+json">` islands, and link the nodes
+inside it by fragment `@id` (e.g. `#website`, `#person`) so a `WebSite`,
+`ProfilePage`, and `Person` describe one connected entity graph. At minimum a
+personal site should carry those three node types; the `ProfilePage` should point
+at the person via `mainEntity -> #person`, and the `Person` (as the site's
+`publisher`) should appear on every page so search engines can consistently
+resolve the author across the site. Do **not** repeat the full `WebSite`
+description on every page -- a slim reference by `@id` is enough once the full node
+has been declared. Feed the Knowledge Graph with `sameAs` links, ideally
+including a Wikidata entry (the highest-value signal). And do not fake dates:
+`dateModified` should reflect the content's real last-modified date, not the build
+clock.
+
+**How we validated it.** The `ProfilePage` shape the article recommends matches
+Google's own [Profile Page structured-data
+documentation](https://developers.google.com/search/docs/appearance/structured-data/profile-page),
+which is a supported rich-result type and expects exactly the
+`ProfilePage -> mainEntity -> Person` linkage. The `sameAs` -> Knowledge Graph
+mechanism is corroborated by Google's
+[general structured-data guidance](https://developers.google.com/search/docs/appearance/structured-data/sd-policies);
+a Wikidata `sameAs` is genuinely the highest-value entry there, which is why we
+have deferred it rather than dropped it (see below). Properties like `knowsAbout`
+and `knowsLanguage` are valid schema.org and useful for LLM/agent consumers, but
+they are not required by any Google rich result -- worth including, not worth
+contorting the data for. The one real gap in the article is that it ships no
+validation tooling: it shows the markup but never asserts the graph is internally
+consistent. We closed that gap on our side (see below).
+
+**What we did.** The audit's headline finding was a live bug: `Dashboard.astro` is
+the shared layout for `/`, `/privacy`, and `/404`, and it emitted the `ProfilePage`
+and `Dataset` nodes unconditionally -- so the privacy policy and the 404 page were
+both advertising themselves to crawlers as Jonathan Lloyd's person profile page and
+as the live biometric datastream. We gated `ProfilePage` and `Dataset` to the home
+page only (`Astro.url.pathname === '/'`) and, on every other page, emit a plain
+`WebPage` node instead (`@id` = canonical URL + `#webpage`, `isPartOf` the
+`#website`, name = the page title). Following Hawksley's "don't repeat the full
+`WebSite` per page" advice, non-home pages now carry a slimmed `WebSite` reference
+while the full node (with `description`, `image`, and `alternateName`) stays on the
+home page; the full `Person` remains on every page as the site publisher, as he
+recommends. We also stopped faking a date: `ProfilePage.dateModified` was
+`new Date().toISOString()` (the build clock -- non-deterministic and dishonest) and
+is now a static, hand-maintained content-modification constant. We pointed
+`Dataset.license` at the real `/privacy` page (it had pointed meaninglessly at the
+site root), enriched the `Person` node with `givenName`/`familyName`,
+`disambiguatingDescription`, a real 200x200 avatar `ImageObject` (the OG card stays
+reserved for `og:image`), and corrected `knowsLanguage` from `["en"]` to the BCP-47
+`["en-US"]`. Every identity string is still sourced from `@lifegames/copy`; no value
+was hardcoded. Closing the article's validation gap, we added a build-output test
+(`tests/build/json-ld.test.ts`) that parses the emitted `@graph` from `/`,
+`/privacy`, and `/404` and asserts every `{"@id"}` reference resolves to a node
+that defines that `@id` on the same page (no dangling links), that `ProfilePage`
+and `Dataset` appear only on the home page, and that a `WebPage` node appears on
+`/privacy`. Two of his recommendations are deferred, not rejected: a Wikidata
+`sameAs` (the highest-value Knowledge Graph signal) and `worksFor` / `alumniOf`
+both await real data plus new `@lifegames/copy` fields, and we will not invent
+identity values to satisfy the schema.
+
 ### 2026-07-20 -- `font-family` recommendations
 
 - **Source:** [font-family recommendations](https://chrismorgan.info/font-family)

--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -17,6 +17,115 @@ const ogImage = new URL('/assets/og-image.png', Astro.site);
 // Cloudflare Web Analytics site token (public — appears in the page markup). The
 // beacon is served first-party via /cf-insights.js; see the tag before </body>.
 const CF_BEACON_TOKEN = '4816323971ac433eb5450e8b0534acfc';
+
+// --- JSON-LD @graph ---------------------------------------------------------
+// Dashboard.astro is the layout for /, /privacy and /404 alike. Only the home
+// page is a person's profile page and the live datastream, so ProfilePage and
+// Dataset are gated to it; other pages emit a plain WebPage instead. WebSite and
+// the full Person are site-wide entities and appear on every page (WebSite is
+// slimmed on non-home pages so the full node is not repeated per page).
+const isHome = Astro.url.pathname === '/';
+
+// Profile's last content-modification date. This is a STATIC literal, not the
+// build time: the ProfilePage content (bio, job title, links) changes rarely and
+// a build-time date would be non-deterministic and dishonest. Bump this by hand
+// whenever the profile content in @lifegames/copy identity.person changes. The
+// legitimately-live surface is the Dataset (temporalCoverage), not this page.
+const PROFILE_MODIFIED = '2026-07-20T00:00:00Z';
+
+const websiteId = siteUrl + '#website';
+const personId = siteUrl + '#person';
+
+// Real avatar (200x200), preloaded in the head. Distinct from the 1200x630 OG
+// card, which stays reserved for og:image social embeds.
+const avatarImage = {
+  '@type': 'ImageObject',
+  url: new URL('/assets/avatar.webp', Astro.site).toString(),
+  width: 200,
+  height: 200,
+  caption: identity.a11y.ogImageAlt,
+};
+
+const personNode = {
+  '@type': 'Person',
+  '@id': personId,
+  name: identity.person.name,
+  alternateName: identity.person.handle,
+  givenName: identity.person.firstName,
+  familyName: identity.person.lastName,
+  jobTitle: identity.person.jobTitle,
+  url: siteUrl,
+  image: avatarImage,
+  sameAs: identity.person.sameAs,
+  knowsAbout: identity.seo.expertise,
+  knowsLanguage: ['en-US'],
+  disambiguatingDescription: identity.person.shortBio,
+  description: identity.person.longBio,
+};
+
+const websiteFull = {
+  '@type': 'WebSite',
+  '@id': websiteId,
+  name: identity.site.fullName,
+  alternateName: identity.site.name,
+  description: identity.site.description,
+  url: siteUrl,
+  inLanguage: 'en-US',
+  image: { '@type': 'ImageObject', url: ogImage.toString() },
+  publisher: { '@id': personId },
+};
+
+// Slim WebSite for non-home pages: identity only, so the full WebSite node is not
+// duplicated on every page. WebPage.isPartOf still resolves against this @id.
+const websiteSlim = {
+  '@type': 'WebSite',
+  '@id': websiteId,
+  name: identity.site.fullName,
+  url: siteUrl,
+};
+
+const profilePageNode = {
+  '@type': 'ProfilePage',
+  '@id': siteUrl + '#profilepage',
+  name: `About ${identity.person.name}`,
+  isPartOf: { '@id': websiteId },
+  mainEntity: { '@id': personId },
+  url: canonicalURL.toString(),
+  dateCreated: '2026-03-04T00:00:00Z',
+  dateModified: PROFILE_MODIFIED,
+  inLanguage: 'en-US',
+};
+
+const datasetNode = {
+  '@type': 'Dataset',
+  '@id': siteUrl + '#datastream',
+  name: identity.site.name,
+  description: llm.dashboard.datasetDescription,
+  creator: { '@id': personId },
+  license: new URL('/privacy', Astro.site).href,
+  isAccessibleForFree: true,
+  variableMeasured: [...DATASET_VARIABLES],
+  distribution: DATASET_DISTRIBUTIONS.map((d) => ({
+    '@type': 'DataDownload',
+    name: d.name,
+    encodingFormat: d.encodingFormat,
+    contentUrl: d.contentUrl,
+  })),
+  temporalCoverage: '2026-03-04/..',
+  inLanguage: 'en-US',
+};
+
+const webPageNode = {
+  '@type': 'WebPage',
+  '@id': canonicalURL.toString() + '#webpage',
+  isPartOf: { '@id': websiteId },
+  name: title,
+  inLanguage: 'en-US',
+};
+
+const jsonLdGraph = isHome
+  ? [websiteFull, profilePageNode, personNode, datasetNode]
+  : [websiteSlim, webPageNode, personNode];
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -66,60 +175,7 @@ const CF_BEACON_TOKEN = '4816323971ac433eb5450e8b0534acfc';
 
   <script type="application/ld+json" is:inline set:html={JSON.stringify({
     "@context": "https://schema.org",
-    "@graph": [
-      {
-        "@type": "WebSite",
-        "@id": siteUrl + "#website",
-        "name": identity.site.fullName,
-        "description": identity.site.description,
-        "url": siteUrl,
-        "inLanguage": "en-US",
-        "publisher": { "@id": siteUrl + "#person" }
-      },
-      {
-        "@type": "ProfilePage",
-        "@id": siteUrl + "#profilepage",
-        "mainEntity": { "@id": siteUrl + "#person" },
-        "url": canonicalURL.toString(),
-        "dateCreated": "2026-03-04T00:00:00Z",
-        "dateModified": new Date().toISOString(),
-        "inLanguage": "en-US"
-      },
-      {
-        "@type": "Person",
-        "@id": siteUrl + "#person",
-        "name": identity.person.name,
-        "alternateName": identity.person.handle,
-        "jobTitle": identity.person.jobTitle,
-        "url": siteUrl,
-        "image": {
-          "@type": "ImageObject",
-          "url": ogImage.toString()
-        },
-        "sameAs": identity.person.sameAs,
-        "knowsAbout": identity.seo.expertise,
-        "knowsLanguage": ["en"],
-        "description": identity.person.longBio
-      },
-      {
-        "@type": "Dataset",
-        "@id": siteUrl + "#datastream",
-        "name": identity.site.name,
-        "description": llm.dashboard.datasetDescription,
-        "creator": { "@id": siteUrl + "#person" },
-        "license": siteUrl,
-        "isAccessibleForFree": true,
-        "variableMeasured": [...DATASET_VARIABLES],
-        "distribution": DATASET_DISTRIBUTIONS.map((d) => ({
-          "@type": "DataDownload",
-          "name": d.name,
-          "encodingFormat": d.encodingFormat,
-          "contentUrl": d.contentUrl
-        })),
-        "temporalCoverage": "2026-03-04/..",
-        "inLanguage": "en-US"
-      }
-    ]
+    "@graph": jsonLdGraph
   })} />
 
   {/* Font preload (critical for swap timing) — paired with the @font-face rules

--- a/tests/build/json-ld.test.ts
+++ b/tests/build/json-ld.test.ts
@@ -6,15 +6,53 @@ import { SITE_URL, DATASET_VARIABLES, DATASET_DISTRIBUTIONS } from '@lifegames/p
 
 const distDir = path.resolve(process.cwd(), 'dist');
 
+/** Parse the single JSON-LD @graph emitted by a built HTML page. */
+function loadGraph(relPath: string): any[] {
+  const html = readFileSync(path.join(distDir, relPath), 'utf-8');
+  const $ = load(html);
+  const scriptContent = $('script[type="application/ld+json"]').html();
+  expect(scriptContent, `${relPath} must emit a JSON-LD block`).toBeTruthy();
+  const parsed = JSON.parse(scriptContent!);
+  return parsed['@graph'];
+}
+
+/**
+ * Collect every `@id` that some node in the graph DEFINES (a node object that
+ * carries both `@type` and `@id`) and every `@id` that is REFERENCED (any nested
+ * object whose only meaningful key is `@id`, e.g. `mainEntity`, `publisher`,
+ * `isPartOf`, `creator`). A reference is dangling if it names an `@id` no node
+ * defines on the same page.
+ */
+function collectIds(graph: any[]): { defined: Set<string>; referenced: Set<string>; } {
+  const defined = new Set<string>();
+  const referenced = new Set<string>();
+  const walk = (value: any, isTopLevelNode: boolean) => {
+    if (Array.isArray(value)) {
+      value.forEach((v) => walk(v, false));
+      return;
+    }
+    if (!value || typeof value !== 'object') return;
+    if (typeof value['@id'] === 'string') {
+      if (isTopLevelNode && value['@type']) {
+        defined.add(value['@id']);
+      } else {
+        // A bare `{ "@id": ... }` (no `@type`) is a cross-reference to another node.
+        referenced.add(value['@id']);
+      }
+    }
+    for (const [key, v] of Object.entries(value)) {
+      if (key === '@id' || key === '@type') continue;
+      walk(v, false);
+    }
+  };
+  graph.forEach((node) => walk(node, true));
+  return { defined, referenced };
+}
+
 let graph: any[];
 
 beforeAll(() => {
-  const html = readFileSync(path.join(distDir, 'index.html'), 'utf-8');
-  const $ = load(html);
-  const scriptContent = $('script[type="application/ld+json"]').html();
-  expect(scriptContent).toBeTruthy();
-  const parsed = JSON.parse(scriptContent!);
-  graph = parsed['@graph'];
+  graph = loadGraph('index.html');
 });
 
 describe('JSON-LD Structured Data', () => {
@@ -101,4 +139,70 @@ describe('JSON-LD Dataset (sourced from @lifegames/portal-contract)', () => {
     }));
     expect(dataset.distribution).toEqual(expected);
   });
+
+  it('license points at the privacy page, not the bare site root', () => {
+    const dataset = graph.find((n: any) => n['@type'] === 'Dataset');
+    expect(dataset.license).toBe(SITE_URL + '/privacy');
+  });
+});
+
+// Regression guard for the /privacy + /404 bug: Dashboard.astro is the shared
+// layout for every page, and it once emitted ProfilePage + Dataset on all of
+// them (labelling the privacy policy as a person's profile page). These assert
+// the per-page @graph is internally consistent and that person-scoped nodes are
+// gated to the home page.
+describe('JSON-LD @graph per-page shape and @id resolution', () => {
+  const pages = [
+    { label: 'home', file: 'index.html', isHome: true },
+    { label: 'privacy', file: 'privacy/index.html', isHome: false },
+    { label: '404', file: '404.html', isHome: false },
+  ];
+
+  for (const page of pages) {
+    describe(`${page.label} (${page.file})`, () => {
+      let pageGraph: any[];
+      beforeAll(() => {
+        pageGraph = loadGraph(page.file);
+      });
+
+      it('parses as a non-empty JSON @graph array', () => {
+        expect(Array.isArray(pageGraph)).toBe(true);
+        expect(pageGraph.length).toBeGreaterThan(0);
+      });
+
+      it('has no dangling @id references (every reference resolves to a defined node)', () => {
+        const { defined, referenced } = collectIds(pageGraph);
+        const dangling = [...referenced].filter((id) => !defined.has(id));
+        expect(dangling, `dangling @id references on ${page.file}`).toEqual([]);
+      });
+
+      it('always carries a WebSite and a Person node', () => {
+        expect(pageGraph.some((n) => n['@type'] === 'WebSite')).toBe(true);
+        expect(pageGraph.some((n) => n['@type'] === 'Person')).toBe(true);
+      });
+
+      if (page.isHome) {
+        it('home page defines ProfilePage and Dataset', () => {
+          expect(pageGraph.some((n) => n['@type'] === 'ProfilePage')).toBe(true);
+          expect(pageGraph.some((n) => n['@type'] === 'Dataset')).toBe(true);
+        });
+
+        it('home page does NOT emit a WebPage node', () => {
+          expect(pageGraph.some((n) => n['@type'] === 'WebPage')).toBe(false);
+        });
+      } else {
+        it('non-home page does NOT emit ProfilePage or Dataset', () => {
+          expect(pageGraph.some((n) => n['@type'] === 'ProfilePage')).toBe(false);
+          expect(pageGraph.some((n) => n['@type'] === 'Dataset')).toBe(false);
+        });
+
+        it('non-home page emits a WebPage node that isPartOf the WebSite', () => {
+          const webpage = pageGraph.find((n) => n['@type'] === 'WebPage');
+          expect(webpage).toBeDefined();
+          expect(webpage.isPartOf['@id']).toBe(SITE_URL + '#website');
+          expect(webpage.name).toBeTruthy();
+        });
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Hardens the site's JSON-LD structured data, implementing the approved review of
Ethan Hawksley's [JSON-LD Explained for Personal Websites](https://hawksley.dev/blog/json-ld-explained-for-personal-websites/).
All JSON-LD lives in a single `@graph` in `src/layouts/Dashboard.astro`; every
identity string is still sourced from `@lifegames/copy` (nothing hardcoded).

### Headline bug fix

`Dashboard.astro` is the shared layout for `/`, `/privacy`, **and** `/404`, and it
emitted the `ProfilePage` and `Dataset` nodes unconditionally. That meant the
privacy policy and the 404 page were both advertising themselves to crawlers as
Jonathan Lloyd's person profile page and as the live biometric datastream.

- **Gated `ProfilePage` + `Dataset` to the home page only** (`Astro.url.pathname === '/'`).
- **Non-home pages now emit a plain `WebPage` node** (`@id` = canonical URL + `#webpage`,
  `isPartOf` the `#website`, `name` = page title, `inLanguage: en-US`).
- **`WebSite` is slimmed on non-home pages** (`@id`/`name`/`url`) so the full node is
  not repeated per page; the full `Person` stays on every page as the site publisher.

### Graph hardening

- `ProfilePage.dateModified`: was `new Date().toISOString()` (build clock -- non-deterministic
  and dishonest) -> a static, hand-maintained content-modification constant.
- `Dataset.license`: was the bare site root (meaningless) -> the `/privacy` page URL.
- `Person`: added `givenName`/`familyName` (from existing `identity.person.firstName`/`lastName`),
  `disambiguatingDescription` (from `identity.person.shortBio`), and a real 200x200 avatar
  `ImageObject` with `caption` (from `identity.a11y.ogImageAlt`). The 1200x630 OG card stays
  reserved for `og:image`. `knowsLanguage` corrected `["en"]` -> BCP-47 `["en-US"]`.
- `WebSite`: added `alternateName` (`identity.site.name`) and an `image` `ImageObject` (OG card).
- `ProfilePage`: added `name` (`About <name>`) and `isPartOf` the `#website`.

### New build test

`tests/build/json-ld.test.ts` now parses the emitted `@graph` from `/`, `/privacy`,
and `/404` and asserts:

1. Valid JSON `@graph` array on every page.
2. **No dangling `@id` references** -- every `{"@id"}` cross-reference resolves to a
   node that defines that `@id` on the same page.
3. `ProfilePage` + `Dataset` appear **only** on `/`, never on `/privacy` or `/404`.
4. A `WebPage` node (isPartOf `#website`) appears on non-home pages.
5. `WebSite` + `Person` appear on every page; `Dataset.license` points at `/privacy`.

This closes the one gap in the source article: it ships markup but no consistency check.

### Docs

Prepended a `docs/wiki/Sources-and-Acknowledgments.md` entry crediting Hawksley --
what it recommends, how we validated it against Google's ProfilePage docs, and what
we did in this PR.

## Deferred follow-ups (not in this PR)

These were intentionally scoped out because they require **real data plus new
`@lifegames/copy` fields**, and inventing identity values to satisfy the schema is
forbidden:

- **Wikidata `sameAs`** -- the highest-value Knowledge Graph signal; awaits a real
  Wikidata entity + a copy field.
- **`worksFor` / `alumniOf`** on `Person` -- await real employer/education data + copy fields.

## Verification

- `npm run build` exits 0 (all prebuild gates pass).
- `npm run test:build` passes -- 89 tests, including the new JSON-LD suite.
- `dprint check` clean.
- Manually confirmed in `dist/`: `ProfilePage` + `Dataset` on `/`, a `WebPage` node on
  `/privacy` and `/404`, and no dangling `@id` references on any page.

This is a `<head>`-only change; it alters no rendered pixels, so visual baselines are
untouched and the local visual gate was skipped (`SKIP_VISUAL=1`); CI re-verifies.
