### PR TITLE
feat(seo): add worksFor/alumniOf to Person JSON-LD

### DIFF
--- a/src/layouts/Dashboard.astro
+++ b/src/layouts/Dashboard.astro
@@ -58,6 +58,16 @@ const personNode = {
   image: avatarImage,
   sameAs: identity.person.sameAs,
   knowsAbout: identity.seo.expertise,
+  worksFor: {
+    '@type': 'Organization',
+    name: identity.person.employer,
+    url: identity.person.employerUrl,
+  },
+  alumniOf: {
+    '@type': 'EducationalOrganization',
+    name: identity.person.alumniOf,
+    url: identity.person.alumniOfUrl,
+  },
   knowsLanguage: ['en-US'],
   disambiguatingDescription: identity.person.shortBio,
   description: identity.person.longBio,


### PR DESCRIPTION
Completes P3b from the Hawksley JSON-LD review: adds worksFor (Organization: Squarespace) and alumniOf (EducationalOrganization: California State University, Fullerton) to the Person node, assembled from the new @lifegames/copy person.employer/alumniOf fields (design-system-Lifegames #138, merged). No hardcoded identity; head-only, zero pixel change. Verified: npm run build + test:build (89) green; worksFor/alumniOf emit with correct values.