### PR TITLE
test(smoke): accept a newer superseding build in the version assertion

### DIFF
--- a/.github/workflows/smoke-check.yml
+++ b/.github/workflows/smoke-check.yml
@@ -68,8 +68,13 @@ jobs:
         id: smoke
         # The just-deployed commit; the smoke check asserts the live version.json
         # serves it. Empty on workflow_dispatch -> that assertion self-skips.
+        # EXPECTED_BUILT_AFTER is this deploy's start time: a NEWER deploy that
+        # superseded this one between deploy and smoke (rapid successive merges)
+        # serves a build with builtAt >= this instant and is accepted; a stale
+        # older build (builtAt before it) still fails. See home.smoke.ts.
         env:
           EXPECTED_BUILD: ${{ github.event.workflow_run.head_sha }}
+          EXPECTED_BUILT_AFTER: ${{ github.event.workflow_run.run_started_at }}
         run: npm run test:smoke
         continue-on-error: true
 

--- a/tests/smoke/home.smoke.ts
+++ b/tests/smoke/home.smoke.ts
@@ -281,6 +281,18 @@ test.describe('production home dashboard', () => {
     const expected = process.env.EXPECTED_BUILD;
     if (!expected) return;
 
+    // Rapid successive deploys: if a NEWER deploy landed between this deploy and
+    // this smoke run (e.g. two PRs merged minutes apart), the origin correctly
+    // serves the newer build, not `expected`. That is a forward supersession, not
+    // a failed deploy, so it must pass. We distinguish it from a genuinely
+    // stale/rolled-back OLDER build by `builtAt`: EXPECTED_BUILT_AFTER is this
+    // deploy's workflow start time (workflow_run.run_started_at), and every build
+    // this deploy (or any later one) produces has builtAt >= that instant, while a
+    // stale older build's builtAt predates it. Unset (older workflow / manual
+    // dispatch) => strict exact-match, preserving the original behavior.
+    const builtAfterMs = Date.parse(process.env.EXPECTED_BUILT_AFTER ?? '');
+    const acceptsNewer = !Number.isNaN(builtAfterMs);
+
     // version.json is edge-cached (`Cache-Control: max-age=600`) and the deploy
     // does NOT purge the Cloudflare cache, so the EDGE can keep serving the
     // PREVIOUS build for up to ~10 min post-deploy. Issue #106 (smoke run
@@ -300,15 +312,24 @@ test.describe('production home dashboard', () => {
           const fresh = await page.request.get(`/version.json?cb=${Date.now()}`, {
             headers: { 'Cache-Control': 'no-cache' },
           });
-          if (fresh.status() !== 200) return null;
-          return (await fresh.json()).build as string;
+          if (fresh.status() !== 200) return false;
+          const live = await fresh.json();
+          if (live.build === expected) return true;
+          // Accept a NEWER superseding deploy (builtAt at/after this deploy started),
+          // never an older/stale one. See the comment above.
+          return (
+            acceptsNewer
+            && typeof live.builtAt === 'string'
+            && Date.parse(live.builtAt) >= builtAfterMs
+          );
         },
         {
-          message: 'live origin never served the just-deployed build within the propagation window',
+          message:
+            'live origin never served the just-deployed build (or a newer superseding build) within the propagation window',
           timeout: 60_000,
           intervals: [2_000, 3_000, 5_000],
         },
       )
-      .toBe(expected);
+      .toBe(true);
   });
 });


### PR DESCRIPTION
Fixes the rapid-deploy false positive (issue #138). The post-deploy smoke `version.json` assertion strictly required the just-deployed SHA; when a newer deploy superseded it between deploy and smoke, the origin served a newer SHA and the check filed a bogus failure issue. Now it passes if the live build equals EXPECTED_BUILD **or** its `builtAt` is at/after this deploy's start (new `EXPECTED_BUILT_AFTER` = `workflow_run.run_started_at`) — a forward supersession is fine, a stale/older build still fails. Validated against live prod (the exact #138 scenario now passes; exact match still passes). Test + workflow only; no rendered-output change.