### PR TITLE
fix(ci): bound deploy notify curl; guard worksFor/alumniOf in build test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,14 @@ jobs:
             exit 0
           fi
           sleep 30
-          curl -fsS -X POST "$DEPLOY_NOTIFY_URL" \
+          # --connect-timeout/--max-time are load-bearing: continue-on-error only
+          # swallows a non-zero EXIT, not a HANG. Without a bound, an unresponsive
+          # notify backend leaves this curl running until the job timeout (~14 min),
+          # which cancels the job and reports the whole deploy as FAILED even though
+          # Build + Deploy to Cloudflare Pages already succeeded -- and a red deploy
+          # skips the post-deploy smoke check (workflow_run.conclusion != success).
+          # Observed on runs 29775663681 (#139) and 29779665862 (#140).
+          curl -fsS --connect-timeout 5 --max-time 20 -X POST "$DEPLOY_NOTIFY_URL" \
             -H "Authorization: Bearer $DEPLOY_NOTIFY_TOKEN" \
             -H "Content-Type: application/json" \
             -d "{\"build\":\"${GITHUB_SHA}\"}"

--- a/tests/build/json-ld.test.ts
+++ b/tests/build/json-ld.test.ts
@@ -110,6 +110,26 @@ describe('JSON-LD Structured Data', () => {
     expect(person.sameAs.length).toBeGreaterThan(0);
   });
 
+  // Guards against a silently-dropped @lifegames/copy field: worksFor/alumniOf are
+  // assembled from identity.person.employer* / alumniOf*, and JSON.stringify omits
+  // undefined, so a missing copy field would vanish with no other test noticing.
+  // Structural (not value-pinned) so it survives an employer/school change.
+  it('Person has worksFor (Organization) with a name and url', () => {
+    const person = graph.find((n: any) => n['@type'] === 'Person');
+    expect(person.worksFor, 'Person.worksFor missing (copy field dropped?)').toBeDefined();
+    expect(person.worksFor['@type']).toBe('Organization');
+    expect(person.worksFor.name).toBeTruthy();
+    expect(person.worksFor.url).toMatch(/^https?:\/\//);
+  });
+
+  it('Person has alumniOf (EducationalOrganization) with a name and url', () => {
+    const person = graph.find((n: any) => n['@type'] === 'Person');
+    expect(person.alumniOf, 'Person.alumniOf missing (copy field dropped?)').toBeDefined();
+    expect(person.alumniOf['@type']).toBe('EducationalOrganization');
+    expect(person.alumniOf.name).toBeTruthy();
+    expect(person.alumniOf.url).toMatch(/^https?:\/\//);
+  });
+
   it('all urls use the canonical site URL', () => {
     const website = graph.find((n: any) => n['@type'] === 'WebSite');
     const person = graph.find((n: any) => n['@type'] === 'Person');


### PR DESCRIPTION
Two robustness fixes found while auditing today's deploys.

**deploy.yml — notify curl can hang the whole deploy.** The best-effort `Notify backend` step (`continue-on-error: true`, comment: *"a failure here must never fail the deploy"*) ran `curl` with no timeout. `continue-on-error` only swallows a non-zero **exit**, not a **hang** — so with the notify backend unresponsive, the curl ran until the ~14 min job timeout, cancelling the job and reporting the deploy **FAILED** even though `Build` + `Deploy to Cloudflare Pages` had already succeeded. A red deploy also **skips the post-deploy smoke check**. Observed on runs 29775663681 (#139) and 29779665862 (#140). Adds `--connect-timeout 5 --max-time 20`. (The backend being down is external/mantle-side; this just makes the deploy resilient to it.)

**json-ld build test — no guard on worksFor/alumniOf.** They're assembled from `@lifegames/copy` fields and `JSON.stringify` drops `undefined`, so a dropped copy field would silently vanish. Adds value-agnostic structural guards (home `Person` has `worksFor`=Organization and `alumniOf`=EducationalOrganization, each with a name + http url).

Verified: `build` exit 0, `test:build` 91 passed (+2), YAML valid, dprint clean. CI/test-only; no rendered-output change.