### PR TITLE
feat(config): adopt @j0nathan-ll0yd/config (dprint) + add typecheck & lint gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,14 @@ updates:
       - dependency-name: "@napi-rs/image"
         update-types:
           - version-update:semver-major
+      # typescript is pinned to ^5 (<6.0.0). The latest published TypeScript is
+      # the native TS 7 line, but @astrojs/check (peer ^5 || ^6) and
+      # typescript-eslint v8 (peer >=4.8.4 <6.1.0) do not support it. Adopt a
+      # newer major only when both the astro check toolchain and typescript-eslint
+      # declare support; until then Dependabot must not open TS major-bump PRs.
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/audit-web.yml
+++ b/.github/workflows/audit-web.yml
@@ -38,6 +38,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
+  packages: read # read @j0nathan-ll0yd/config from GitHub Packages during ci-setup.sh's npm ci
 
 jobs:
   daily:
@@ -60,6 +61,7 @@ jobs:
         env:
           DS_REF: main
           LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci-setup.sh
 
       - name: Install Playwright Chromium
@@ -129,6 +131,7 @@ jobs:
         env:
           DS_REF: main
           LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci-setup.sh
 
       # validate-sitemap.mjs shells out to xmllint (scripts/audit/vendor/*.xsd
@@ -281,6 +284,7 @@ jobs:
         env:
           DS_REF: main
           LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci-setup.sh
 
       - name: B2 -- security.txt RFC 9116 expiry

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  packages: read # read @j0nathan-ll0yd/config from GitHub Packages during ci-setup.sh's npm ci
 
 concurrency:
   group: deploy
@@ -29,6 +30,7 @@ jobs:
       - name: Setup design-system + install dependencies
         env:
           LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci-setup.sh
 
       - name: Build
@@ -87,6 +89,7 @@ jobs:
       - name: Setup design-system + install dependencies
         env:
           LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci-setup.sh
 
       - name: Check for new images

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,16 +1,40 @@
 name: Format
 
-# Blocking format gate (dprint). Prevents the quote/reflow churn that used to slip in
-# because the repo had no formatter — see dprint.json. Local: `npm run format`.
+# Blocking format gate (dprint). dprint.json now `extends` the shared
+# @j0nathan-ll0yd/config base from node_modules, so the check must run against an
+# installed dependency tree -- the standalone dprint/check action cannot resolve a
+# package `extends`. We install via the repo's design-system setup (ci-setup.sh)
+# and run `npm run format:check`. The @j0nathan-ll0yd scope lives on GitHub
+# Packages; the built-in Actions token authenticates it via `packages: read`
+# (the committed .npmrc expands ${GITHUB_TOKEN}). Local: `npm run format`.
 on:
   pull_request:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Setup design-system + install dependencies
+        env:
+          DS_REF: main
+          LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci-setup.sh
+
       - name: dprint check
-        uses: dprint/check@2f1cf31537886c3bfb05591c031f7744e48ba8a1 # v2.2
+        run: npm run format:check

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  packages: read # read @j0nathan-ll0yd/config from GitHub Packages during ci-setup.sh's npm ci
 
 jobs:
   preview:
@@ -31,6 +32,7 @@ jobs:
       - name: Setup design-system + install dependencies
         env:
           LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci-setup.sh
 
       - name: Build

--- a/.github/workflows/smoke-check.yml
+++ b/.github/workflows/smoke-check.yml
@@ -38,6 +38,7 @@ on:
 permissions:
   contents: read
   issues: write
+  packages: read # read @j0nathan-ll0yd/config from GitHub Packages during ci-setup.sh's npm ci
 
 jobs:
   smoke-check:
@@ -59,6 +60,7 @@ jobs:
         env:
           DS_REF: main
           LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci-setup.sh
 
       - name: Install Playwright Chromium

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -1,0 +1,71 @@
+name: Static Checks
+
+# Type-safety + lint gates (Wave 2: adopt @j0nathan-ll0yd/config).
+#   - typecheck: `astro check` against the estate tsconfig floor
+#     (astro/tsconfigs/strict + @j0nathan-ll0yd/config/tsconfig-base.json).
+#   - lint: `eslint .` with the estate flat-config standard (type-aware).
+#
+# Both need the yalc-linked @lifegames/* packages resolved (src imports them), so
+# they use the same design-system setup as deploy.yml (ci-setup.sh). The
+# @j0nathan-ll0yd scope is on GitHub Packages; `packages: read` + the built-in
+# Actions token (committed .npmrc expands ${GITHUB_TOKEN}) authenticate it during
+# ci-setup.sh's `npm ci`.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Setup design-system + install dependencies
+        env:
+          DS_REF: main
+          LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci-setup.sh
+
+      - name: Type check (astro check)
+        run: npm run typecheck
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Setup design-system + install dependencies
+        env:
+          DS_REF: main
+          LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci-setup.sh
+
+      # Generate Astro's content-collection types (.astro/*.d.ts) so type-aware
+      # ESLint can resolve `astro:content` in src/content.config.ts. astro check
+      # syncs on its own; eslint does not, so sync explicitly here.
+      - name: Astro sync
+        run: npx astro sync
+
+      - name: Lint (eslint)
+        run: npm run lint

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -37,6 +37,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: read # read @j0nathan-ll0yd/config from GitHub Packages during ci-setup.sh / npm ci
 
 jobs:
   contract-check:
@@ -92,6 +93,7 @@ jobs:
           DS_REF: ${{ steps.producers.outputs.ds_ref }}
           LP_REF: ${{ steps.producers.outputs.lp_ref }}
           LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci-setup.sh
 
       # Tier 2 (Plan #11): the single contract gate. Recomputes the expected lock
@@ -163,6 +165,7 @@ jobs:
           DS_REF: ${{ steps.producers.outputs.ds_ref }}
           LP_REF: ${{ steps.producers.outputs.lp_ref }}
           LP_REPO_TOKEN: ${{ secrets.LP_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci-setup.sh
 
       - name: Run unit tests (app-owned client runtime)
@@ -208,6 +211,8 @@ jobs:
           name: visual-tests-ds-dist
 
       - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm ci --legacy-peer-deps
 
       - name: Run visual regression tests
@@ -268,6 +273,8 @@ jobs:
           name: visual-tests-ds-dist
 
       - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm ci --legacy-peer-deps
 
       - name: Run behavioral (interaction) tests
@@ -385,6 +392,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Install dependencies (Playwright CLI only)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm ci --legacy-peer-deps
       - name: Download blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,13 +1,39 @@
 #!/usr/bin/env sh
-# Pre-push visual-regression gate.
+# Pre-push gates.
 #
-# Runs the full Playwright visual suite in the same Docker image (arm64-native
-# under Apple Virtualization Framework) that the self-hosted CI runner is
-# built FROM. A passing run here means the PNG bytes will match CI.
-#
-# Bypass: `SKIP_VISUAL=1 git push` (use for branches that genuinely don't touch
-# rendered output -- e.g. docs-only edits -- and accept that CI will catch any
-# pixel regression on the PR).
+# 1) Static quality gates (fast): dprint format check, astro check (types), and
+#    ESLint. These mirror the CI jobs (format-check.yml + static-checks.yml) so a
+#    red check never reaches the PR. Always run -- SKIP_VISUAL does not skip them.
+#    Order: typecheck before lint, because `astro check` syncs .astro content
+#    types that type-aware ESLint needs to resolve `astro:content`.
+# 2) Visual-regression suite (slow, Docker): runs the full Playwright suite in the
+#    same arm64-native image the self-hosted CI runner is built FROM, so a passing
+#    run means the PNG bytes will match CI. Bypass with `SKIP_VISUAL=1 git push`
+#    (use only for branches that genuinely don't touch rendered output -- e.g.
+#    docs-only edits -- and accept that CI will catch any pixel regression).
+
+echo "[pre-push] Static gates: format:check -> typecheck -> lint"
+
+if ! npm run format:check; then
+  echo ""
+  echo "ERROR: dprint format check failed. Fix with:  npm run format"
+  echo ""
+  exit 1
+fi
+
+if ! npm run typecheck; then
+  echo ""
+  echo "ERROR: astro check (typecheck) failed. Fix the type errors above."
+  echo ""
+  exit 1
+fi
+
+if ! npm run lint; then
+  echo ""
+  echo "ERROR: eslint failed. Fix the lint errors above (some are auto-fixable:  npx eslint . --fix)."
+  echo ""
+  exit 1
+fi
 
 if [ "${SKIP_VISUAL:-0}" = "1" ]; then
   echo "[pre-push] SKIP_VISUAL=1 -- bypassing local visual gate. CI will re-verify."

--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,10 @@
 # visual-tests.yml, scripts/run-in-docker.sh); this makes plain `npm ci` /
 # `npm install` behave identically. Remove when @vite-pwa/astro supports astro 6.
 legacy-peer-deps=true
+
+# @j0nathan-ll0yd/config (dprint/tsconfig/eslint standard) is published to
+# GitHub Packages. npm expands ${GITHUB_TOKEN} from the environment (unlike
+# pnpm), so CI authenticates with the workflow token in env and local installs
+# fall through to the token in the developer's machine ~/.npmrc.
+@j0nathan-ll0yd:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/.puppeteerrc.cjs
+++ b/.puppeteerrc.cjs
@@ -19,6 +19,4 @@
 /**
  * @type {import("puppeteer").Configuration}
  */
-module.exports = {
-  skipDownload: true,
-};
+module.exports = {skipDownload: true}

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,43 +1,35 @@
-import { defineConfig } from 'astro/config';
-import AstroPWA from '@vite-pwa/astro';
-import sitemap from '@astrojs/sitemap';
-import { CLOUDFRONT_BASE, SITE_URL } from '@lifegames/portal-contract/constants';
-import identity from '@lifegames/copy/identity.flat.json';
+import {defineConfig} from 'astro/config'
+import AstroPWA from '@vite-pwa/astro'
+import sitemap from '@astrojs/sitemap'
+import {CLOUDFRONT_BASE, SITE_URL} from '@lifegames/portal-contract/constants'
+import identity from '@lifegames/copy/identity.flat.json'
 
 // Host portion of CLOUDFRONT_BASE, regex-escaped for use in service-worker
 // urlPattern RegExps so the CloudFront host is never hardcoded here.
-const CF_HOST = new URL(CLOUDFRONT_BASE).host;
-const CF_HOST_RE = CF_HOST.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const CF_HOST = new URL(CLOUDFRONT_BASE).host
+const CF_HOST_RE = CF_HOST.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 export default defineConfig({
   site: SITE_URL,
   output: 'static',
   trailingSlash: 'never',
-  build: { inlineStylesheets: 'always' },
+  build: {inlineStylesheets: 'always'},
   vite: {
     define: {
       // Expose the build-time fixture-variation selector to source. Astro/Vite
       // only forwards VITE_-prefixed env to import.meta.env by default; the
       // visual suite sets FIXTURE_VARIATION on the build process to pick a named
       // @lifegames/fixtures post-adapter variation (default 'baseline').
-      'import.meta.env.FIXTURE_VARIATION': JSON.stringify(process.env.FIXTURE_VARIATION ?? 'baseline'),
+      'import.meta.env.FIXTURE_VARIATION': JSON.stringify(process.env.FIXTURE_VARIATION ?? 'baseline')
     },
     build: {
       // Force every bundled JS chunk to emit as an external _astro/*.js file
       // instead of being inlined into the HTML. Required because production CSP
       // (functions/_middleware.ts) does not allow inline scripts — `'self'` only
       // covers the hashed external chunks. See .omc/plans/fix-bio-csp-blocked-inline-script.md.
-      assetsInlineLimit: 0,
+      assetsInlineLimit: 0
     },
-    server: {
-      proxy: {
-        '/api/live': {
-          target: CLOUDFRONT_BASE,
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/api\/live/, ''),
-        },
-      },
-    },
+    server: {proxy: {'/api/live': {target: CLOUDFRONT_BASE, changeOrigin: true, rewrite: (path) => path.replace(/^\/api\/live/, '')}}}
   },
   integrations: [
     sitemap(),
@@ -57,9 +49,9 @@ export default defineConfig({
         background_color: '#06060f',
         display: 'standalone',
         icons: [
-          { src: '/assets/icon-192.png', sizes: '192x192', type: 'image/png' },
-          { src: '/assets/icon-512.png', sizes: '512x512', type: 'image/png', purpose: 'any maskable' },
-        ],
+          {src: '/assets/icon-192.png', sizes: '192x192', type: 'image/png'},
+          {src: '/assets/icon-512.png', sizes: '512x512', type: 'image/png', purpose: 'any maskable'}
+        ]
       },
       workbox: {
         globPatterns: ['**/*.{css,js,html,svg,png,ico,txt,webmanifest,woff2}'],
@@ -79,34 +71,23 @@ export default defineConfig({
             // Local optimized images — CacheFirst (downloaded at build time from CloudFront)
             urlPattern: /\/images\/(books|theatre)\//,
             handler: 'CacheFirst',
-            options: {
-              cacheName: 'local-images',
-              expiration: { maxEntries: 200, maxAgeSeconds: 2592000 },
-            },
+            options: {cacheName: 'local-images', expiration: {maxEntries: 200, maxAgeSeconds: 2592000}}
           },
           {
             // CloudFront images fallback — safety net for onerror fallback fetches
             urlPattern: new RegExp(`^https://${CF_HOST_RE}/images/`),
             handler: 'CacheFirst',
-            options: {
-              cacheName: 'optimized-images-fallback',
-              expiration: { maxEntries: 50, maxAgeSeconds: 604800 },
-            },
+            options: {cacheName: 'optimized-images-fallback', expiration: {maxEntries: 50, maxAgeSeconds: 604800}}
           },
           {
             // CloudFront JSON data — NetworkFirst for guaranteed freshness
             // Poll requests (?_poll=1) bypass the SW entirely via negative lookahead
             urlPattern: new RegExp(`^https://${CF_HOST_RE}/(?!.*[?&]_poll=).*\\.json$`),
             handler: 'NetworkFirst',
-            options: {
-              cacheName: 'live-data',
-              networkTimeoutSeconds: 3,
-              fetchOptions: { cache: 'no-store' },
-              expiration: { maxAgeSeconds: 300 },
-            },
-          },
-        ],
-      },
-    }),
-  ],
-});
+            options: {cacheName: 'live-data', networkTimeoutSeconds: 3, fetchOptions: {cache: 'no-store'}, expiration: {maxAgeSeconds: 300}}
+          }
+        ]
+      }
+    })
+  ]
+})

--- a/dprint.json
+++ b/dprint.json
@@ -1,20 +1,7 @@
 {
   "$schema": "https://dprint.dev/schemas/v0.json",
 
-  "lineWidth": 120,
-  "indentWidth": 2,
-  "useTabs": false,
-  "newLineKind": "lf",
-
-  "typescript": {
-    "quoteStyle": "preferSingle",
-    "jsx.quoteStyle": "preferSingle",
-    "semiColons": "always",
-    "trailingCommas": "onlyMultiLine",
-    "arrowFunction.useParentheses": "force",
-    "importDeclaration.sortNamedImports": "maintain",
-    "module.sortImportDeclarations": "maintain"
-  },
+  "extends": "./node_modules/@j0nathan-ll0yd/config/dprint.json",
 
   "includes": [
     "src/**/*.{ts,tsx}",
@@ -34,9 +21,5 @@
     "**/*.d.ts",
     "**/*.astro",
     "src/env.d.ts"
-  ],
-
-  "plugins": [
-    "https://plugins.dprint.dev/typescript-0.93.4.wasm"
   ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,43 @@
+import {createBaseConfig} from '@j0nathan-ll0yd/config/eslint'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+// Estate-standard flat config (@j0nathan-ll0yd/config). Formatting is owned by
+// dprint; this only enforces lint rules. Type-aware rules are enabled via
+// `tsconfigRootDir`, so every type-aware-linted file must be in tsconfig.json's
+// project graph. tests/** is excluded there, so it is ignored here too (bringing
+// tests under type-aware lint needs a dedicated tests tsconfig -- a separate change).
+export default [
+  {
+    ignores: [
+      'dist/**',
+      '.astro/**',
+      '.yalc/**',
+      'coverage/**',
+      'node_modules/**',
+      'previews/**',
+      'playwright-report/**',
+      'test-results/**',
+      'docs/**',
+      'public/**',
+      'tests/**',
+      '**/*.d.ts'
+    ]
+  },
+  ...createBaseConfig({tsconfigRootDir: import.meta.dirname}),
+  {
+    // Build/config scripts are plain JS (.mjs/.cjs/.js) and are not part of the
+    // typed project graph. Turn off type-aware linting for them (disableTypeChecked
+    // also turns off the project service, which would otherwise fail to resolve
+    // them, e.g. .puppeteerrc.cjs).
+    files: ['**/*.{js,mjs,cjs}'],
+    ...tseslint.configs.disableTypeChecked
+  },
+  {
+    // Node globals for the same build/config scripts (process, console, Buffer,
+    // fetch, ...). Separate object so it merges with disableTypeChecked above
+    // rather than replacing its parserOptions.
+    files: ['**/*.{js,mjs,cjs}'],
+    languageOptions: {globals: {...globals.node}}
+  }
+]

--- a/functions/_lib/proxy.ts
+++ b/functions/_lib/proxy.ts
@@ -8,34 +8,31 @@
 // Not itself a route: Pages Functions only creates routes for modules that
 // export an onRequest* handler; this module exports a factory.
 
-import { CLOUDFRONT_BASE } from '@lifegames/portal-contract/constants';
+import {CLOUDFRONT_BASE} from '@lifegames/portal-contract/constants'
 
 // Minimal Cloudflare Pages Function fetch options — only the cf cache fields used here.
 interface CfRequestInit extends RequestInit {
-  cf?: { cacheTtl?: number; cacheEverything?: boolean; };
+  cf?: {cacheTtl?: number; cacheEverything?: boolean}
 }
 
 export interface CloudfrontProxyConfig {
   /** Artifact path on the CloudFront data plane, e.g. '/llms-full.txt'. */
-  path: string;
+  path: string
   /** Content-Type served to the client (CloudFront serves its own; the route owns the public one). */
-  contentType: string;
+  contentType: string
 }
 
 /** Builds an onRequest handler that proxies one CloudFront artifact with edge caching. */
-export function makeCloudfrontProxy({ path, contentType }: CloudfrontProxyConfig): () => Promise<Response> {
-  const upstreamUrl = `${CLOUDFRONT_BASE}${path}`;
-  const artifactName = path.slice(1);
+export function makeCloudfrontProxy({path, contentType}: CloudfrontProxyConfig): () => Promise<Response> {
+  const upstreamUrl = `${CLOUDFRONT_BASE}${path}`
+  const artifactName = path.slice(1)
 
   return async function onRequest(): Promise<Response> {
-    const init: CfRequestInit = { cf: { cacheTtl: 3600, cacheEverything: true } };
-    const upstream = await fetch(upstreamUrl, init);
+    const init: CfRequestInit = {cf: {cacheTtl: 3600, cacheEverything: true}}
+    const upstream = await fetch(upstreamUrl, init)
 
     if (!upstream.ok) {
-      return new Response(`${artifactName} unavailable`, {
-        status: 502,
-        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-      });
+      return new Response(`${artifactName} unavailable`, {status: 502, headers: {'Content-Type': 'text/plain; charset=utf-8'}})
     }
 
     return new Response(upstream.body, {
@@ -43,8 +40,8 @@ export function makeCloudfrontProxy({ path, contentType }: CloudfrontProxyConfig
       headers: {
         'Content-Type': contentType,
         'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400',
-        'X-Source': 'cloudfront-proxy',
-      },
-    });
-  };
+        'X-Source': 'cloudfront-proxy'
+      }
+    })
+  }
 }

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -2,12 +2,12 @@
 // Replaces both cloudflare/api-catalog-content-type.js (Worker) and public/_headers
 // because root middleware disables _headers file processing.
 
-import { CLOUDFRONT_BASE, LLM_CONTENT_PATHS, WEBSOCKET_URL } from '@lifegames/portal-contract/constants';
+import {CLOUDFRONT_BASE, LLM_CONTENT_PATHS, WEBSOCKET_URL} from '@lifegames/portal-contract/constants'
 
 // WebSocket CSP source is the ORIGIN only (no /live path); CLOUDFRONT_BASE is
 // already an origin. Sourcing both from the contract keeps the CSP in sync with
 // the live addressing without hardcoded literals.
-const WEBSOCKET_ORIGIN = new URL(WEBSOCKET_URL).origin;
+const WEBSOCKET_ORIGIN = new URL(WEBSOCKET_URL).origin
 
 const CSP = [
   "default-src 'self'",
@@ -24,13 +24,13 @@ const CSP = [
   'upgrade-insecure-requests',
   // Violation reporting: report-to (Reporting API, modern) + report-uri (legacy fallback).
   // The named endpoint matches the Reporting-Endpoints header set below.
-  'report-uri /api/csp-report; report-to csp-endpoint',
-].join('; ') + ';';
+  'report-uri /api/csp-report; report-to csp-endpoint'
+].join('; ') + ';'
 
 // CSP violation reports are collected at /api/csp-report (functions/api/csp-report.ts).
 // The Reporting-Endpoints header names the endpoint; the CSP report-to directive references
 // that name. report-uri is retained as a fallback for older browsers (Firefox <130, Safari <17).
-const REPORTING_ENDPOINTS = 'csp-endpoint="https://jonathanlloyd.me/api/csp-report"';
+const REPORTING_ENDPOINTS = 'csp-endpoint="https://jonathanlloyd.me/api/csp-report"'
 
 // Trusted Types telemetry, REPORT-ONLY (non-enforcing). Every script is first-party
 // (script-src 'self') with no user-input XSS surface, so this does NOT enforce
@@ -38,7 +38,7 @@ const REPORTING_ENDPOINTS = 'csp-endpoint="https://jonathanlloyd.me/api/csp-repo
 // /api/csp-report collector to scope a possible future enforcement. Review the reports,
 // then remove this or promote the directive into the enforced CSP. Expect roughly one
 // report per innerHTML sink while it runs.
-const CSP_REPORT_ONLY = "require-trusted-types-for 'script'; report-uri /api/csp-report; report-to csp-endpoint";
+const CSP_REPORT_ONLY = "require-trusted-types-for 'script'; report-uri /api/csp-report; report-to csp-endpoint"
 
 const LINK_HEADER = [
   '</llms.txt>; rel="describedby"; type="text/plain"',
@@ -48,56 +48,48 @@ const LINK_HEADER = [
   '</sitemap-index.xml>; rel="sitemap"',
   '</humans.txt>; rel="author"',
   '</feed.xml>; rel="alternate"; type="application/rss+xml"',
-  '</feed.json>; rel="alternate"; type="application/feed+json"',
-].join(', ');
+  '</feed.json>; rel="alternate"; type="application/feed+json"'
+].join(', ')
 
 // Minimal Cloudflare Pages Function context -- only the fields this middleware reads.
 // Avoids pulling in @cloudflare/workers-types just for one signature.
 interface PagesContext {
-  request: Request;
-  next(): Promise<Response>;
+  request: Request
+  next(): Promise<Response>
 }
 
 export async function onRequest(context: PagesContext): Promise<Response> {
-  const { request } = context;
-  const url = new URL(request.url);
-  const accept = request.headers.get('Accept') || '';
+  const {request} = context
+  const url = new URL(request.url)
+  const accept = request.headers.get('Accept') || ''
 
   // Markdown negotiation: serve pre-composed markdown from CloudFront when
   // agents send Accept: text/markdown (passes isitagentready.com check)
   if (accept.includes('text/markdown')) {
-    const mdResponse = await fetch(
-      `${CLOUDFRONT_BASE}${LLM_CONTENT_PATHS.llmsFull}`,
-    );
+    const mdResponse = await fetch(`${CLOUDFRONT_BASE}${LLM_CONTENT_PATHS.llmsFull}`)
     return new Response(mdResponse.body, {
       status: mdResponse.status,
-      headers: {
-        'Content-Type': 'text/markdown',
-        'Cache-Control': 'no-store',
-        'x-markdown-tokens': '2500',
-      },
-    });
+      headers: {'Content-Type': 'text/markdown', 'Cache-Control': 'no-store', 'x-markdown-tokens': '2500'}
+    })
   }
 
-  const response = await context.next();
-  const headers = new Headers(response.headers);
+  const response = await context.next()
+  const headers = new Headers(response.headers)
 
   // Security headers
-  headers.set('Content-Security-Policy', CSP);
-  headers.set('Reporting-Endpoints', REPORTING_ENDPOINTS);
-  headers.set('Content-Security-Policy-Report-Only', CSP_REPORT_ONLY);
-  headers.set('X-Content-Type-Options', 'nosniff');
-  headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  headers.set('Content-Security-Policy', CSP)
+  headers.set('Reporting-Endpoints', REPORTING_ENDPOINTS)
+  headers.set('Content-Security-Policy-Report-Only', CSP_REPORT_ONLY)
+  headers.set('X-Content-Type-Options', 'nosniff')
+  headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
   // HSTS: 2-year max-age + subdomains. Preload intentionally omitted -- owner-gated process.
-  headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
-  headers.set('X-Frame-Options', 'DENY');
+  headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains')
+  headers.set('X-Frame-Options', 'DENY')
   // COOP: same-origin-allow-popups permits OAuth/payment popups while isolating the browsing context.
   // COEP/CORP omitted -- would break cross-origin Amazon and Carto tile resources.
-  headers.set('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
-  headers.set(
-    'Permissions-Policy',
-    'accelerometer=(), ambient-light-sensor=(), autoplay=(), bluetooth=(), camera=(), compute-pressure=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-create=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()',
-  );
+  headers.set('Cross-Origin-Opener-Policy', 'same-origin-allow-popups')
+  headers.set('Permissions-Policy',
+    'accelerometer=(), ambient-light-sensor=(), autoplay=(), bluetooth=(), camera=(), compute-pressure=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-create=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), speaker-selection=(), usb=(), web-share=(), xr-spatial-tracking=()')
 
   // sw.js and version.json must always revalidate so a new deploy is picked up
   // promptly: sw.js drives the update-check path in public/js/sw-register.js, and
@@ -106,40 +98,30 @@ export async function onRequest(context: PagesContext): Promise<Response> {
   // Chromium already bypasses the HTTP cache for sw.js via updateViaCache:'imports';
   // this covers older engines and version.json defensively.
   if (url.pathname === '/sw.js' || url.pathname === '/version.json') {
-    headers.set('Cache-Control', 'max-age=0, no-store');
+    headers.set('Cache-Control', 'max-age=0, no-store')
   }
 
   // Homepage: disable CDN caching so content negotiation always works
   // (Cloudflare edge cache bypasses Functions on cache HITs,
   //  and Pages overrides Function-set Cache-Control for HTML assets)
   if (url.pathname === '/') {
-    headers.set('Link', LINK_HEADER);
-    headers.set('CDN-Cache-Control', 'no-store');
+    headers.set('Link', LINK_HEADER)
+    headers.set('CDN-Cache-Control', 'no-store')
     // Prevent UTM/ad-click params from fragmenting the cache or Back/Forward Cache.
-    headers.set(
-      'No-Vary-Search',
-      'params=("utm_source" "utm_medium" "utm_campaign" "utm_term" "utm_content" "gclid" "fbclid")',
-    );
+    headers.set('No-Vary-Search', 'params=("utm_source" "utm_medium" "utm_campaign" "utm_term" "utm_content" "gclid" "fbclid")')
   }
 
   // API catalog Content-Type override for RFC 9727 compliance
   if (url.pathname === '/.well-known/api-catalog') {
-    headers.set(
-      'Content-Type',
-      'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
-    );
+    headers.set('Content-Type', 'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"')
   }
 
   // WebFinger (RFC 7033) Content-Type + permissive CORS for the static JRD at
   // public/.well-known/webfinger. Mirrors the api-catalog override above.
   if (url.pathname === '/.well-known/webfinger') {
-    headers.set('Content-Type', 'application/jrd+json');
-    headers.set('Access-Control-Allow-Origin', '*');
+    headers.set('Content-Type', 'application/jrd+json')
+    headers.set('Access-Control-Allow-Origin', '*')
   }
 
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
+  return new Response(response.body, {status: response.status, statusText: response.statusText, headers})
 }

--- a/functions/api/csp-report.ts
+++ b/functions/api/csp-report.ts
@@ -6,46 +6,40 @@
 
 // Minimal Cloudflare Pages Function context -- only the fields this handler reads.
 interface PagesContext {
-  request: Request;
+  request: Request
 }
 
 const ACCEPTED_CONTENT_TYPES = [
   'application/csp-report',
-  'application/reports+json',
-];
+  'application/reports+json'
+]
 
 export async function onRequestPost(context: PagesContext): Promise<Response> {
-  const { request } = context;
+  const {request} = context
 
-  const contentType = request.headers.get('Content-Type') ?? '';
-  const accepted = ACCEPTED_CONTENT_TYPES.some((t) => contentType.includes(t));
+  const contentType = request.headers.get('Content-Type') ?? ''
+  const accepted = ACCEPTED_CONTENT_TYPES.some((t) => contentType.includes(t))
   if (!accepted) {
-    return new Response(null, { status: 415 });
+    return new Response(null, {status: 415})
   }
 
-  const userAgent = request.headers.get('User-Agent') ?? '';
+  const userAgent = request.headers.get('User-Agent') ?? ''
 
   try {
-    const body = await request.text();
+    const body = await request.text()
     // Parse permissively -- both report types are JSON; swallow errors so a
     // malformed body never causes a retry storm.
-    let report: unknown;
+    let report: unknown
     try {
-      report = JSON.parse(body);
+      report = JSON.parse(body)
     } catch {
-      report = { raw: body };
+      report = {raw: body}
     }
 
-    console.log(
-      JSON.stringify({
-        event: 'csp-report',
-        userAgent,
-        report,
-      }),
-    );
+    console.log(JSON.stringify({event: 'csp-report', userAgent, report}))
   } catch {
     // Body read failure -- still return 204 to suppress retries.
   }
 
-  return new Response(null, { status: 204 });
+  return new Response(null, {status: 204})
 }

--- a/functions/cf-insights.js.ts
+++ b/functions/cf-insights.js.ts
@@ -16,44 +16,36 @@
 // never affected — never a 5xx (which would trip the smoke console-error check).
 // Mirrors functions/sa.ts (the Simple Analytics first-party proxy).
 
-const BEACON_URL = 'https://static.cloudflareinsights.com/beacon.min.js';
+const BEACON_URL = 'https://static.cloudflareinsights.com/beacon.min.js'
 
 // Minimal Cloudflare Pages Function fetch options — only the cf cache fields used here.
 interface CfRequestInit extends RequestInit {
-  cf?: { cacheTtl?: number; cacheEverything?: boolean; };
+  cf?: {cacheTtl?: number; cacheEverything?: boolean}
 }
 
 function unavailable(): Response {
   return new Response('/* cf-insights unavailable */', {
     status: 200,
-    headers: {
-      'Content-Type': 'application/javascript; charset=utf-8',
-      'Cache-Control': 'no-store',
-    },
-  });
+    headers: {'Content-Type': 'application/javascript; charset=utf-8', 'Cache-Control': 'no-store'}
+  })
 }
 
 export async function onRequest(): Promise<Response> {
-  const init: CfRequestInit = {
-    cf: { cacheTtl: 86400, cacheEverything: true },
-  };
+  const init: CfRequestInit = {cf: {cacheTtl: 86400, cacheEverything: true}}
 
-  let upstream: Response;
+  let upstream: Response
   try {
-    upstream = await fetch(BEACON_URL, init);
+    upstream = await fetch(BEACON_URL, init)
   } catch {
-    return unavailable();
+    return unavailable()
   }
 
   if (!upstream.ok) {
-    return unavailable();
+    return unavailable()
   }
 
   return new Response(upstream.body, {
     status: 200,
-    headers: {
-      'Content-Type': 'application/javascript; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400',
-    },
-  });
+    headers: {'Content-Type': 'application/javascript; charset=utf-8', 'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400'}
+  })
 }

--- a/functions/cf-rum.ts
+++ b/functions/cf-rum.ts
@@ -10,65 +10,54 @@
 // else 204) and Cache-Control: no-store — never a 4xx/5xx, which would surface as
 // a console error and trip the post-deploy smoke check.
 
-const RUM_UPSTREAM = 'https://cloudflareinsights.com/cdn-cgi/rum';
+const RUM_UPSTREAM = 'https://cloudflareinsights.com/cdn-cgi/rum'
 
 // Minimal Cloudflare Pages Function context — only the field used here.
 interface PagesContext {
-  request: Request;
+  request: Request
 }
 
 // Minimal CF fetch extensions. `duplex` is required by undici (Node) when
 // streaming a request body; it is a no-op on the Cloudflare Workers runtime.
 interface CfRequestInit extends RequestInit {
-  duplex?: 'half';
+  duplex?: 'half'
 }
 
 function noContent(): Response {
-  return new Response(null, {
-    status: 204,
-    headers: { 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store' },
-  });
+  return new Response(null, {status: 204, headers: {'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store'}})
 }
 
 export async function onRequest(context: PagesContext): Promise<Response> {
-  const { request } = context;
+  const {request} = context
 
   // The beacon only POSTs; anything else is a no-op.
   if (request.method !== 'POST') {
-    return noContent();
+    return noContent()
   }
 
-  const outboundHeaders: Record<string, string> = {};
-  const contentType = request.headers.get('Content-Type');
+  const outboundHeaders: Record<string, string> = {}
+  const contentType = request.headers.get('Content-Type')
   if (contentType) {
-    outboundHeaders['Content-Type'] = contentType;
+    outboundHeaders['Content-Type'] = contentType
   }
-  const clientIp = request.headers.get('CF-Connecting-IP');
+  const clientIp = request.headers.get('CF-Connecting-IP')
   if (clientIp) {
-    outboundHeaders['X-Forwarded-For'] = clientIp;
+    outboundHeaders['X-Forwarded-For'] = clientIp
   }
 
-  let upstream: Response;
+  let upstream: Response
   try {
-    const init: CfRequestInit = {
-      method: 'POST',
-      headers: outboundHeaders,
-      body: request.body,
-      duplex: 'half',
-    };
-    upstream = await fetch(RUM_UPSTREAM, init);
+    const init: CfRequestInit = {method: 'POST', headers: outboundHeaders, body: request.body, duplex: 'half'}
+    upstream = await fetch(RUM_UPSTREAM, init)
   } catch {
     // Network failure — swallow so the page stays clean (data best-effort).
-    return noContent();
+    return noContent()
   }
 
   // Forward a 2xx through; collapse any non-2xx to 204 so the browser never
   // logs an error (RUM data is best-effort telemetry).
   if (upstream.ok) {
-    return new Response(null, {
-      status: 204,
-      headers: { 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store' },
-    });
+    return new Response(null, {status: 204, headers: {'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store'}})
   }
-  return noContent();
+  return noContent()
 }

--- a/functions/feed.json.ts
+++ b/functions/feed.json.ts
@@ -1,9 +1,6 @@
 // Pages Function: proxy /feed.json from CloudFront with edge caching.
 // The backend (mantle-LifegamesPortal) owns the canonical JSON Feed 1.1.
 
-import { makeCloudfrontProxy } from './_lib/proxy';
+import {makeCloudfrontProxy} from './_lib/proxy'
 
-export const onRequest = makeCloudfrontProxy({
-  path: '/feed.json',
-  contentType: 'application/feed+json; charset=utf-8',
-});
+export const onRequest = makeCloudfrontProxy({path: '/feed.json', contentType: 'application/feed+json; charset=utf-8'})

--- a/functions/feed.xml.ts
+++ b/functions/feed.xml.ts
@@ -1,9 +1,6 @@
 // Pages Function: proxy /feed.xml from CloudFront with edge caching.
 // The backend (mantle-LifegamesPortal) owns the canonical RSS 2.0 feed.
 
-import { makeCloudfrontProxy } from './_lib/proxy';
+import {makeCloudfrontProxy} from './_lib/proxy'
 
-export const onRequest = makeCloudfrontProxy({
-  path: '/feed.xml',
-  contentType: 'application/rss+xml; charset=utf-8',
-});
+export const onRequest = makeCloudfrontProxy({path: '/feed.xml', contentType: 'application/rss+xml; charset=utf-8'})

--- a/functions/index.md.ts
+++ b/functions/index.md.ts
@@ -3,10 +3,7 @@
 // expecting .md extensions); this route ensures it resolves on jonathanlloyd.me,
 // not only on the raw CloudFront host.
 
-import { LLM_CONTENT_PATHS } from '@lifegames/portal-contract/constants';
-import { makeCloudfrontProxy } from './_lib/proxy';
+import {LLM_CONTENT_PATHS} from '@lifegames/portal-contract/constants'
+import {makeCloudfrontProxy} from './_lib/proxy'
 
-export const onRequest = makeCloudfrontProxy({
-  path: LLM_CONTENT_PATHS.indexMarkdown,
-  contentType: 'text/markdown; charset=utf-8',
-});
+export const onRequest = makeCloudfrontProxy({path: LLM_CONTENT_PATHS.indexMarkdown, contentType: 'text/markdown; charset=utf-8'})

--- a/functions/llms-full.txt.ts
+++ b/functions/llms-full.txt.ts
@@ -3,10 +3,7 @@
 // route ensures the path the llms.txt discovery index advertises resolves on
 // jonathanlloyd.me, not only on the raw CloudFront host.
 
-import { LLM_CONTENT_PATHS } from '@lifegames/portal-contract/constants';
-import { makeCloudfrontProxy } from './_lib/proxy';
+import {LLM_CONTENT_PATHS} from '@lifegames/portal-contract/constants'
+import {makeCloudfrontProxy} from './_lib/proxy'
 
-export const onRequest = makeCloudfrontProxy({
-  path: LLM_CONTENT_PATHS.llmsFull,
-  contentType: 'text/markdown; charset=utf-8',
-});
+export const onRequest = makeCloudfrontProxy({path: LLM_CONTENT_PATHS.llmsFull, contentType: 'text/markdown; charset=utf-8'})

--- a/functions/llms.txt.ts
+++ b/functions/llms.txt.ts
@@ -6,9 +6,6 @@
 // sourced from the contract inside the factory so no CloudFront literal is
 // hardcoded here.
 
-import { makeCloudfrontProxy } from './_lib/proxy';
+import {makeCloudfrontProxy} from './_lib/proxy'
 
-export const onRequest = makeCloudfrontProxy({
-  path: '/llms.txt',
-  contentType: 'text/plain; charset=utf-8',
-});
+export const onRequest = makeCloudfrontProxy({path: '/llms.txt', contentType: 'text/plain; charset=utf-8'})

--- a/functions/sa.ts
+++ b/functions/sa.ts
@@ -7,52 +7,41 @@
 // On upstream failure: returns a harmless empty 200 JS no-op so the loader's
 // onerror path / page is unaffected — never a 5xx.
 
-const SA_PROXY_SCRIPT_URL = 'https://simpleanalyticsexternal.com/proxy.js?hostname=jonathanlloyd.me&path=/simple';
+const SA_PROXY_SCRIPT_URL = 'https://simpleanalyticsexternal.com/proxy.js?hostname=jonathanlloyd.me&path=/simple'
 
 // The collection path baked into the script above must equal the catch-all
 // Function route directory (/simple). This string is read by scripts/check-sa-proxy-path.mjs
 // for the blocking build assertion (US-003).
-export const SA_COLLECTION_PATH = '/simple';
+export const SA_COLLECTION_PATH = '/simple'
 
 // Minimal Cloudflare Pages Function fetch options — only the cf cache fields used here.
 interface CfRequestInit extends RequestInit {
-  cf?: { cacheTtl?: number; cacheEverything?: boolean; };
+  cf?: {cacheTtl?: number; cacheEverything?: boolean}
 }
 
 export async function onRequest(): Promise<Response> {
-  const init: CfRequestInit = {
-    cf: { cacheTtl: 86400, cacheEverything: true },
-  };
+  const init: CfRequestInit = {cf: {cacheTtl: 86400, cacheEverything: true}}
 
-  let upstream: Response;
+  let upstream: Response
   try {
-    upstream = await fetch(SA_PROXY_SCRIPT_URL, init);
+    upstream = await fetch(SA_PROXY_SCRIPT_URL, init)
   } catch {
     // Network failure — return a harmless JS no-op so the page is unaffected
     return new Response('/* sa unavailable */', {
       status: 200,
-      headers: {
-        'Content-Type': 'application/javascript; charset=utf-8',
-        'Cache-Control': 'no-store',
-      },
-    });
+      headers: {'Content-Type': 'application/javascript; charset=utf-8', 'Cache-Control': 'no-store'}
+    })
   }
 
   if (!upstream.ok) {
     return new Response('/* sa unavailable */', {
       status: 200,
-      headers: {
-        'Content-Type': 'application/javascript; charset=utf-8',
-        'Cache-Control': 'no-store',
-      },
-    });
+      headers: {'Content-Type': 'application/javascript; charset=utf-8', 'Cache-Control': 'no-store'}
+    })
   }
 
   return new Response(upstream.body, {
     status: 200,
-    headers: {
-      'Content-Type': 'application/javascript; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400',
-    },
-  });
+    headers: {'Content-Type': 'application/javascript; charset=utf-8', 'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400'}
+  })
 }

--- a/functions/simple/[[path]].ts
+++ b/functions/simple/[[path]].ts
@@ -11,7 +11,7 @@
 // On upstream failure: returns a silent 2xx no-op (204, or a 1×1 transparent GIF
 // for *.gif paths) — NEVER a 5xx, which would trip the smoke console-error check.
 
-const UPSTREAM_BASE = 'https://queue.simpleanalyticscdn.com';
+const UPSTREAM_BASE = 'https://queue.simpleanalyticscdn.com'
 
 // Minimal 1×1 transparent GIF (43 bytes, standard)
 const TRANSPARENT_GIF = new Uint8Array([
@@ -57,13 +57,13 @@ const TRANSPARENT_GIF = new Uint8Array([
   0x44,
   0x01,
   0x00,
-  0x3b,
-]);
+  0x3b
+])
 
 // Minimal Cloudflare Pages Function context — only the fields used here.
 interface PagesContext {
-  request: Request;
-  params: Record<string, string | string[]>;
+  request: Request
+  params: Record<string, string | string[]>
 }
 
 // Minimal CF fetch extensions — only the cf cache fields used here.
@@ -71,38 +71,35 @@ interface PagesContext {
 // no-op on the Cloudflare Workers runtime. Typed here because it is not yet in
 // the lib.dom RequestInit.
 interface CfRequestInit extends RequestInit {
-  cf?: { cacheEverything?: boolean; };
-  duplex?: 'half';
+  cf?: {cacheEverything?: boolean}
+  duplex?: 'half'
 }
 
 export async function onRequest(context: PagesContext): Promise<Response> {
-  const { request } = context;
-  const url = new URL(request.url);
+  const {request} = context
+  const url = new URL(request.url)
 
   // Strip the /simple prefix: the catch-all param captures everything after /simple/
   // e.g. pathname=/simple/simple.gif → upstreamPath=/simple.gif
   // The [[path]] param may be undefined for bare /simple requests.
-  const rawParam = context.params['path'];
+  const rawParam = context.params['path']
   const suffix = rawParam
     ? '/' + (Array.isArray(rawParam) ? rawParam.join('/') : rawParam)
-    : '';
+    : ''
 
-  const upstreamUrl = `${UPSTREAM_BASE}${suffix}${url.search}`;
+  const upstreamUrl = `${UPSTREAM_BASE}${suffix}${url.search}`
 
-  const clientIp = request.headers.get('CF-Connecting-IP') ?? '';
+  const clientIp = request.headers.get('CF-Connecting-IP') ?? ''
 
-  const outboundHeaders: Record<string, string> = {
-    'X-Forwarded-For': clientIp,
-    'X-Real-IP': clientIp,
-  };
+  const outboundHeaders: Record<string, string> = {'X-Forwarded-For': clientIp, 'X-Real-IP': clientIp}
 
   // Preserve Content-Type for POST beacons (sendBeacon sends text/plain)
-  const contentType = request.headers.get('Content-Type');
+  const contentType = request.headers.get('Content-Type')
   if (contentType) {
-    outboundHeaders['Content-Type'] = contentType;
+    outboundHeaders['Content-Type'] = contentType
   }
 
-  const isGif = suffix.endsWith('.gif');
+  const isGif = suffix.endsWith('.gif')
 
   // Collection endpoints must never be cached. `Cache-Control: no-store` covers
   // the browser, but Cloudflare's edge overrides it and caches GET responses by
@@ -110,59 +107,46 @@ export async function onRequest(context: PagesContext): Promise<Response> {
   // `noscript.gif` pageview across a 600s window. `CDN-Cache-Control: no-store`
   // is the Cloudflare-honored directive that keeps the EDGE from caching too.
   const silentGif = () =>
-    new Response(TRANSPARENT_GIF, {
-      status: 200,
-      headers: {
-        'Content-Type': 'image/gif',
-        'Cache-Control': 'no-store',
-        'CDN-Cache-Control': 'no-store',
-      },
-    });
+    new Response(TRANSPARENT_GIF, {status: 200, headers: {'Content-Type': 'image/gif', 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store'}})
 
   const silentNoOp = () =>
     isGif
       ? silentGif()
-      : new Response(null, {
-        status: 204,
-        headers: { 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store' },
-      });
+      : new Response(null, {status: 204, headers: {'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store'}})
 
-  let upstream: Response;
+  let upstream: Response
   try {
     const init: CfRequestInit = {
       method: request.method,
       headers: outboundHeaders,
       // Never cache collection endpoints
-      cf: { cacheEverything: false },
-    };
+      cf: {cacheEverything: false}
+    }
     // Forward the body for POST beacons (sendBeacon → /append). Streaming
     // request.body requires duplex:'half' under undici (Node); no-op on workerd.
     if (request.method !== 'GET' && request.method !== 'HEAD') {
-      init.body = request.body;
-      init.duplex = 'half';
+      init.body = request.body
+      init.duplex = 'half'
     }
-    upstream = await fetch(upstreamUrl, init);
+    upstream = await fetch(upstreamUrl, init)
   } catch {
     // Network failure / timeout — return silent no-op, never a 5xx
-    return silentNoOp();
+    return silentNoOp()
   }
 
   if (!upstream.ok) {
-    return silentNoOp();
+    return silentNoOp()
   }
 
   // For GIF paths, forward the upstream response; for others forward as-is or 204
-  const responseHeaders = new Headers();
-  responseHeaders.set('Cache-Control', 'no-store');
-  responseHeaders.set('CDN-Cache-Control', 'no-store');
+  const responseHeaders = new Headers()
+  responseHeaders.set('Cache-Control', 'no-store')
+  responseHeaders.set('CDN-Cache-Control', 'no-store')
 
-  const upstreamContentType = upstream.headers.get('Content-Type');
+  const upstreamContentType = upstream.headers.get('Content-Type')
   if (upstreamContentType) {
-    responseHeaders.set('Content-Type', upstreamContentType);
+    responseHeaders.set('Content-Type', upstreamContentType)
   }
 
-  return new Response(upstream.body, {
-    status: upstream.status,
-    headers: responseHeaders,
-  });
+  return new Response(upstream.body, {status: upstream.status, headers: responseHeaders})
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "astro": "^6.4.4"
       },
       "devDependencies": {
+        "@astrojs/check": "^0.9.9",
         "@astrojs/sitemap": "^3.7.3",
+        "@j0nathan-ll0yd/config": "^1.1.0",
         "@lhci/cli": "^0.15.1",
         "@napi-rs/image": "1.14.0",
         "@playwright/test": "^1.60.0",
@@ -25,7 +27,9 @@
         "ajv": "^8.20.0",
         "cheerio": "^1.2.0",
         "dprint": "^0.55.1",
+        "eslint": "^10.7.0",
         "fast-xml-parser": "^5.10.1",
+        "globals": "^17.7.0",
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
         "pa11y-ci": "^4.1.1",
@@ -33,6 +37,8 @@
         "pngjs": "^7.0.0",
         "robots-parser": "^3.0.1",
         "tsx": "^4.22.4",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.64.0",
         "vitest": "^4.1.8",
         "wrangler": "^4.98.0"
       }
@@ -157,6 +163,175 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@astrojs/check": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
+      "integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/language-server": "^2.16.7",
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "astro-check": "bin/astro-check.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@astrojs/compiler": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
@@ -178,6 +353,55 @@
         "smol-toml": "^1.6.0",
         "unified": "^11.0.5"
       }
+    },
+    "node_modules/@astrojs/language-server": {
+      "version": "2.16.12",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.12.tgz",
+      "integrity": "sha512-3LpFphBCzveUgm5ZVDINB/v3YA4TgPa1EMOEFn3Zt/Ww6jojR25iN+kmzeUz7v/b9xkmq+hMACTX4hizN3VCEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.1",
+        "@astrojs/yaml2ts": "^0.2.4",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@volar/kit": "~2.4.28",
+        "@volar/language-core": "~2.4.28",
+        "@volar/language-server": "~2.4.28",
+        "@volar/language-service": "~2.4.28",
+        "muggle-string": "^0.4.1",
+        "tinyglobby": "^0.2.16",
+        "volar-service-css": "0.0.71",
+        "volar-service-emmet": "0.0.71",
+        "volar-service-html": "0.0.71",
+        "volar-service-prettier": "0.0.71",
+        "volar-service-typescript": "0.0.71",
+        "volar-service-typescript-twoslash-queries": "0.0.71",
+        "volar-service-yaml": "0.0.71",
+        "vscode-html-languageservice": "^5.6.2",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "astro-ls": "bin/nodeServer.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": ">=0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/language-server/node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "7.2.0",
@@ -242,6 +466,16 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+      "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2439,6 +2673,68 @@
         "win32"
       ]
     },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
@@ -2888,6 +3184,121 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
@@ -2960,6 +3371,72 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@img/colour": {
@@ -3436,6 +3913,22 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@j0nathan-ll0yd/config": {
+      "version": "1.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@j0nathan-ll0yd/config/1.1.0/6a4c4c6905b56c7c068d5916089c3ea998eb0ded",
+      "integrity": "sha512-7NXjZLSbJKmIYs0W0t7dHapfqVre+QHvNqnbFq2D6P6vbKoUz6tHE8LD+A3+ootsFriXPpuMDHFRCasZbvm5ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/js": "^10.0.1",
+        "@typescript-eslint/eslint-plugin": "^8.64.0",
+        "@typescript-eslint/parser": "^8.64.0",
+        "typescript-eslint": "^8.64.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=10.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -5279,6 +5772,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5293,6 +5793,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -5367,6 +5874,239 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -5511,6 +6251,111 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@volar/kit": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "typesafe-path": "^0.2.2",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/language-server": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "request-light": "^0.7.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/language-service": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emmet": "^2.4.3",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper/node_modules/jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@zip.js/zip.js": {
       "version": "2.8.26",
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
@@ -5559,6 +6404,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -5585,6 +6440,21 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
@@ -5600,6 +6470,16 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ajv-i18n": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+      "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -7324,6 +8204,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -7649,6 +8536,23 @@
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emmet": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -8025,6 +8929,266 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -8037,6 +9201,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
@@ -8296,6 +9486,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
@@ -8427,6 +9624,19 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/file-url": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/file-url/-/file-url-3.0.0.tgz",
@@ -8526,6 +9736,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/flattie": {
       "version": "1.1.1",
@@ -8839,6 +10070,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/glob-to-regex.js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
@@ -8853,6 +10097,19 @@
       },
       "peerDependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -9447,6 +10704,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/image-ssim": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
@@ -9838,6 +11105,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
@@ -9881,6 +11158,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-inside-container": {
@@ -10445,6 +11735,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -10463,6 +11760,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -10506,6 +11810,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -10531,6 +11845,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lie": {
@@ -12027,6 +13355,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mustache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
@@ -12061,6 +13396,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
@@ -12405,6 +13747,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/os-tmpdir": {
@@ -12829,6 +14189,13 @@
         "util": "^0.10.3"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -13102,6 +14469,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/prepend-http": {
@@ -13661,6 +15038,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/request-light": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -15108,13 +16492,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -15335,6 +16719,19 @@
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -15845,6 +17242,19 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -15952,6 +17362,61 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typesafe-path": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-auto-import-cache": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.8"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/ufo": {
@@ -16386,6 +17851,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/url": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
@@ -16705,6 +18180,289 @@
         }
       }
     },
+    "node_modules/volar-service-css": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.71.tgz",
+      "integrity": "sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-emmet": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.71.tgz",
+      "integrity": "sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/css-parser": "^0.4.1",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-html": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.71.tgz",
+      "integrity": "sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-html-languageservice": "^5.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-prettier": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.71.tgz",
+      "integrity": "sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0",
+        "prettier": "^2.2 || ^3.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.71.tgz",
+      "integrity": "sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript-twoslash-queries": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.71.tgz",
+      "integrity": "sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.71.tgz",
+      "integrity": "sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.23.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-css-languageservice/node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-html-languageservice": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -16920,6 +18678,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {
@@ -17379,6 +19147,69 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.23.0.tgz",
+      "integrity": "sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-i18n": "^4.2.0",
+        "prettier": "^3.8.1",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.8.3"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "test:smoke": "npx playwright test --config=playwright.smoke.config.ts",
     "test:behavioral": "./scripts/run-in-docker.sh playwright.behavioral.config.ts",
     "format": "dprint fmt",
-    "format:check": "dprint check"
+    "format:check": "dprint check",
+    "lint": "eslint .",
+    "typecheck": "astro check"
   },
   "dependencies": {
     "@lifegames/copy": "file:.yalc/@lifegames/copy",
@@ -36,7 +38,9 @@
     "astro": "^6.4.4"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.9",
     "@astrojs/sitemap": "^3.7.3",
+    "@j0nathan-ll0yd/config": "^1.1.0",
     "@lhci/cli": "^0.15.1",
     "@napi-rs/image": "1.14.0",
     "@playwright/test": "^1.60.0",
@@ -44,7 +48,9 @@
     "ajv": "^8.20.0",
     "cheerio": "^1.2.0",
     "dprint": "^0.55.1",
+    "eslint": "^10.7.0",
     "fast-xml-parser": "^5.10.1",
+    "globals": "^17.7.0",
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "pa11y-ci": "^4.1.1",
@@ -52,6 +58,8 @@
     "pngjs": "^7.0.0",
     "robots-parser": "^3.0.1",
     "tsx": "^4.22.4",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.64.0",
     "vitest": "^4.1.8",
     "wrangler": "^4.98.0"
   }

--- a/playwright.behavioral.config.ts
+++ b/playwright.behavioral.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import {defineConfig} from '@playwright/test'
 
 // Behavioral (interaction) test suite for BookModal.
 //
@@ -12,7 +12,7 @@ import { defineConfig } from '@playwright/test';
 // deterministically populated. SKIP_BUILD=1 skips the astro build step
 // when the dist/ is already current.
 
-const isCI = !!process.env.CI;
+const isCI = !!process.env.CI
 
 export default defineConfig({
   testDir: './tests/behavioral',
@@ -25,8 +25,8 @@ export default defineConfig({
   timeout: 30_000,
 
   reporter: isCI
-    ? [['github'], ['html', { open: 'never', outputFolder: 'playwright-report' }]]
-    : [['list'], ['html', { open: 'on-failure' }]],
+    ? [['github'], ['html', {open: 'never', outputFolder: 'playwright-report'}]]
+    : [['list'], ['html', {open: 'on-failure'}]],
 
   webServer: {
     command: process.env.SKIP_BUILD
@@ -34,7 +34,7 @@ export default defineConfig({
       : 'npm run build && npm run preview',
     url: 'http://localhost:4321/',
     timeout: 120_000,
-    reuseExistingServer: !isCI,
+    reuseExistingServer: !isCI
   },
 
   use: {
@@ -44,20 +44,17 @@ export default defineConfig({
     video: 'off',
     trace: 'on-first-retry',
     // Block service workers so they don't intercept fetch calls.
-    serviceWorkers: 'block',
+    serviceWorkers: 'block'
   },
 
   projects: [
-    {
-      name: 'behavioral-chromium',
-      use: { browserName: 'chromium', viewport: { width: 1400, height: 900 } },
-    },
+    {name: 'behavioral-chromium', use: {browserName: 'chromium', viewport: {width: 1400, height: 900}}},
     {
       // Scoped to the mobile-layout spec only — book-modal.spec.ts assumes a
       // desktop layout and would emit false failures at 390px.
       name: 'behavioral-mobile-chromium',
       testMatch: '**/mobile-layout.spec.ts',
-      use: { browserName: 'chromium', viewport: { width: 390, height: 844 }, hasTouch: true },
-    },
-  ],
-});
+      use: {browserName: 'chromium', viewport: {width: 390, height: 844}, hasTouch: true}
+    }
+  ]
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from '@playwright/test';
-import { CHROMIUM_DETERMINISM_ARGS } from './tests/shared/chromium-launch-args';
+import {defineConfig} from '@playwright/test'
+import {CHROMIUM_DETERMINISM_ARGS} from './tests/shared/chromium-launch-args'
 
-const isCI = !!process.env.CI;
+const isCI = !!process.env.CI
 
 export default defineConfig({
   testDir: './tests/visual',
@@ -22,14 +22,14 @@ export default defineConfig({
   workers: 1,
 
   reporter: isCI
-    ? [['github'], ['blob'], ['html', { open: 'never', outputFolder: 'playwright-report' }]]
-    : [['html', { open: 'on-failure' }]],
+    ? [['github'], ['blob'], ['html', {open: 'never', outputFolder: 'playwright-report'}]]
+    : [['html', {open: 'on-failure'}]],
 
   webServer: {
     command: process.env.SKIP_BUILD ? 'npm run preview' : 'npm run build && npm run preview',
     url: 'http://localhost:4321/',
     timeout: 120_000,
-    reuseExistingServer: !isCI,
+    reuseExistingServer: !isCI
   },
 
   use: {
@@ -45,8 +45,8 @@ export default defineConfig({
       // Determinism flags from tests/shared/chromium-launch-args.ts. Used only by
       // this visual-regression suite; the production smoke check
       // (playwright.smoke.config.ts) deliberately omits them.
-      args: [...CHROMIUM_DETERMINISM_ARGS],
-    },
+      args: [...CHROMIUM_DETERMINISM_ARGS]
+    }
   },
 
   expect: {
@@ -55,32 +55,17 @@ export default defineConfig({
       threshold: 0.2, // per-pixel YIQ color tolerance
       animations: 'disabled', // freeze CSS animations for determinism
       caret: 'hide', // hide blinking text caret
-      scale: 'device', // capture at the emulated 2x device px so baselines are retina-resolution (was 'css' at 1x)
-    },
+      scale: 'device' // capture at the emulated 2x device px so baselines are retina-resolution (was 'css' at 1x)
+    }
   },
 
   snapshotPathTemplate: '{testDir}/__screenshots__/{projectName}/{testFilePath}/{arg}{ext}',
 
   projects: [
-    {
-      name: 'desktop-1400',
-      use: { browserName: 'chromium', viewport: { width: 1400, height: 900 } },
-    },
-    {
-      name: 'tablet-1100',
-      use: { browserName: 'chromium', viewport: { width: 1100, height: 800 } },
-    },
-    {
-      name: 'tablet-768',
-      use: { browserName: 'chromium', viewport: { width: 768, height: 1024 } },
-    },
-    {
-      name: 'mobile-600',
-      use: { browserName: 'chromium', viewport: { width: 600, height: 900 } },
-    },
-    {
-      name: 'mobile-390',
-      use: { browserName: 'chromium', viewport: { width: 390, height: 844 } },
-    },
-  ],
-});
+    {name: 'desktop-1400', use: {browserName: 'chromium', viewport: {width: 1400, height: 900}}},
+    {name: 'tablet-1100', use: {browserName: 'chromium', viewport: {width: 1100, height: 800}}},
+    {name: 'tablet-768', use: {browserName: 'chromium', viewport: {width: 768, height: 1024}}},
+    {name: 'mobile-600', use: {browserName: 'chromium', viewport: {width: 600, height: 900}}},
+    {name: 'mobile-390', use: {browserName: 'chromium', viewport: {width: 390, height: 844}}}
+  ]
+})

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from '@playwright/test';
-import { SITE_URL } from '@lifegames/portal-contract/constants';
+import {defineConfig} from '@playwright/test'
+import {SITE_URL} from '@lifegames/portal-contract/constants'
 
 // Production smoke check — runs against the LIVE deployed site after each deploy.
 //
@@ -17,7 +17,7 @@ import { SITE_URL } from '@lifegames/portal-contract/constants';
 // script is CSP-blocked still renders its SSR shell at correct pixels). This
 // suite asserts the DOM actually hydrated instead.
 
-const isCI = !!process.env.CI;
+const isCI = !!process.env.CI
 
 export default defineConfig({
   testDir: './tests/smoke',
@@ -36,8 +36,8 @@ export default defineConfig({
   timeout: 45_000,
 
   reporter: isCI
-    ? [['github'], ['html', { open: 'never', outputFolder: 'playwright-report' }]]
-    : [['list'], ['html', { open: 'on-failure' }]],
+    ? [['github'], ['html', {open: 'never', outputFolder: 'playwright-report'}]]
+    : [['list'], ['html', {open: 'on-failure'}]],
 
   use: {
     baseURL: SITE_URL,
@@ -48,13 +48,10 @@ export default defineConfig({
     trace: 'on-first-retry',
     // Do NOT block service workers: the smoke check verifies the SW registers.
     // Do NOT set bypassCSP: real CSP enforcement is what catches the #50 class.
-    serviceWorkers: 'allow',
+    serviceWorkers: 'allow'
   },
 
   projects: [
-    {
-      name: 'smoke-chromium',
-      use: { browserName: 'chromium', viewport: { width: 1400, height: 900 } },
-    },
-  ],
-});
+    {name: 'smoke-chromium', use: {browserName: 'chromium', viewport: {width: 1400, height: 900}}}
+  ]
+})

--- a/scripts/audit-fixtures.mjs
+++ b/scripts/audit-fixtures.mjs
@@ -14,32 +14,32 @@
  *
  * Runs in `prebuild`; CI gates on it. Regenerate/extend fixtures in
  * design-system-Lifegames/packages/fixtures, then `pnpm yalc:publish`. */
-import { globSync } from 'glob';
+import {globSync} from 'glob'
 
 var PATTERNS = [
   'data/**/*.json',
   'test/fixtures/**/*.json',
-  'src/**/fixtures/**/*.json',
-];
+  'src/**/fixtures/**/*.json'
+]
 
-var offenders = [];
+var offenders = []
 for (var i = 0; i < PATTERNS.length; i++) {
-  var matches = globSync(PATTERNS[i], { ignore: ['node_modules/**', '**/node_modules/**', '.yalc/**'] });
+  var matches = globSync(PATTERNS[i], {ignore: ['node_modules/**', '**/node_modules/**', '.yalc/**']})
   for (var m = 0; m < matches.length; m++) {
-    offenders.push(matches[m]);
+    offenders.push(matches[m])
   }
 }
 
 if (offenders.length > 0) {
-  console.error('Consumer-side fixtures are forbidden (Invariant I2):');
+  console.error('Consumer-side fixtures are forbidden (Invariant I2):')
   for (var o = 0; o < offenders.length; o++) {
-    console.error('  x ' + offenders[o]);
+    console.error('  x ' + offenders[o])
   }
-  console.error('\nFixtures are DS-owned. Add/edit them in');
-  console.error('design-system-Lifegames/packages/fixtures, then `pnpm yalc:publish`.');
-  console.error('Consume via `@lifegames/fixtures` (SSR shell) and');
-  console.error('`@lifegames/fixtures/generated/<domain>/<variation>.json` (Playwright).');
-  process.exit(1);
+  console.error('\nFixtures are DS-owned. Add/edit them in')
+  console.error('design-system-Lifegames/packages/fixtures, then `pnpm yalc:publish`.')
+  console.error('Consume via `@lifegames/fixtures` (SSR shell) and')
+  console.error('`@lifegames/fixtures/generated/<domain>/<variation>.json` (Playwright).')
+  process.exit(1)
 }
 
-console.log('No consumer-side fixtures ✓ (Invariant I2: data/, test/fixtures/, src/**/fixtures/ clean)');
+console.log('No consumer-side fixtures ✓ (Invariant I2: data/, test/fixtures/, src/**/fixtures/ clean)')

--- a/scripts/audit-inline-scripts.mjs
+++ b/scripts/audit-inline-scripts.mjs
@@ -25,70 +25,72 @@
  * is not a CSP issue and is ignored.
  *
  * Tier 1 (this script) runs in `prebuild`; CI gates on it. */
-import { globSync } from 'glob';
-import fs from 'node:fs';
+import {globSync} from 'glob'
+import fs from 'node:fs'
 
 var EVENT_HANDLER_RE =
-  /\son(click|load|error|change|submit|focus|blur|input|keyup|keydown|mouseenter|mouseleave|mouseover|mouseout|dblclick|contextmenu)\s*=/i;
+  /\son(click|load|error|change|submit|focus|blur|input|keyup|keydown|mouseenter|mouseleave|mouseover|mouseout|dblclick|contextmenu)\s*=/i
 
 /* Inline HTML event-handler attribute inside a string literal emitted by JS
  * (e.g. innerHTML += '... onerror="..." ...'). A quote MUST immediately follow
  * `=` so we match the HTML-attribute form `onerror="..."` while ignoring
  * JS property assignment like `el.onclick = fn` / `this.onerror = null`. */
-var JS_INLINE_HANDLER_RE = /\bon[a-z]+=["']/i;
+var JS_INLINE_HANDLER_RE = /\bon[a-z]+=["']/i
 
 // Matches a full <script ...> ... </script> element (open tag captured in g1).
-var SCRIPT_BLOCK_RE = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+var SCRIPT_BLOCK_RE = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi
 
 function isDataScript(openTag) {
-  return /\btype\s*=\s*["'](application\/(ld\+json|json))["']/i.test(openTag);
+  return /\btype\s*=\s*["'](application\/(ld\+json|json))["']/i.test(openTag)
 }
 
 function hasSrc(openTag) {
-  return /\bsrc\s*=/.test(openTag);
+  return /\bsrc\s*=/.test(openTag)
 }
 
 function isInline(openTag) {
-  return /\bis:inline\b/.test(openTag);
+  return /\bis:inline\b/.test(openTag)
 }
 
 function lineAt(content, index) {
-  return content.slice(0, index).split('\n').length;
+  return content.slice(0, index).split('\n').length
 }
 
-var files = globSync('src/**/*.{astro,html}', { ignore: ['node_modules/**', '**/node_modules/**'] });
-var violations = 0;
+var files = globSync('src/**/*.{astro,html}', {ignore: ['node_modules/**', '**/node_modules/**']})
+var violations = 0
 
 for (var f = 0; f < files.length; f++) {
-  var file = files[f];
-  var content = fs.readFileSync(file, 'utf-8');
+  var file = files[f]
+  var content = fs.readFileSync(file, 'utf-8')
 
   // 1. Inline <script is:inline> WITH a non-empty body (no src, not data).
-  var m;
-  SCRIPT_BLOCK_RE.lastIndex = 0;
+  var m
+  SCRIPT_BLOCK_RE.lastIndex = 0
   while ((m = SCRIPT_BLOCK_RE.exec(content)) !== null) {
-    var openTag = m[1];
-    var body = m[2];
-    if (!isInline(openTag)) continue; // bundled scripts are exempt
-    if (hasSrc(openTag)) continue; // external reference is fine
-    if (isDataScript(openTag)) continue; // inert data, not script
-    if (!/\S/.test(body)) continue; // empty body
-    violations++;
-    console.error(
-      '✗ ' + file + ':' + lineAt(content, m.index)
-        + " -- <script is:inline> with body (CSP script-src 'self' blocks this).",
-    );
+    var openTag = m[1]
+    var body = m[2]
+    if (!isInline(openTag)) {
+      continue // bundled scripts are exempt
+    }
+    if (hasSrc(openTag)) {
+      continue // external reference is fine
+    }
+    if (isDataScript(openTag)) {
+      continue // inert data, not script
+    }
+    if (!/\S/.test(body)) {
+      continue // empty body
+    }
+    violations++
+    console.error('✗ ' + file + ':' + lineAt(content, m.index) + " -- <script is:inline> with body (CSP script-src 'self' blocks this).")
   }
 
   // 2. Inline event handlers in markup (e.g. onclick=, onload=).
-  var lines = content.split('\n');
+  var lines = content.split('\n')
   for (var i = 0; i < lines.length; i++) {
     if (EVENT_HANDLER_RE.test(lines[i])) {
-      violations++;
-      console.error(
-        '✗ ' + file + ':' + (i + 1)
-          + " -- inline event handler (CSP rejects without 'unsafe-hashes').",
-      );
+      violations++
+      console.error('✗ ' + file + ':' + (i + 1) + " -- inline event handler (CSP rejects without 'unsafe-hashes').")
     }
   }
 }
@@ -98,28 +100,25 @@ for (var f = 0; f < files.length; f++) {
  * carry inline event-handler attributes (e.g. onerror="..."), which CSP blocks
  * at runtime. Flag the HTML-attribute form only (quote right after `=`); plain
  * JS property assignment like `el.onclick = fn` is not an issue and is ignored. */
-var jsFiles = globSync('public/js/**/*.js', { ignore: ['node_modules/**', '**/node_modules/**'] });
+var jsFiles = globSync('public/js/**/*.js', {ignore: ['node_modules/**', '**/node_modules/**']})
 
 for (var jf = 0; jf < jsFiles.length; jf++) {
-  var jsFile = jsFiles[jf];
-  var jsContent = fs.readFileSync(jsFile, 'utf-8');
-  var jsLines = jsContent.split('\n');
+  var jsFile = jsFiles[jf]
+  var jsContent = fs.readFileSync(jsFile, 'utf-8')
+  var jsLines = jsContent.split('\n')
   for (var jl = 0; jl < jsLines.length; jl++) {
     if (JS_INLINE_HANDLER_RE.test(jsLines[jl])) {
-      violations++;
-      console.error(
-        '✗ ' + jsFile + ':' + (jl + 1)
-          + ' -- inline event-handler string (CSP rejects onX="..." without \'unsafe-hashes\').',
-      );
+      violations++
+      console.error('✗ ' + jsFile + ':' + (jl + 1) + ' -- inline event-handler string (CSP rejects onX="..." without \'unsafe-hashes\').')
     }
   }
 }
 
 if (violations > 0) {
-  console.error('\n' + violations + ' inline-JS violation(s).');
-  console.error('Per CLAUDE.md: extract to public/js/*.js and reference via <script is:inline src="..." defer>.');
-  console.error("CSP: script-src 'self' -- inline JS is rejected in production.");
-  process.exit(1);
+  console.error('\n' + violations + ' inline-JS violation(s).')
+  console.error('Per CLAUDE.md: extract to public/js/*.js and reference via <script is:inline src="..." defer>.')
+  console.error("CSP: script-src 'self' -- inline JS is rejected in production.")
+  process.exit(1)
 }
 
-console.log('No inline-JS violations ✓ (' + (files.length + jsFiles.length) + ' files scanned)');
+console.log('No inline-JS violations ✓ (' + (files.length + jsFiles.length) + ' files scanned)')

--- a/scripts/audit/check-analytics.mjs
+++ b/scripts/audit/check-analytics.mjs
@@ -20,141 +20,136 @@
 // asserted here to keep this check fast and deterministic; the pageview pixel
 // already proves the SA collection path is wired end-to-end.
 
-import { chromium } from '@playwright/test';
-import { SITE_URL } from '@lifegames/portal-contract/constants';
-import { fetchStable, isMain, report } from './lib/http.mjs';
+import {chromium} from '@playwright/test'
+import {SITE_URL} from '@lifegames/portal-contract/constants'
+import {fetchStable, isMain, report} from './lib/http.mjs'
 
-const NAV_TIMEOUT_MS = 30_000;
-const BEACON_WAIT_MS = 15_000;
+const NAV_TIMEOUT_MS = 30_000
+const BEACON_WAIT_MS = 15_000
 
 const EXPECTATIONS = [
-  { id: 'cf-insights-js', urlPattern: /\/cf-insights\.js/, method: 'GET', acceptStatus: (s) => s === 200 },
-  { id: 'cf-rum', urlPattern: /\/cf-rum(\?|$)/, method: 'POST', acceptStatus: (s) => s >= 200 && s < 300 },
-  { id: 'sa-script', urlPattern: /\/sa(\?|$)/, method: 'GET', acceptStatus: (s) => s === 200 },
+  {id: 'cf-insights-js', urlPattern: /\/cf-insights\.js/, method: 'GET', acceptStatus: (s) => s === 200},
+  {id: 'cf-rum', urlPattern: /\/cf-rum(\?|$)/, method: 'POST', acceptStatus: (s) => s >= 200 && s < 300},
+  {id: 'sa-script', urlPattern: /\/sa(\?|$)/, method: 'GET', acceptStatus: (s) => s === 200},
   {
     id: 'sa-pageview-pixel',
     urlPattern: /\/simple\/simple\.gif/,
     method: 'GET',
     acceptStatus: (s) => s === 202,
     onWrongStatus: (s) =>
-      `expected HTTP 202 from the SA collector (verified live behavior for a well-formed pageview ping); `
-      + `got ${s}. If Simple Analytics' upstream contract changed, update EXPECTATIONS here deliberately.`,
-  },
-];
+      `expected HTTP 202 from the SA collector (verified live behavior for a well-formed pageview ping); ` +
+      `got ${s}. If Simple Analytics' upstream contract changed, update EXPECTATIONS here deliberately.`
+  }
+]
 
 /** Collects matching request/response pairs from a live page load. Network I/O -- not unit tested directly. */
 async function collectBeaconEvents(url) {
-  const browser = await chromium.launch();
+  const browser = await chromium.launch()
   try {
-    const page = await browser.newPage();
-    const seen = new Map(); // id -> { status, method }
+    const page = await browser.newPage()
+    const seen = new Map() // id -> { status, method }
 
     page.on('response', (res) => {
-      const req = res.request();
+      const req = res.request()
       for (const exp of EXPECTATIONS) {
         if (exp.urlPattern.test(res.url()) && req.method() === exp.method && !seen.has(exp.id)) {
-          seen.set(exp.id, { status: res.status(), url: res.url() });
+          seen.set(exp.id, {status: res.status(), url: res.url()})
         }
       }
-    });
+    })
 
-    await page.goto(url, { waitUntil: 'load', timeout: NAV_TIMEOUT_MS });
+    await page.goto(url, {waitUntil: 'load', timeout: NAV_TIMEOUT_MS})
 
-    const deadline = Date.now() + BEACON_WAIT_MS;
+    const deadline = Date.now() + BEACON_WAIT_MS
     while (seen.size < EXPECTATIONS.length && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, 250));
+      await new Promise((r) => setTimeout(r, 250))
     }
 
-    return seen;
+    return seen
   } finally {
-    await browser.close();
+    await browser.close()
   }
 }
 
 /** Pure: (Map of id -> {status,url}) -> findings[]. Testable without a browser. */
 export function evaluateBeacons(seen) {
-  const findings = [];
+  const findings = []
   for (const exp of EXPECTATIONS) {
-    const hit = seen.get(exp.id);
+    const hit = seen.get(exp.id)
     if (!hit) {
       findings.push({
         severity: 'fail',
         id: `analytics-${exp.id}-missing`,
-        message: `no ${exp.method} request matching ${exp.urlPattern} fired within ${BEACON_WAIT_MS}ms of page load`,
-      });
-      continue;
+        message: `no ${exp.method} request matching ${exp.urlPattern} fired within ${BEACON_WAIT_MS}ms of page load`
+      })
+      continue
     }
     if (!exp.acceptStatus(hit.status)) {
       findings.push({
         severity: 'fail',
         id: `analytics-${exp.id}-status`,
-        message: exp.onWrongStatus ? exp.onWrongStatus(hit.status) : `${hit.url} returned HTTP ${hit.status}`,
-      });
+        message: exp.onWrongStatus ? exp.onWrongStatus(hit.status) : `${hit.url} returned HTTP ${hit.status}`
+      })
     }
   }
-  return findings;
+  return findings
 }
 
 /** Optional server-side confirmation via the SA Stats API (https://simpleanalytics.com/{hostname}.json). */
 async function checkSaStatsApi(apiKey) {
-  const hostname = new URL(SITE_URL).hostname;
-  const url = `https://simpleanalytics.com/${hostname}.json?version=5&fields=pageviews&start=today&end=today`;
-  let res;
+  const hostname = new URL(SITE_URL).hostname
+  const url = `https://simpleanalytics.com/${hostname}.json?version=5&fields=pageviews&start=today&end=today`
+  let res
   try {
-    res = await fetchStable(url, { headers: { 'Api-Key': apiKey } });
+    res = await fetchStable(url, {headers: {'Api-Key': apiKey}})
   } catch (err) {
-    return [{ severity: 'fail', id: 'analytics-sa-stats-api-fetch', message: `fetch failed: ${err.message}` }];
+    return [{severity: 'fail', id: 'analytics-sa-stats-api-fetch', message: `fetch failed: ${err.message}`}]
   }
-  let json;
+  let json
   try {
-    json = await res.json();
+    json = await res.json()
   } catch (err) {
-    return [{
-      severity: 'fail',
-      id: 'analytics-sa-stats-api-parse',
-      message: `${url} did not return valid JSON: ${err.message}`,
-    }];
+    return [{severity: 'fail', id: 'analytics-sa-stats-api-parse', message: `${url} did not return valid JSON: ${err.message}`}]
   }
   if (!res.ok || json.ok !== true) {
     return [{
       severity: 'fail',
       id: 'analytics-sa-stats-api-error',
-      message: `SA Stats API returned an error (HTTP ${res.status}): ${json.error ?? '(no error field)'}`,
-    }];
+      message: `SA Stats API returned an error (HTTP ${res.status}): ${json.error ?? '(no error field)'}`
+    }]
   }
   if (!(typeof json.pageviews === 'number' && json.pageviews > 0)) {
     return [{
       severity: 'fail',
       id: 'analytics-sa-stats-api-zero-pageviews',
-      message: `SA Stats API reports ${json.pageviews ?? 0} pageviews today for ${hostname} -- expected > 0`,
-    }];
+      message: `SA Stats API reports ${json.pageviews ?? 0} pageviews today for ${hostname} -- expected > 0`
+    }]
   }
-  return [];
+  return []
 }
 
 async function main() {
-  const findings = [];
+  const findings = []
 
-  const seen = await collectBeaconEvents(SITE_URL);
-  findings.push(...evaluateBeacons(seen));
+  const seen = await collectBeaconEvents(SITE_URL)
+  findings.push(...evaluateBeacons(seen))
 
-  const saApiKey = process.env.SA_API_KEY;
+  const saApiKey = process.env.SA_API_KEY
   if (saApiKey) {
-    findings.push(...(await checkSaStatsApi(saApiKey)));
+    findings.push(...(await checkSaStatsApi(saApiKey)))
   } else {
     // Explicit, visible SKIPPED marker -- never silently green when a whole
     // sub-check didn't run (§8 Q2: SA_API_KEY is a Phase 0 user-provisioned secret).
     findings.push({
       severity: 'info',
       id: 'analytics-sa-stats-api-skipped',
-      message:
-        'SKIPPED(server-side): SA_API_KEY not set -- server-side pageview confirmation via the SA Stats API was not run',
-    });
+      message: 'SKIPPED(server-side): SA_API_KEY not set -- server-side pageview confirmation via the SA Stats API was not run'
+    })
   }
 
-  process.exit(report('check-analytics', findings));
+  process.exit(report('check-analytics', findings))
 }
 
 if (isMain(import.meta.url)) {
-  main();
+  main()
 }

--- a/scripts/audit/check-feeds.mjs
+++ b/scripts/audit/check-feeds.mjs
@@ -10,195 +10,163 @@
 // structural parsing already gives us -- the same judgment call the plan
 // makes for CrUX/PSI (D10).
 
-import { XMLParser, XMLValidator } from 'fast-xml-parser';
-import { SITE_URL } from '@lifegames/portal-contract/constants';
-import { fetchStable, isMain, report } from './lib/http.mjs';
+import {XMLParser, XMLValidator} from 'fast-xml-parser'
+import {SITE_URL} from '@lifegames/portal-contract/constants'
+import {fetchStable, isMain, report} from './lib/http.mjs'
 
-const FEED_XML_URL = `${SITE_URL}/feed.xml`;
-const FEED_JSON_URL = `${SITE_URL}/feed.json`;
-const FRESHNESS_WINDOW_DAYS = 7; // matches the plan's "event-driven ... 7d soft window" cadence class
+const FEED_XML_URL = `${SITE_URL}/feed.xml`
+const FEED_JSON_URL = `${SITE_URL}/feed.json`
+const FRESHNESS_WINDOW_DAYS = 7 // matches the plan's "event-driven ... 7d soft window" cadence class
 
 /** Pure validation function: (feed.xml body) -> findings[]. Testable without network. */
 export function validateFeedXml(xml, now = new Date()) {
-  const findings = [];
+  const findings = []
 
   // XMLParser.parse() is deliberately lenient (verified: it does not throw on
   // `<rss><channel><title>unclosed`, mismatched tags, or even `<<<garbage>>>`
   // -- fast-xml-parser recovers rather than erroring). XMLValidator.validate()
   // is the library's own stricter well-formedness check (bundled, no new
   // dependency) and is what actually catches malformed XML.
-  const validation = XMLValidator.validate(xml);
+  const validation = XMLValidator.validate(xml)
   if (validation !== true) {
     return [{
       severity: 'fail',
       id: 'feed-xml-parse',
-      message: `not well-formed XML (${validation.err.code} at line ${validation.err.line}): ${validation.err.msg}`,
-    }];
+      message: `not well-formed XML (${validation.err.code} at line ${validation.err.line}): ${validation.err.msg}`
+    }]
   }
 
-  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' });
-  const doc = parser.parse(xml);
+  const parser = new XMLParser({ignoreAttributes: false, attributeNamePrefix: '@_'})
+  const doc = parser.parse(xml)
 
-  const channel = doc?.rss?.channel;
+  const channel = doc?.rss?.channel
   if (!channel) {
-    findings.push({ severity: 'fail', id: 'feed-xml-shape', message: 'no <rss><channel> root found' });
-    return findings;
+    findings.push({severity: 'fail', id: 'feed-xml-shape', message: 'no <rss><channel> root found'})
+    return findings
   }
   for (const field of ['title', 'link', 'description']) {
     if (!channel[field]) {
-      findings.push({
-        severity: 'fail',
-        id: 'feed-xml-channel-field',
-        message: `<channel> missing required <${field}>`,
-      });
+      findings.push({severity: 'fail', id: 'feed-xml-channel-field', message: `<channel> missing required <${field}>`})
     }
   }
 
-  const items = channel.item === undefined ? [] : (Array.isArray(channel.item) ? channel.item : [channel.item]);
+  const items = channel.item === undefined ? [] : (Array.isArray(channel.item) ? channel.item : [channel.item])
   if (items.length === 0) {
-    findings.push({ severity: 'warn', id: 'feed-xml-no-items', message: '<channel> has no <item> entries' });
-    return findings;
+    findings.push({severity: 'warn', id: 'feed-xml-no-items', message: '<channel> has no <item> entries'})
+    return findings
   }
   for (const [idx, item] of items.entries()) {
     for (const field of ['title', 'link', 'guid']) {
       if (!item[field]) {
-        findings.push({
-          severity: 'fail',
-          id: 'feed-xml-item-field',
-          message: `item[${idx}] missing required <${field}>`,
-        });
+        findings.push({severity: 'fail', id: 'feed-xml-item-field', message: `item[${idx}] missing required <${field}>`})
       }
     }
   }
 
-  const newestPubDate = items
-    .map((item) => item.pubDate && new Date(item.pubDate))
-    .filter((d) => d && !Number.isNaN(d.getTime()))
-    .sort((a, b) => b - a)[0];
+  const newestPubDate = items.map((item) => item.pubDate && new Date(item.pubDate)).filter((d) => d && !Number.isNaN(d.getTime())).sort((a, b) => b - a)[0]
   if (!newestPubDate) {
-    findings.push({
-      severity: 'warn',
-      id: 'feed-xml-no-parseable-pubdate',
-      message: 'no item has a parseable <pubDate>',
-    });
+    findings.push({severity: 'warn', id: 'feed-xml-no-parseable-pubdate', message: 'no item has a parseable <pubDate>'})
   } else {
-    const ageDays = (now - newestPubDate) / 86_400_000;
+    const ageDays = (now - newestPubDate) / 86_400_000
     if (ageDays > FRESHNESS_WINDOW_DAYS) {
       findings.push({
         severity: 'fail',
         id: 'feed-xml-stale',
-        message: `newest item is ${ageDays.toFixed(1)} days old (${newestPubDate.toISOString()}), `
-          + `exceeds the ${FRESHNESS_WINDOW_DAYS}-day soft window`,
-      });
+        message: `newest item is ${ageDays.toFixed(1)} days old (${newestPubDate.toISOString()}), ` + `exceeds the ${FRESHNESS_WINDOW_DAYS}-day soft window`
+      })
     }
   }
 
-  return findings;
+  return findings
 }
 
 /** Pure validation function: (feed.json body, parsed) -> findings[]. Testable without network. */
 export function validateFeedJson(json, now = new Date()) {
-  const findings = [];
+  const findings = []
   for (const field of ['version', 'title', 'items']) {
     if (!(field in json)) {
-      findings.push({
-        severity: 'fail',
-        id: 'feed-json-field',
-        message: `missing required top-level field "${field}"`,
-      });
+      findings.push({severity: 'fail', id: 'feed-json-field', message: `missing required top-level field "${field}"`})
     }
   }
   if (json.version && !/^https:\/\/jsonfeed\.org\/version\/1(\.\d+)?$/.test(json.version)) {
-    findings.push({
-      severity: 'fail',
-      id: 'feed-json-version',
-      message: `"version" (${json.version}) is not a recognized JSON Feed version URI`,
-    });
+    findings.push({severity: 'fail', id: 'feed-json-version', message: `"version" (${json.version}) is not a recognized JSON Feed version URI`})
   }
   if (!Array.isArray(json.items)) {
-    return findings;
+    return findings
   }
   if (json.items.length === 0) {
-    findings.push({ severity: 'warn', id: 'feed-json-no-items', message: '"items" array is empty' });
-    return findings;
+    findings.push({severity: 'warn', id: 'feed-json-no-items', message: '"items" array is empty'})
+    return findings
   }
   for (const [idx, item] of json.items.entries()) {
     if (!item.id) {
-      findings.push({ severity: 'fail', id: 'feed-json-item-field', message: `items[${idx}] missing required "id"` });
+      findings.push({severity: 'fail', id: 'feed-json-item-field', message: `items[${idx}] missing required "id"`})
     }
     if (!item.content_html && !item.content_text) {
       findings.push({
         severity: 'fail',
         id: 'feed-json-item-field',
-        message: `items[${idx}] has neither "content_html" nor "content_text" (JSON Feed 1.1 requires at least one)`,
-      });
+        message: `items[${idx}] has neither "content_html" nor "content_text" (JSON Feed 1.1 requires at least one)`
+      })
     }
   }
 
-  const newestPublished = json.items
-    .map((item) => item.date_published && new Date(item.date_published))
-    .filter((d) => d && !Number.isNaN(d.getTime()))
-    .sort((a, b) => b - a)[0];
+  const newestPublished =
+    json.items.map((item) => item.date_published && new Date(item.date_published)).filter((d) => d && !Number.isNaN(d.getTime())).sort((a, b) => b - a)[0]
   if (!newestPublished) {
-    findings.push({
-      severity: 'warn',
-      id: 'feed-json-no-parseable-date',
-      message: 'no item has a parseable "date_published"',
-    });
+    findings.push({severity: 'warn', id: 'feed-json-no-parseable-date', message: 'no item has a parseable "date_published"'})
   } else {
-    const ageDays = (now - newestPublished) / 86_400_000;
+    const ageDays = (now - newestPublished) / 86_400_000
     if (ageDays > FRESHNESS_WINDOW_DAYS) {
       findings.push({
         severity: 'fail',
         id: 'feed-json-stale',
-        message: `newest item is ${ageDays.toFixed(1)} days old (${newestPublished.toISOString()}), `
-          + `exceeds the ${FRESHNESS_WINDOW_DAYS}-day soft window`,
-      });
+        message: `newest item is ${ageDays.toFixed(1)} days old (${newestPublished.toISOString()}), ` +
+          `exceeds the ${FRESHNESS_WINDOW_DAYS}-day soft window`
+      })
     }
   }
 
-  return findings;
+  return findings
 }
 
 async function main() {
-  const findings = [];
+  const findings = []
 
   try {
-    const res = await fetchStable(FEED_XML_URL);
+    const res = await fetchStable(FEED_XML_URL)
     if (!res.ok) {
-      findings.push({ severity: 'fail', id: 'feed-xml-fetch', message: `HTTP ${res.status} fetching ${FEED_XML_URL}` });
+      findings.push({severity: 'fail', id: 'feed-xml-fetch', message: `HTTP ${res.status} fetching ${FEED_XML_URL}`})
     } else {
-      findings.push(...validateFeedXml(await res.text()));
+      findings.push(...validateFeedXml(await res.text()))
     }
   } catch (err) {
-    findings.push({ severity: 'fail', id: 'feed-xml-fetch', message: `fetch failed: ${err.message}` });
+    findings.push({severity: 'fail', id: 'feed-xml-fetch', message: `fetch failed: ${err.message}`})
   }
 
   try {
-    const res = await fetchStable(FEED_JSON_URL);
+    const res = await fetchStable(FEED_JSON_URL)
     if (!res.ok) {
-      findings.push({
-        severity: 'fail',
-        id: 'feed-json-fetch',
-        message: `HTTP ${res.status} fetching ${FEED_JSON_URL}`,
-      });
+      findings.push({severity: 'fail', id: 'feed-json-fetch', message: `HTTP ${res.status} fetching ${FEED_JSON_URL}`})
     } else {
-      let json;
+      let json
       try {
-        json = await res.json();
+        json = await res.json()
       } catch (err) {
-        findings.push({ severity: 'fail', id: 'feed-json-parse', message: `not valid JSON: ${err.message}` });
-        json = null;
+        findings.push({severity: 'fail', id: 'feed-json-parse', message: `not valid JSON: ${err.message}`})
+        json = null
       }
-      if (json) findings.push(...validateFeedJson(json));
+      if (json) {
+        findings.push(...validateFeedJson(json))
+      }
     }
   } catch (err) {
-    findings.push({ severity: 'fail', id: 'feed-json-fetch', message: `fetch failed: ${err.message}` });
+    findings.push({severity: 'fail', id: 'feed-json-fetch', message: `fetch failed: ${err.message}`})
   }
 
-  process.exit(report('check-feeds', findings));
+  process.exit(report('check-feeds', findings))
 }
 
 if (isMain(import.meta.url)) {
-  main();
+  main()
 }

--- a/scripts/audit/check-headers.mjs
+++ b/scripts/audit/check-headers.mjs
@@ -4,129 +4,109 @@
 // asserts the Trusted Types report-only header is present, and checks
 // certificate expiry via a raw node:tls connection (no new dependency).
 
-import tls from 'node:tls';
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { SITE_URL } from '@lifegames/portal-contract/constants';
-import { fetchStable, isMain, report } from './lib/http.mjs';
+import tls from 'node:tls'
+import {readFileSync} from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {SITE_URL} from '@lifegames/portal-contract/constants'
+import {fetchStable, isMain, report} from './lib/http.mjs'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const GOLDEN_CSP_PATH = path.join(__dirname, '..', '..', 'tests', 'audit', 'golden', 'csp.txt');
-const MIN_CERT_DAYS_REMAINING = 30;
-const TLS_TIMEOUT_MS = 10_000;
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const GOLDEN_CSP_PATH = path.join(__dirname, '..', '..', 'tests', 'audit', 'golden', 'csp.txt')
+const MIN_CERT_DAYS_REMAINING = 30
+const TLS_TIMEOUT_MS = 10_000
 
-const REQUIRED_TRUSTED_TYPES_DIRECTIVE = "require-trusted-types-for 'script'";
+const REQUIRED_TRUSTED_TYPES_DIRECTIVE = "require-trusted-types-for 'script'"
 
 /** Pure validation function: (live headers) -> findings[]. Testable without network. */
 export function validateHeaders(headers, goldenCsp) {
-  const findings = [];
+  const findings = []
 
-  const liveCsp = (headers.get('content-security-policy') || '').trim();
-  const expectedCsp = goldenCsp.trim();
+  const liveCsp = (headers.get('content-security-policy') || '').trim()
+  const expectedCsp = goldenCsp.trim()
   if (!liveCsp) {
-    findings.push({
-      severity: 'fail',
-      id: 'headers-csp-missing',
-      message: 'no Content-Security-Policy header on the live response',
-    });
+    findings.push({severity: 'fail', id: 'headers-csp-missing', message: 'no Content-Security-Policy header on the live response'})
   } else if (liveCsp !== expectedCsp) {
     findings.push({
       severity: 'fail',
       id: 'headers-csp-drift',
-      message: 'live CSP differs from tests/audit/golden/csp.txt (either functions/_middleware.ts changed '
-        + 'and the golden needs updating, or this is an unintended drift):\n'
-        + `    live:     ${liveCsp}\n    expected: ${expectedCsp}`,
-    });
+      message: 'live CSP differs from tests/audit/golden/csp.txt (either functions/_middleware.ts changed ' +
+        'and the golden needs updating, or this is an unintended drift):\n' +
+        `    live:     ${liveCsp}\n    expected: ${expectedCsp}`
+    })
   }
 
-  const reportOnly = headers.get('content-security-policy-report-only') || '';
+  const reportOnly = headers.get('content-security-policy-report-only') || ''
   if (!reportOnly.includes(REQUIRED_TRUSTED_TYPES_DIRECTIVE)) {
     findings.push({
       severity: 'fail',
       id: 'headers-trusted-types-missing',
-      message: `Content-Security-Policy-Report-Only does not contain "${REQUIRED_TRUSTED_TYPES_DIRECTIVE}"`,
-    });
+      message: `Content-Security-Policy-Report-Only does not contain "${REQUIRED_TRUSTED_TYPES_DIRECTIVE}"`
+    })
   }
 
-  return findings;
+  return findings
 }
 
 /** Connects via TLS, reads the peer certificate's expiry, and returns findings. */
 function checkCertExpiry(host, minDaysRemaining = MIN_CERT_DAYS_REMAINING) {
   return new Promise((resolve) => {
-    const findings = [];
-    const socket = tls.connect({ host, port: 443, servername: host, timeout: TLS_TIMEOUT_MS }, () => {
-      const cert = socket.getPeerCertificate();
-      socket.end();
+    const findings = []
+    const socket = tls.connect({host, port: 443, servername: host, timeout: TLS_TIMEOUT_MS}, () => {
+      const cert = socket.getPeerCertificate()
+      socket.end()
       if (!cert || !cert.valid_to) {
-        findings.push({
-          severity: 'fail',
-          id: 'headers-cert-unreadable',
-          message: `could not read a peer certificate for ${host}`,
-        });
-        resolve(findings);
-        return;
+        findings.push({severity: 'fail', id: 'headers-cert-unreadable', message: `could not read a peer certificate for ${host}`})
+        resolve(findings)
+        return
       }
-      const validTo = new Date(cert.valid_to);
-      const daysRemaining = (validTo.getTime() - Date.now()) / 86_400_000;
+      const validTo = new Date(cert.valid_to)
+      const daysRemaining = (validTo.getTime() - Date.now()) / 86_400_000
       if (daysRemaining < 0) {
-        findings.push({
-          severity: 'fail',
-          id: 'headers-cert-expired',
-          message: `TLS certificate for ${host} expired on ${cert.valid_to}`,
-        });
+        findings.push({severity: 'fail', id: 'headers-cert-expired', message: `TLS certificate for ${host} expired on ${cert.valid_to}`})
       } else if (daysRemaining < minDaysRemaining) {
         findings.push({
           severity: 'fail',
           id: 'headers-cert-expiring-soon',
-          message: `TLS certificate for ${host} expires in ${daysRemaining.toFixed(1)} days (${cert.valid_to}), `
-            + `below the ${minDaysRemaining}-day warn threshold`,
-        });
+          message: `TLS certificate for ${host} expires in ${daysRemaining.toFixed(1)} days (${cert.valid_to}), ` +
+            `below the ${minDaysRemaining}-day warn threshold`
+        })
       }
-      resolve(findings);
-    });
+      resolve(findings)
+    })
     socket.on('error', (err) => {
-      findings.push({
-        severity: 'fail',
-        id: 'headers-cert-connect-failed',
-        message: `TLS connection to ${host}:443 failed: ${err.message}`,
-      });
-      resolve(findings);
-    });
+      findings.push({severity: 'fail', id: 'headers-cert-connect-failed', message: `TLS connection to ${host}:443 failed: ${err.message}`})
+      resolve(findings)
+    })
     socket.on('timeout', () => {
-      findings.push({
-        severity: 'fail',
-        id: 'headers-cert-connect-timeout',
-        message: `TLS connection to ${host}:443 timed out after ${TLS_TIMEOUT_MS}ms`,
-      });
-      socket.destroy();
-      resolve(findings);
-    });
-  });
+      findings.push({severity: 'fail', id: 'headers-cert-connect-timeout', message: `TLS connection to ${host}:443 timed out after ${TLS_TIMEOUT_MS}ms`})
+      socket.destroy()
+      resolve(findings)
+    })
+  })
 }
 
 async function main() {
-  const findings = [];
-  const goldenCsp = readFileSync(GOLDEN_CSP_PATH, 'utf-8');
+  const findings = []
+  const goldenCsp = readFileSync(GOLDEN_CSP_PATH, 'utf-8')
 
   try {
-    const res = await fetchStable(SITE_URL);
+    const res = await fetchStable(SITE_URL)
     if (!res.ok) {
-      findings.push({ severity: 'fail', id: 'headers-fetch', message: `HTTP ${res.status} fetching ${SITE_URL}` });
+      findings.push({severity: 'fail', id: 'headers-fetch', message: `HTTP ${res.status} fetching ${SITE_URL}`})
     } else {
-      findings.push(...validateHeaders(res.headers, goldenCsp));
+      findings.push(...validateHeaders(res.headers, goldenCsp))
     }
   } catch (err) {
-    findings.push({ severity: 'fail', id: 'headers-fetch', message: `fetch failed: ${err.message}` });
+    findings.push({severity: 'fail', id: 'headers-fetch', message: `fetch failed: ${err.message}`})
   }
 
-  const host = new URL(SITE_URL).hostname;
-  findings.push(...(await checkCertExpiry(host)));
+  const host = new URL(SITE_URL).hostname
+  findings.push(...(await checkCertExpiry(host)))
 
-  process.exit(report('check-headers', findings));
+  process.exit(report('check-headers', findings))
 }
 
 if (isMain(import.meta.url)) {
-  main();
+  main()
 }

--- a/scripts/audit/check-security-txt.mjs
+++ b/scripts/audit/check-security-txt.mjs
@@ -6,85 +6,72 @@
 // standing gap the check exists to eventually catch (§7 finding #4 of the
 // monorepo audit plan).
 
-import { SITE_URL } from '@lifegames/portal-contract/constants';
-import { fetchStable, isMain, report } from './lib/http.mjs';
+import {SITE_URL} from '@lifegames/portal-contract/constants'
+import {fetchStable, isMain, report} from './lib/http.mjs'
 
-const SECURITY_TXT_URL = `${SITE_URL}/.well-known/security.txt`;
-const MIN_DAYS_REMAINING = 30;
+const SECURITY_TXT_URL = `${SITE_URL}/.well-known/security.txt`
+const MIN_DAYS_REMAINING = 30
 
 /** Pure validation function: (security.txt body) -> findings[]. Testable without network. */
 export function validateSecurityTxt(body, now = new Date(), minDaysRemaining = MIN_DAYS_REMAINING) {
-  const findings = [];
+  const findings = []
 
-  const match = /^Expires:\s*(.+)$/im.exec(body);
+  const match = /^Expires:\s*(.+)$/im.exec(body)
   if (!match) {
-    findings.push({
-      severity: 'fail',
-      id: 'security-txt-expires-missing',
-      message: 'no "Expires:" field found (required by RFC 9116 §2.5.5)',
-    });
-    return findings;
+    findings.push({severity: 'fail', id: 'security-txt-expires-missing', message: 'no "Expires:" field found (required by RFC 9116 §2.5.5)'})
+    return findings
   }
 
-  const expiresRaw = match[1].trim();
-  const expires = new Date(expiresRaw);
+  const expiresRaw = match[1].trim()
+  const expires = new Date(expiresRaw)
   if (Number.isNaN(expires.getTime())) {
     findings.push({
       severity: 'fail',
       id: 'security-txt-expires-unparseable',
-      message: `"Expires: ${expiresRaw}" is not a parseable date (RFC 9116 requires ISO 8601 / RFC 3339)`,
-    });
-    return findings;
+      message: `"Expires: ${expiresRaw}" is not a parseable date (RFC 9116 requires ISO 8601 / RFC 3339)`
+    })
+    return findings
   }
 
-  const daysRemaining = (expires.getTime() - now.getTime()) / 86_400_000;
+  const daysRemaining = (expires.getTime() - now.getTime()) / 86_400_000
   if (daysRemaining < 0) {
-    findings.push({
-      severity: 'fail',
-      id: 'security-txt-expired',
-      message: `Expires (${expires.toISOString()}) is in the PAST -- security.txt has expired`,
-    });
+    findings.push({severity: 'fail', id: 'security-txt-expired', message: `Expires (${expires.toISOString()}) is in the PAST -- security.txt has expired`})
   } else if (daysRemaining < minDaysRemaining) {
     findings.push({
       severity: 'fail',
       id: 'security-txt-expiring-soon',
-      message: `Expires (${expires.toISOString()}) is only ${daysRemaining.toFixed(1)} days out, `
-        + `below the ${minDaysRemaining}-day warn threshold`,
-    });
+      message: `Expires (${expires.toISOString()}) is only ${daysRemaining.toFixed(1)} days out, ` + `below the ${minDaysRemaining}-day warn threshold`
+    })
   }
 
   if (!/^Contact:\s*\S/im.test(body)) {
-    findings.push({
-      severity: 'warn',
-      id: 'security-txt-contact-missing',
-      message: 'no "Contact:" field found (required by RFC 9116 §2.5.1)',
-    });
+    findings.push({severity: 'warn', id: 'security-txt-contact-missing', message: 'no "Contact:" field found (required by RFC 9116 §2.5.1)'})
   }
 
-  return findings;
+  return findings
 }
 
 async function main() {
-  let body;
+  let body
   try {
-    const res = await fetchStable(SECURITY_TXT_URL);
+    const res = await fetchStable(SECURITY_TXT_URL)
     if (!res.ok) {
       process.exit(report('check-security-txt', [
-        { severity: 'fail', id: 'security-txt-fetch', message: `HTTP ${res.status} fetching ${SECURITY_TXT_URL}` },
-      ]));
-      return;
+        {severity: 'fail', id: 'security-txt-fetch', message: `HTTP ${res.status} fetching ${SECURITY_TXT_URL}`}
+      ]))
+      return
     }
-    body = await res.text();
+    body = await res.text()
   } catch (err) {
     process.exit(report('check-security-txt', [
-      { severity: 'fail', id: 'security-txt-fetch', message: `fetch failed: ${err.message}` },
-    ]));
-    return;
+      {severity: 'fail', id: 'security-txt-fetch', message: `fetch failed: ${err.message}`}
+    ]))
+    return
   }
 
-  process.exit(report('check-security-txt', validateSecurityTxt(body)));
+  process.exit(report('check-security-txt', validateSecurityTxt(body)))
 }
 
 if (isMain(import.meta.url)) {
-  main();
+  main()
 }

--- a/scripts/audit/check-wellknown.mjs
+++ b/scripts/audit/check-wellknown.mjs
@@ -14,197 +14,139 @@
 // Each surface's assertions are a pure `validateXShape(json, contentType)`
 // function (testable without network); main() below is just fetch-and-call.
 
-import { SITE_URL } from '@lifegames/portal-contract/constants';
-import { fetchStable, isMain, report } from './lib/http.mjs';
+import {SITE_URL} from '@lifegames/portal-contract/constants'
+import {fetchStable, isMain, report} from './lib/http.mjs'
 
 // Pinned per docs/discovery-surface.md "Agent-discovery conformance notes"
 // (point-in-time 2026-07-07). A monthly T3 skill re-verifies these against
 // the upstream specs; bump only after that re-verification, not casually.
-export const PINNED_A2A_SPEC_VERSION = '1.0';
-export const PINNED_ARD_SPEC_VERSION = '1.0';
+export const PINNED_A2A_SPEC_VERSION = '1.0'
+export const PINNED_ARD_SPEC_VERSION = '1.0'
 
 function assertFields(obj, fields, id, label, findings) {
   for (const field of fields) {
     if (!(field in obj)) {
-      findings.push({ severity: 'fail', id, message: `${label} missing required field "${field}"` });
+      findings.push({severity: 'fail', id, message: `${label} missing required field "${field}"`})
     }
   }
 }
 
 /** webfinger (RFC 7033): a JRD with a `subject` and a `links` array. Pure -- testable without network. */
 export function validateWebfingerShape(json, contentType) {
-  const findings = [];
+  const findings = []
   if (!contentType.includes('application/jrd+json')) {
-    findings.push({
-      severity: 'fail',
-      id: 'wellknown-webfinger-content-type',
-      message: `expected Content-Type application/jrd+json, got "${contentType}"`,
-    });
+    findings.push({severity: 'fail', id: 'wellknown-webfinger-content-type', message: `expected Content-Type application/jrd+json, got "${contentType}"`})
   }
-  assertFields(json, ['subject', 'links'], 'wellknown-webfinger-shape', 'webfinger JRD', findings);
+  assertFields(json, ['subject', 'links'], 'wellknown-webfinger-shape', 'webfinger JRD', findings)
   if (json.subject && !/^acct:/.test(json.subject)) {
     findings.push({
       severity: 'fail',
       id: 'wellknown-webfinger-subject',
-      message: `webfinger "subject" (${json.subject}) is not an "acct:" URI (RFC 7033 §3.1)`,
-    });
+      message: `webfinger "subject" (${json.subject}) is not an "acct:" URI (RFC 7033 §3.1)`
+    })
   }
   if (Array.isArray(json.links) && !json.links.some((l) => l.rel === 'self')) {
-    findings.push({
-      severity: 'warn',
-      id: 'wellknown-webfinger-no-self-link',
-      message: 'webfinger response has no rel="self" link',
-    });
+    findings.push({severity: 'warn', id: 'wellknown-webfinger-no-self-link', message: 'webfinger response has no rel="self" link'})
   }
-  return findings;
+  return findings
 }
 
 /** agent-card.json (A2A AgentCard). Pure -- testable without network. */
 export function validateAgentCardShape(json) {
-  const findings = [];
-  assertFields(
-    json,
-    [
-      'name',
-      'description',
-      'supportedInterfaces',
-      'version',
-      'capabilities',
-      'defaultInputModes',
-      'defaultOutputModes',
-      'skills',
-    ],
-    'wellknown-agent-card-shape',
-    `agent-card.json (A2A v${PINNED_A2A_SPEC_VERSION})`,
-    findings,
-  );
+  const findings = []
+  assertFields(json, [
+    'name',
+    'description',
+    'supportedInterfaces',
+    'version',
+    'capabilities',
+    'defaultInputModes',
+    'defaultOutputModes',
+    'skills'
+  ], 'wellknown-agent-card-shape', `agent-card.json (A2A v${PINNED_A2A_SPEC_VERSION})`, findings)
   if (Array.isArray(json.supportedInterfaces)) {
     if (json.supportedInterfaces.length === 0) {
       findings.push({
         severity: 'fail',
         id: 'wellknown-agent-card-no-interfaces',
-        message: 'agent-card.json "supportedInterfaces" is empty -- A2A requires at least one',
-      });
+        message: 'agent-card.json "supportedInterfaces" is empty -- A2A requires at least one'
+      })
     }
     for (const iface of json.supportedInterfaces) {
-      assertFields(
-        iface,
-        ['url', 'protocolBinding', 'protocolVersion'],
-        'wellknown-agent-card-interface-shape',
-        'agent-card.json supportedInterfaces[] entry',
-        findings,
-      );
+      assertFields(iface, ['url', 'protocolBinding', 'protocolVersion'], 'wellknown-agent-card-interface-shape',
+        'agent-card.json supportedInterfaces[] entry', findings)
     }
   }
   if (Array.isArray(json.skills) && json.skills.length === 0) {
-    findings.push({
-      severity: 'warn',
-      id: 'wellknown-agent-card-no-skills',
-      message: 'agent-card.json "skills" array is empty',
-    });
+    findings.push({severity: 'warn', id: 'wellknown-agent-card-no-skills', message: 'agent-card.json "skills" array is empty'})
   }
-  return findings;
+  return findings
 }
 
 /** ai-catalog.json (ARD -- Agentic Resource Discovery). Pure -- testable without network. */
 export function validateAiCatalogShape(json) {
-  const findings = [];
-  assertFields(
-    json,
-    ['specVersion', 'entries'],
-    'wellknown-ai-catalog-shape',
-    `ai-catalog.json (ARD specVersion ${PINNED_ARD_SPEC_VERSION})`,
-    findings,
-  );
+  const findings = []
+  assertFields(json, ['specVersion', 'entries'], 'wellknown-ai-catalog-shape', `ai-catalog.json (ARD specVersion ${PINNED_ARD_SPEC_VERSION})`, findings)
   if (json.specVersion !== undefined && String(json.specVersion) !== PINNED_ARD_SPEC_VERSION) {
     findings.push({
       severity: 'warn',
       id: 'wellknown-ai-catalog-spec-version-drift',
-      message: `ai-catalog.json "specVersion" is "${json.specVersion}", pinned constant is `
-        + `"${PINNED_ARD_SPEC_VERSION}" -- re-verify against agenticresourcediscovery/ard-spec`,
-    });
+      message: `ai-catalog.json "specVersion" is "${json.specVersion}", pinned constant is ` +
+        `"${PINNED_ARD_SPEC_VERSION}" -- re-verify against agenticresourcediscovery/ard-spec`
+    })
   }
   if (Array.isArray(json.entries)) {
     if (json.entries.length === 0) {
-      findings.push({
-        severity: 'fail',
-        id: 'wellknown-ai-catalog-no-entries',
-        message: 'ai-catalog.json "entries" is empty',
-      });
+      findings.push({severity: 'fail', id: 'wellknown-ai-catalog-no-entries', message: 'ai-catalog.json "entries" is empty'})
     }
     for (const entry of json.entries) {
-      assertFields(
-        entry,
-        ['identifier', 'displayName', 'type'],
-        'wellknown-ai-catalog-entry-shape',
-        'ai-catalog.json entries[] entry',
-        findings,
-      );
+      assertFields(entry, ['identifier', 'displayName', 'type'], 'wellknown-ai-catalog-entry-shape', 'ai-catalog.json entries[] entry', findings)
       if (entry.identifier && !/^urn:air:/.test(entry.identifier)) {
         findings.push({
           severity: 'fail',
           id: 'wellknown-ai-catalog-entry-identifier',
-          message: `ai-catalog.json entry identifier "${entry.identifier}" is not an RFC 8141 `
-            + '"urn:air:<publisher>:<namespace>:<name>" URN',
-        });
+          message: `ai-catalog.json entry identifier "${entry.identifier}" is not an RFC 8141 ` + '"urn:air:<publisher>:<namespace>:<name>" URN'
+        })
       }
       if (!('url' in entry) && !('data' in entry)) {
         findings.push({
           severity: 'fail',
           id: 'wellknown-ai-catalog-entry-no-locator',
-          message: `ai-catalog.json entry "${entry.identifier ?? '(no identifier)'}" has neither "url" nor "data"`,
-        });
+          message: `ai-catalog.json entry "${entry.identifier ?? '(no identifier)'}" has neither "url" nor "data"`
+        })
       }
     }
   }
-  return findings;
+  return findings
 }
 
 /** .well-known/mcp/server-card.json (MCP server descriptor). Pure -- testable without network. */
 export function validateMcpServerCardShape(json) {
-  const findings = [];
-  assertFields(
-    json,
-    ['name', 'serverInfo', 'capabilities', 'transport', 'resources'],
-    'wellknown-mcp-server-card-shape',
-    'mcp/server-card.json',
-    findings,
-  );
+  const findings = []
+  assertFields(json, ['name', 'serverInfo', 'capabilities', 'transport', 'resources'], 'wellknown-mcp-server-card-shape', 'mcp/server-card.json', findings)
   if (json.transport && !json.transport.url) {
-    findings.push({
-      severity: 'fail',
-      id: 'wellknown-mcp-server-card-transport-url',
-      message: 'mcp/server-card.json "transport" is missing a "url"',
-    });
+    findings.push({severity: 'fail', id: 'wellknown-mcp-server-card-transport-url', message: 'mcp/server-card.json "transport" is missing a "url"'})
   }
   if (Array.isArray(json.resources) && json.resources.length === 0) {
-    findings.push({
-      severity: 'warn',
-      id: 'wellknown-mcp-server-card-no-resources',
-      message: 'mcp/server-card.json "resources" array is empty',
-    });
+    findings.push({severity: 'warn', id: 'wellknown-mcp-server-card-no-resources', message: 'mcp/server-card.json "resources" array is empty'})
   }
-  return findings;
+  return findings
 }
 
 /** .well-known/api-catalog (RFC 9727 linkset). Pure -- testable without network. */
 export function validateApiCatalogShape(json, contentType) {
-  const findings = [];
+  const findings = []
   if (!contentType.includes('application/linkset+json')) {
     findings.push({
       severity: 'fail',
       id: 'wellknown-api-catalog-content-type',
-      message: `expected Content-Type application/linkset+json (RFC 9727), got "${contentType}"`,
-    });
+      message: `expected Content-Type application/linkset+json (RFC 9727), got "${contentType}"`
+    })
   }
   if (!Array.isArray(json.linkset) || json.linkset.length === 0) {
-    findings.push({
-      severity: 'fail',
-      id: 'wellknown-api-catalog-linkset',
-      message: 'api-catalog "linkset" is missing or empty',
-    });
+    findings.push({severity: 'fail', id: 'wellknown-api-catalog-linkset', message: 'api-catalog "linkset" is missing or empty'})
   }
-  return findings;
+  return findings
 }
 
 // Never throws -- every failure mode (network error, non-2xx, bad JSON)
@@ -213,31 +155,31 @@ export function validateApiCatalogShape(json, contentType) {
 // (C77 cascade-safety: a bare Promise.all over independent HTTP fetches must
 // not let one throw abort the rest).
 async function fetchJson(url, headers) {
-  let res;
+  let res
   try {
-    res = await fetchStable(url, headers ? { headers } : undefined);
+    res = await fetchStable(url, headers ? {headers} : undefined)
   } catch (err) {
-    return { error: `fetch failed for ${url}: ${err.message}` };
+    return {error: `fetch failed for ${url}: ${err.message}`}
   }
   if (!res.ok) {
-    return { error: `HTTP ${res.status} fetching ${url}` };
+    return {error: `HTTP ${res.status} fetching ${url}`}
   }
-  const contentType = res.headers.get('content-type') || '';
-  let json;
+  const contentType = res.headers.get('content-type') || ''
+  let json
   try {
-    json = await res.json();
+    json = await res.json()
   } catch (err) {
-    return { error: `${url} did not return valid JSON: ${err.message}` };
+    return {error: `${url} did not return valid JSON: ${err.message}`}
   }
-  return { json, contentType };
+  return {json, contentType}
 }
 
 async function fetchAndValidate(url, validate, fetchErrorId, headers) {
-  const { json, contentType, error } = await fetchJson(url, headers);
+  const {json, contentType, error} = await fetchJson(url, headers)
   if (error) {
-    return [{ severity: 'fail', id: fetchErrorId, message: error }];
+    return [{severity: 'fail', id: fetchErrorId, message: error}]
   }
-  return validate(json, contentType);
+  return validate(json, contentType)
 }
 
 async function main() {
@@ -248,20 +190,16 @@ async function main() {
       'wellknown-webfinger-fetch',
       // Accept: application/jrd+json avoids the text/markdown negotiation
       // early-return in functions/_middleware.ts (same header the smoke suite uses).
-      { Accept: 'application/jrd+json' },
+      {Accept: 'application/jrd+json'}
     ),
     fetchAndValidate(`${SITE_URL}/.well-known/agent-card.json`, validateAgentCardShape, 'wellknown-agent-card-fetch'),
     fetchAndValidate(`${SITE_URL}/.well-known/ai-catalog.json`, validateAiCatalogShape, 'wellknown-ai-catalog-fetch'),
-    fetchAndValidate(
-      `${SITE_URL}/.well-known/mcp/server-card.json`,
-      validateMcpServerCardShape,
-      'wellknown-mcp-server-card-fetch',
-    ),
-    fetchAndValidate(`${SITE_URL}/.well-known/api-catalog`, validateApiCatalogShape, 'wellknown-api-catalog-fetch'),
-  ]);
-  process.exit(report('check-wellknown', results.flat()));
+    fetchAndValidate(`${SITE_URL}/.well-known/mcp/server-card.json`, validateMcpServerCardShape, 'wellknown-mcp-server-card-fetch'),
+    fetchAndValidate(`${SITE_URL}/.well-known/api-catalog`, validateApiCatalogShape, 'wellknown-api-catalog-fetch')
+  ])
+  process.exit(report('check-wellknown', results.flat()))
 }
 
 if (isMain(import.meta.url)) {
-  main();
+  main()
 }

--- a/scripts/audit/lib/file-check-issues.mjs
+++ b/scripts/audit/lib/file-check-issues.mjs
@@ -18,14 +18,14 @@
 // Report-only phase (D4): labels only (`audit`, `audit:report-only`); this
 // script and its caller have no blocking behavior.
 
-import { execFileSync } from 'node:child_process';
+import {execFileSync} from 'node:child_process'
 
 function gh(args) {
-  return execFileSync('gh', args, { encoding: 'utf-8' });
+  return execFileSync('gh', args, {encoding: 'utf-8'})
 }
 
-function fileOrUpdateIssue({ id, title }, repo, runUrl) {
-  const issueTitle = `[audit] ${title}`;
+function fileOrUpdateIssue({id, title}, repo, runUrl) {
+  const issueTitle = `[audit] ${title}`
   const existingRaw = gh([
     'issue',
     'list',
@@ -40,22 +40,22 @@ function fileOrUpdateIssue({ id, title }, repo, runUrl) {
     '--json',
     'number,title',
     '--limit',
-    '20',
-  ]);
-  const existing = JSON.parse(existingRaw);
-  const dup = existing.find((i) => i.title === issueTitle);
+    '20'
+  ])
+  const existing = JSON.parse(existingRaw)
+  const dup = existing.find((i) => i.title === issueTitle)
   const body = [
     `Check \`${id}\` failed.`,
     '',
     `Run: ${runUrl}`,
     '',
-    'This is a **report-only** finding (lp-audit Phase 2, D4) -- it does not block CI or deploys. '
-    + "See the run's job log for this check's own findings output.",
-  ].join('\n');
+    'This is a **report-only** finding (lp-audit Phase 2, D4) -- it does not block CI or deploys. ' +
+    "See the run's job log for this check's own findings output."
+  ].join('\n')
 
   if (dup) {
-    gh(['issue', 'comment', String(dup.number), '--repo', repo, '--body', `Another run failed: ${runUrl}`]);
-    console.log(`Updated existing issue #${dup.number} for check "${id}"`);
+    gh(['issue', 'comment', String(dup.number), '--repo', repo, '--body', `Another run failed: ${runUrl}`])
+    console.log(`Updated existing issue #${dup.number} for check "${id}"`)
   } else {
     gh([
       'issue',
@@ -67,29 +67,29 @@ function fileOrUpdateIssue({ id, title }, repo, runUrl) {
       '--body',
       body,
       '--label',
-      'audit,audit:report-only',
-    ]);
-    console.log(`Filed new issue for check "${id}"`);
+      'audit,audit:report-only'
+    ])
+    console.log(`Filed new issue for check "${id}"`)
   }
 }
 
 function main() {
-  const repo = process.env.GH_REPO;
-  const runUrl = process.env.GH_RUN_URL;
-  const checks = JSON.parse(process.env.CHECK_RESULTS_JSON || '[]');
+  const repo = process.env.GH_REPO
+  const runUrl = process.env.GH_RUN_URL
+  const checks = JSON.parse(process.env.CHECK_RESULTS_JSON || '[]')
 
-  const failed = checks.filter((c) => c.outcome === 'failure');
+  const failed = checks.filter((c) => c.outcome === 'failure')
   if (failed.length === 0) {
-    console.log('No failing checks in this job -- nothing to file.');
-    return;
+    console.log('No failing checks in this job -- nothing to file.')
+    return
   }
   if (!repo) {
-    console.error('GH_REPO env var not set -- cannot file issues.');
-    process.exit(1);
+    console.error('GH_REPO env var not set -- cannot file issues.')
+    process.exit(1)
   }
   for (const check of failed) {
-    fileOrUpdateIssue(check, repo, runUrl);
+    fileOrUpdateIssue(check, repo, runUrl)
   }
 }
 
-main();
+main()

--- a/scripts/audit/lib/http.mjs
+++ b/scripts/audit/lib/http.mjs
@@ -5,7 +5,7 @@
 // is not an outage (see web's tests/smoke/home.smoke.ts getStable(), issue #106)
 // but a steady-state 5xx still fails once the retry budget is spent.
 
-const DEFAULT_BUDGET_MS = 20_000;
+const DEFAULT_BUDGET_MS = 20_000
 
 /**
  * Fetch a URL, retrying transient upstream 5xx responses with capped
@@ -14,13 +14,13 @@ const DEFAULT_BUDGET_MS = 20_000;
  * one-off gateway blip, and should fail the check immediately.
  */
 export async function fetchStable(url, init = {}, budgetMs = DEFAULT_BUDGET_MS) {
-  const deadline = Date.now() + budgetMs;
-  let res = await fetch(url, init);
+  const deadline = Date.now() + budgetMs
+  let res = await fetch(url, init)
   for (let attempt = 0; res.status >= 500 && Date.now() < deadline; attempt++) {
-    await new Promise((resolve) => setTimeout(resolve, Math.min(1_000 * 2 ** attempt, 5_000)));
-    res = await fetch(url, init);
+    await new Promise((resolve) => setTimeout(resolve, Math.min(1_000 * 2 ** attempt, 5_000)))
+    res = await fetch(url, init)
   }
-  return res;
+  return res
 }
 
 /**
@@ -29,8 +29,8 @@ export async function fetchStable(url, init = {}, budgetMs = DEFAULT_BUDGET_MS) 
  * remember to drain/ignore the body.
  */
 export async function headStable(url, budgetMs = DEFAULT_BUDGET_MS) {
-  const res = await fetchStable(url, { method: 'HEAD', redirect: 'follow' }, budgetMs);
-  return { ok: res.ok, status: res.status, finalUrl: res.url || url };
+  const res = await fetchStable(url, {method: 'HEAD', redirect: 'follow'}, budgetMs)
+  return {ok: res.ok, status: res.status, finalUrl: res.url || url}
 }
 
 /**
@@ -41,20 +41,20 @@ export async function headStable(url, budgetMs = DEFAULT_BUDGET_MS) {
  * something an individual script decides.
  */
 export function report(checkId, findings) {
-  const fails = findings.filter((f) => f.severity === 'fail');
-  const warns = findings.filter((f) => f.severity === 'warn');
-  console.log(`\n=== ${checkId} ===`);
+  const fails = findings.filter((f) => f.severity === 'fail')
+  const warns = findings.filter((f) => f.severity === 'warn')
+  console.log(`\n=== ${checkId} ===`)
   if (findings.length === 0) {
-    console.log('  (no findings)');
+    console.log('  (no findings)')
   }
   for (const f of findings) {
-    console.log(`  [${f.severity}] ${f.id}: ${f.message}`);
+    console.log(`  [${f.severity}] ${f.id}: ${f.message}`)
   }
-  console.log(`  ${fails.length} fail, ${warns.length} warn, ${findings.length} total`);
-  return fails.length > 0 ? 1 : 0;
+  console.log(`  ${fails.length} fail, ${warns.length} warn, ${findings.length} total`)
+  return fails.length > 0 ? 1 : 0
 }
 
 /** True when this module is being executed directly (`node script.mjs`), not imported by a test. */
 export function isMain(importMetaUrl) {
-  return importMetaUrl === `file://${process.argv[1]}`;
+  return importMetaUrl === `file://${process.argv[1]}`
 }

--- a/scripts/audit/validate-llms-txt.mjs
+++ b/scripts/audit/validate-llms-txt.mjs
@@ -21,196 +21,188 @@
 // universal real-world practice and this repo's own llms.txt, even though the
 // spec technically marks the H1 alone as required -- see inline note.
 
-import { LLM_CONTENT_PATHS, SITE_URL } from '@lifegames/portal-contract/constants';
-import { fetchStable, isMain, report } from './lib/http.mjs';
+import {LLM_CONTENT_PATHS, SITE_URL} from '@lifegames/portal-contract/constants'
+import {fetchStable, isMain, report} from './lib/http.mjs'
 
-const LLMS_TXT_URL = `${SITE_URL}/llms.txt`;
+const LLMS_TXT_URL = `${SITE_URL}/llms.txt`
 // PROD-DOMAIN paths, deliberately: B2's concern is that jonathanlloyd.me serves
 // these (they 404'd there until 2026-07-17 because only /llms.txt had a proxy
 // route — functions/llms-full.txt.ts + functions/index.md.ts now cover them).
 // Source-side CloudFront freshness for the same artifacts is C1's job
 // (mantle-LifegamesPortal/scripts/audit/freshness.mjs).
-const LLMS_FULL_URL = `${SITE_URL}${LLM_CONTENT_PATHS.llmsFull}`;
-const INDEX_MD_URL = `${SITE_URL}${LLM_CONTENT_PATHS.indexMarkdown}`;
+const LLMS_FULL_URL = `${SITE_URL}${LLM_CONTENT_PATHS.llmsFull}`
+const INDEX_MD_URL = `${SITE_URL}${LLM_CONTENT_PATHS.indexMarkdown}`
 
-const LINK_ITEM_RE = /^[-*]\s+\[([^\]]+)\]\(([^)]+)\)(:\s*.*)?$/;
-const LIST_ITEM_RE = /^[-*]\s+/;
+const LINK_ITEM_RE = /^[-*]\s+\[([^\]]+)\]\(([^)]+)\)(:\s*.*)?$/
+const LIST_ITEM_RE = /^[-*]\s+/
 
 /**
  * Validate llms.txt structure against the llmstxt.org convention.
  * Pure function (string in, findings out) so it's testable without network.
  */
 export function validateLlmsTxt(rawText) {
-  const findings = [];
-  let text = rawText;
+  const findings = []
+  let text = rawText
 
   // 1. Optional BOM.
   if (text.charCodeAt(0) === 0xfeff) {
-    text = text.slice(1);
+    text = text.slice(1)
   }
 
-  const lines = text.split(/\r\n|\r|\n/);
-  let i = 0;
+  const lines = text.split(/\r\n|\r|\n/)
+  let i = 0
   const nextNonBlank = () => {
-    while (i < lines.length && lines[i].trim() === '') i++;
-    return i < lines.length ? lines[i] : null;
-  };
+    while (i < lines.length && lines[i].trim() === '') {
+      i++
+    }
+    return i < lines.length ? lines[i] : null
+  }
 
   // 2. First non-blank line MUST be an H1.
-  const h1Line = nextNonBlank();
+  const h1Line = nextNonBlank()
   if (h1Line === null || !/^#\s+\S/.test(h1Line)) {
-    findings.push({
-      severity: 'fail',
-      id: 'llms-txt-h1',
-      message: `first non-blank line must be "# <title>"; got ${JSON.stringify(h1Line)}`,
-    });
-    return findings; // structure is unrecoverable past this point
+    findings.push({severity: 'fail', id: 'llms-txt-h1', message: `first non-blank line must be "# <title>"; got ${JSON.stringify(h1Line)}`})
+    return findings // structure is unrecoverable past this point
   }
-  i++;
+  i++
 
   // 3. Next non-blank line MUST be a blockquote (required by this validator;
   // the spec's own prose marks only the H1 as strictly required, but every
   // real-world llms.txt -- including this site's -- includes it, and the
   // team's validator contract treats it as required).
-  const bqLine = nextNonBlank();
+  const bqLine = nextNonBlank()
   if (bqLine === null || !/^>\s+\S/.test(bqLine)) {
     findings.push({
       severity: 'fail',
       id: 'llms-txt-blockquote',
-      message: `expected a "> summary" blockquote immediately after the H1; got ${JSON.stringify(bqLine)}`,
-    });
+      message: `expected a "> summary" blockquote immediately after the H1; got ${JSON.stringify(bqLine)}`
+    })
   } else {
-    i++;
+    i++
   }
 
   // 4/5. Walk remaining lines. Before the first H2: anything except another
   // H1 is fine (free-form body). From the first H2 onward: every H2 section's
   // list items must be markdown links.
-  let sawH2 = false;
-  let currentSection = null; // { name, hasListItem, isOptional }
-  const sectionFindings = [];
+  let sawH2 = false
+  let currentSection = null // { name, hasListItem, isOptional }
+  const sectionFindings = []
 
   const closeSection = () => {
     if (currentSection && !currentSection.hasListItem) {
       sectionFindings.push({
         severity: 'warn',
         id: 'llms-txt-h2-no-file-list',
-        message: `H2 section "${currentSection.name}" has no [name](url) file-list items`
-          + ' (llmstxt.org: H2 sections are "file lists" of links)',
-      });
+        message: `H2 section "${currentSection.name}" has no [name](url) file-list items` + ' (llmstxt.org: H2 sections are "file lists" of links)'
+      })
     }
-  };
+  }
 
   for (; i < lines.length; i++) {
-    const line = lines[i];
-    const h2Match = /^##\s+(.+?)\s*$/.exec(line);
+    const line = lines[i]
+    const h2Match = /^##\s+(.+?)\s*$/.exec(line)
     if (h2Match) {
-      closeSection();
-      sawH2 = true;
-      currentSection = { name: h2Match[1], hasListItem: false, isOptional: h2Match[1].trim() === 'Optional' };
-      continue;
+      closeSection()
+      sawH2 = true
+      currentSection = {name: h2Match[1], hasListItem: false, isOptional: h2Match[1].trim() === 'Optional'}
+      continue
     }
     if (/^#\s+\S/.test(line)) {
-      sectionFindings.push({
-        severity: 'fail',
-        id: 'llms-txt-second-h1',
-        message: `unexpected second H1 at "${line}" -- only one H1 is allowed`,
-      });
-      continue;
+      sectionFindings.push({severity: 'fail', id: 'llms-txt-second-h1', message: `unexpected second H1 at "${line}" -- only one H1 is allowed`})
+      continue
     }
     if (!sawH2) {
-      continue; // free-form pre-H2 body: anything but headings is spec-legal
+      continue // free-form pre-H2 body: anything but headings is spec-legal
     }
     if (LIST_ITEM_RE.test(line) && currentSection) {
-      currentSection.hasListItem = true;
+      currentSection.hasListItem = true
       if (!LINK_ITEM_RE.test(line)) {
         sectionFindings.push({
           severity: 'fail',
           id: 'llms-txt-non-link-list-item',
-          message: `H2 section "${currentSection.name}" has a list item that is not a `
-            + `"[name](url)" or "[name](url): notes" markdown link: ${JSON.stringify(line.trim())}`,
-        });
+          message: `H2 section "${currentSection.name}" has a list item that is not a ` +
+            `"[name](url)" or "[name](url): notes" markdown link: ${JSON.stringify(line.trim())}`
+        })
       }
     }
   }
-  closeSection();
+  closeSection()
 
-  return [...findings, ...sectionFindings];
+  return [...findings, ...sectionFindings]
 }
 
 /** Existence/non-emptiness/freshness check for an artifact with no formal spec. */
 async function checkPresence(id, url, maxAgeHours) {
-  const findings = [];
-  let res;
+  const findings = []
+  let res
   try {
-    res = await fetchStable(url);
+    res = await fetchStable(url)
   } catch (err) {
-    findings.push({ severity: 'fail', id, message: `fetch failed: ${err.message}` });
-    return findings;
+    findings.push({severity: 'fail', id, message: `fetch failed: ${err.message}`})
+    return findings
   }
   if (!res.ok) {
-    findings.push({ severity: 'fail', id, message: `HTTP ${res.status} fetching ${url}` });
-    return findings;
+    findings.push({severity: 'fail', id, message: `HTTP ${res.status} fetching ${url}`})
+    return findings
   }
-  const body = await res.text();
+  const body = await res.text()
   if (body.trim().length === 0) {
-    findings.push({ severity: 'fail', id, message: `${url} returned an empty body` });
-    return findings;
+    findings.push({severity: 'fail', id, message: `${url} returned an empty body`})
+    return findings
   }
 
   // Freshness: prefer an embedded "**Generated:** <ISO date>" marker (present
   // in this composer's output); fall back to the Last-Modified header.
-  const generatedMatch = body.match(/\*\*Generated:\*\*\s*([0-9T:.Z-]+)/);
-  const generatedAt = generatedMatch ? new Date(generatedMatch[1]) : null;
-  const lastModifiedHeader = res.headers.get('last-modified');
+  const generatedMatch = body.match(/\*\*Generated:\*\*\s*([0-9T:.Z-]+)/)
+  const generatedAt = generatedMatch ? new Date(generatedMatch[1]) : null
+  const lastModifiedHeader = res.headers.get('last-modified')
   const referenceDate = generatedAt && !Number.isNaN(generatedAt.getTime())
     ? generatedAt
-    : (lastModifiedHeader ? new Date(lastModifiedHeader) : null);
+    : (lastModifiedHeader ? new Date(lastModifiedHeader) : null)
 
   if (!referenceDate || Number.isNaN(referenceDate.getTime())) {
     findings.push({
       severity: 'warn',
       id: `${id}-freshness-unknown`,
-      message: `could not determine a generation/modification time for ${url} (no embedded `
-        + 'Generated marker and no Last-Modified header) -- freshness unchecked',
-    });
+      message: `could not determine a generation/modification time for ${url} (no embedded ` +
+        'Generated marker and no Last-Modified header) -- freshness unchecked'
+    })
   } else {
-    const ageHours = (Date.now() - referenceDate.getTime()) / 3_600_000;
+    const ageHours = (Date.now() - referenceDate.getTime()) / 3_600_000
     if (ageHours > maxAgeHours) {
       findings.push({
         severity: 'fail',
         id: `${id}-stale`,
-        message: `${url} is ${ageHours.toFixed(1)}h old (reference: ${referenceDate.toISOString()}), `
-          + `exceeds the ${maxAgeHours}h warn threshold`,
-      });
+        message: `${url} is ${ageHours.toFixed(1)}h old (reference: ${referenceDate.toISOString()}), ` + `exceeds the ${maxAgeHours}h warn threshold`
+      })
     }
   }
 
-  return findings;
+  return findings
 }
 
 async function main() {
-  let exit = 0;
+  let exit = 0
 
-  let llmsTxtBody;
+  let llmsTxtBody
   try {
-    const res = await fetchStable(LLMS_TXT_URL);
+    const res = await fetchStable(LLMS_TXT_URL)
     if (!res.ok) {
       exit = report('validate-llms-txt', [
-        { severity: 'fail', id: 'llms-txt-fetch', message: `HTTP ${res.status} fetching ${LLMS_TXT_URL}` },
-      ]);
+        {severity: 'fail', id: 'llms-txt-fetch', message: `HTTP ${res.status} fetching ${LLMS_TXT_URL}`}
+      ])
     } else {
-      llmsTxtBody = await res.text();
+      llmsTxtBody = await res.text()
     }
   } catch (err) {
     exit = report('validate-llms-txt', [
-      { severity: 'fail', id: 'llms-txt-fetch', message: `fetch failed: ${err.message}` },
-    ]);
+      {severity: 'fail', id: 'llms-txt-fetch', message: `fetch failed: ${err.message}`}
+    ])
   }
 
   if (llmsTxtBody !== undefined) {
-    const findings = validateLlmsTxt(llmsTxtBody);
-    exit = report('validate-llms-txt (llms.txt structure)', findings) || exit;
+    const findings = validateLlmsTxt(llmsTxtBody)
+    exit = report('validate-llms-txt (llms.txt structure)', findings) || exit
   }
 
   // llms-full.txt / index.md: the composer runs on a 30m EventBridge rate +
@@ -219,14 +211,13 @@ async function main() {
   // routes edge-cache the CloudFront upstream for up to an hour
   // (functions/_lib/proxy.ts: cacheTtl 3600 / s-maxage=3600), so a legitimately
   // fresh document can read up to 1h older through the proxy.
-  const fullFindings = await checkPresence('llms-full-txt', LLMS_FULL_URL, 4);
-  const indexMdFindings = await checkPresence('index-md', INDEX_MD_URL, 4);
-  exit = report('validate-llms-txt (llms-full.txt + index.md presence)', [...fullFindings, ...indexMdFindings])
-    || exit;
+  const fullFindings = await checkPresence('llms-full-txt', LLMS_FULL_URL, 4)
+  const indexMdFindings = await checkPresence('index-md', INDEX_MD_URL, 4)
+  exit = report('validate-llms-txt (llms-full.txt + index.md presence)', [...fullFindings, ...indexMdFindings]) || exit
 
-  process.exit(exit);
+  process.exit(exit)
 }
 
 if (isMain(import.meta.url)) {
-  main();
+  main()
 }

--- a/scripts/audit/validate-robots.mjs
+++ b/scripts/audit/validate-robots.mjs
@@ -7,18 +7,18 @@
 // direct text match instead) is present, and diffs the AI-crawler User-agent
 // sections against a committed golden snapshot (drift guard).
 
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import robotsParser from 'robots-parser';
-import { SITE_URL } from '@lifegames/portal-contract/constants';
-import { fetchStable, isMain, report } from './lib/http.mjs';
+import {readFileSync} from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import robotsParser from 'robots-parser'
+import {SITE_URL} from '@lifegames/portal-contract/constants'
+import {fetchStable, isMain, report} from './lib/http.mjs'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const GOLDEN_PATH = path.join(__dirname, '..', '..', 'tests', 'audit', 'golden', 'robots-ai-crawlers.json');
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const GOLDEN_PATH = path.join(__dirname, '..', '..', 'tests', 'audit', 'golden', 'robots-ai-crawlers.json')
 
-const ROBOTS_URL = `${SITE_URL}/robots.txt`;
-const EXPECTED_SITEMAP_URL = `${SITE_URL}/sitemap-index.xml`;
+const ROBOTS_URL = `${SITE_URL}/robots.txt`
+const EXPECTED_SITEMAP_URL = `${SITE_URL}/sitemap-index.xml`
 
 /**
  * Extract the set of `User-agent: <name>` values that appear in a robots.txt
@@ -27,90 +27,91 @@ const EXPECTED_SITEMAP_URL = `${SITE_URL}/sitemap-index.xml`;
  * checks exactly what a human editing the file would see.
  */
 function extractUserAgents(body) {
-  const names = new Set();
+  const names = new Set()
   for (const line of body.split(/\r\n|\r|\n/)) {
-    const m = /^\s*User-agent:\s*(\S+)/i.exec(line);
-    if (m) names.add(m[1]);
+    const m = /^\s*User-agent:\s*(\S+)/i.exec(line)
+    if (m) {
+      names.add(m[1])
+    }
   }
-  return names;
+  return names
 }
 
 /** Pure validation function: (robots.txt body) -> findings[]. Testable without network. */
 export function validateRobots(body, golden) {
-  const findings = [];
+  const findings = []
 
-  const robots = robotsParser(ROBOTS_URL, body);
-  const sitemaps = robots.getSitemaps();
+  const robots = robotsParser(ROBOTS_URL, body)
+  const sitemaps = robots.getSitemaps()
   if (!sitemaps.includes(EXPECTED_SITEMAP_URL)) {
     findings.push({
       severity: 'fail',
       id: 'robots-sitemap-directive',
-      message: `Sitemap: directive ${JSON.stringify(sitemaps)} does not include the served sitemap `
-        + `${EXPECTED_SITEMAP_URL}`,
-    });
+      message: `Sitemap: directive ${JSON.stringify(sitemaps)} does not include the served sitemap ` + `${EXPECTED_SITEMAP_URL}`
+    })
   }
 
   if (!/^Content-Signal:\s*\S/im.test(body)) {
     findings.push({
       severity: 'fail',
       id: 'robots-content-signal-missing',
-      message: 'no "Content-Signal:" directive found (contentsignals.org / IETF draft-romm-aipref-contentsignals)',
-    });
+      message: 'no "Content-Signal:" directive found (contentsignals.org / IETF draft-romm-aipref-contentsignals)'
+    })
   }
 
-  const liveAgents = extractUserAgents(body);
+  const liveAgents = extractUserAgents(body)
   const expectedAgents = [
     ...golden.aiTrainingBotsBlockedExceptLlmsTxt,
-    ...golden.aiSearchAgentsAllowedFullSite,
-  ];
+    ...golden.aiSearchAgentsAllowedFullSite
+  ]
   for (const agent of expectedAgents) {
     if (!liveAgents.has(agent)) {
       findings.push({
         severity: 'fail',
         id: 'robots-ai-crawler-missing',
-        message: `expected "User-agent: ${agent}" section is missing from the live robots.txt `
-          + `(golden snapshot: tests/audit/golden/robots-ai-crawlers.json)`,
-      });
+        message: `expected "User-agent: ${agent}" section is missing from the live robots.txt ` +
+          `(golden snapshot: tests/audit/golden/robots-ai-crawlers.json)`
+      })
     }
   }
-  const expectedSet = new Set(expectedAgents);
+  const expectedSet = new Set(expectedAgents)
   for (const agent of liveAgents) {
     if (!expectedSet.has(agent) && agent !== '*') {
       findings.push({
         severity: 'warn',
         id: 'robots-ai-crawler-new',
-        message: `"User-agent: ${agent}" appears in the live robots.txt but is not in the golden snapshot -- `
-          + 'update tests/audit/golden/robots-ai-crawlers.json to acknowledge the addition',
-      });
+        message: `"User-agent: ${agent}" appears in the live robots.txt but is not in the golden snapshot -- ` +
+          'update tests/audit/golden/robots-ai-crawlers.json to acknowledge the addition'
+      })
     }
   }
 
-  return findings;
+  return findings
 }
 
 async function main() {
-  let body;
+  let body
   try {
-    const res = await fetchStable(ROBOTS_URL);
+    const res = await fetchStable(ROBOTS_URL)
     if (!res.ok) {
       process.exit(report('validate-robots', [
-        { severity: 'fail', id: 'robots-fetch', message: `HTTP ${res.status} fetching ${ROBOTS_URL}` },
-      ]));
-      return;
+        {severity: 'fail', id: 'robots-fetch', message: `HTTP ${res.status} fetching ${ROBOTS_URL}`}
+      ]))
+      return
     }
-    body = await res.text();
+    body = await res.text()
   } catch (err) {
     process.exit(report('validate-robots', [
-      { severity: 'fail', id: 'robots-fetch', message: `fetch failed: ${err.message}` },
-    ]));
-    return;
+      {severity: 'fail', id: 'robots-fetch', message: `fetch failed: ${err.message}`}
+    ]))
+    return
   }
 
-  const golden = JSON.parse(readFileSync(GOLDEN_PATH, 'utf-8'));
-  const findings = validateRobots(body, golden);
-  process.exit(report('validate-robots', findings));
+  const golden = JSON.parse(readFileSync(GOLDEN_PATH, 'utf-8'))
+  const findings = validateRobots(body, golden)
+  process.exit(report('validate-robots', findings))
 }
 
 if (isMain(import.meta.url)) {
-  main();
+  main()
 }

--- a/scripts/audit/validate-sitemap.mjs
+++ b/scripts/audit/validate-sitemap.mjs
@@ -9,148 +9,124 @@
 // (sitemap-index.xml) pointing at one or more urlset files (sitemap-0.xml, ...)
 // -- verified against this repo's own `dist/` build output, 2026-07-16.
 
-import { execFileSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { SITE_URL } from '@lifegames/portal-contract/constants';
-import { fetchStable, headStable, isMain, report } from './lib/http.mjs';
+import {execFileSync} from 'node:child_process'
+import {mkdtempSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {SITE_URL} from '@lifegames/portal-contract/constants'
+import {fetchStable, headStable, isMain, report} from './lib/http.mjs'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const VENDOR_DIR = path.join(__dirname, 'vendor');
-const SITEINDEX_XSD = path.join(VENDOR_DIR, 'siteindex-0.9.xsd');
-const URLSET_XSD = path.join(VENDOR_DIR, 'sitemap-0.9.xsd');
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const VENDOR_DIR = path.join(__dirname, 'vendor')
+const SITEINDEX_XSD = path.join(VENDOR_DIR, 'siteindex-0.9.xsd')
+const URLSET_XSD = path.join(VENDOR_DIR, 'sitemap-0.9.xsd')
 
-const SITEMAP_INDEX_URL = `${SITE_URL}/sitemap-index.xml`;
-const SITE_ORIGIN = new URL(SITE_URL).origin;
+const SITEMAP_INDEX_URL = `${SITE_URL}/sitemap-index.xml`
+const SITE_ORIGIN = new URL(SITE_URL).origin
 
 /** Extract <loc>...</loc> text content via regex -- deliberately not a full XML
  * parser dependency for a single flat, non-nested tag (matches the "prefer
  * vendoring tiny validators" guidance for this catalog). Exported: pure, testable. */
 export function extractLocs(xml) {
-  const locs = [];
-  const re = /<loc>([^<]+)<\/loc>/g;
-  let m;
+  const locs = []
+  const re = /<loc>([^<]+)<\/loc>/g
+  let m
   while ((m = re.exec(xml)) !== null) {
-    locs.push(m[1].trim());
+    locs.push(m[1].trim())
   }
-  return locs;
+  return locs
 }
 
 /** Run `xmllint --noout --schema <xsd> <file>`; returns a finding array (empty = valid). Exported: testable with local fixtures, no network. */
 export function validateAgainstXsd(id, xmlPath, xsdPath, sourceUrl) {
   try {
-    execFileSync('xmllint', ['--noout', '--schema', xsdPath, xmlPath], { stdio: 'pipe' });
-    return [];
+    execFileSync('xmllint', ['--noout', '--schema', xsdPath, xmlPath], {stdio: 'pipe'})
+    return []
   } catch (err) {
-    const stderr = err.stderr ? err.stderr.toString() : err.message;
-    return [{
-      severity: 'fail',
-      id,
-      message: `${sourceUrl} failed XSD validation against ${path.basename(xsdPath)}:\n${stderr.trim()}`,
-    }];
+    const stderr = err.stderr ? err.stderr.toString() : err.message
+    return [{severity: 'fail', id, message: `${sourceUrl} failed XSD validation against ${path.basename(xsdPath)}:\n${stderr.trim()}`}]
   }
 }
 
 async function main() {
-  const findings = [];
-  const tmpDir = mkdtempSync(path.join(tmpdir(), 'audit-sitemap-'));
+  const findings = []
+  const tmpDir = mkdtempSync(path.join(tmpdir(), 'audit-sitemap-'))
 
-  let indexRes;
+  let indexRes
   try {
-    indexRes = await fetchStable(SITEMAP_INDEX_URL);
+    indexRes = await fetchStable(SITEMAP_INDEX_URL)
   } catch (err) {
     process.exit(report('validate-sitemap', [
-      { severity: 'fail', id: 'sitemap-index-fetch', message: `fetch failed: ${err.message}` },
-    ]));
-    return;
+      {severity: 'fail', id: 'sitemap-index-fetch', message: `fetch failed: ${err.message}`}
+    ]))
+    return
   }
   if (!indexRes.ok) {
     process.exit(report('validate-sitemap', [
-      { severity: 'fail', id: 'sitemap-index-fetch', message: `HTTP ${indexRes.status} fetching ${SITEMAP_INDEX_URL}` },
-    ]));
-    return;
+      {severity: 'fail', id: 'sitemap-index-fetch', message: `HTTP ${indexRes.status} fetching ${SITEMAP_INDEX_URL}`}
+    ]))
+    return
   }
-  const indexXml = await indexRes.text();
-  const indexPath = path.join(tmpDir, 'sitemap-index.xml');
-  writeFileSync(indexPath, indexXml);
-  findings.push(...validateAgainstXsd('sitemap-index-xsd', indexPath, SITEINDEX_XSD, SITEMAP_INDEX_URL));
+  const indexXml = await indexRes.text()
+  const indexPath = path.join(tmpDir, 'sitemap-index.xml')
+  writeFileSync(indexPath, indexXml)
+  findings.push(...validateAgainstXsd('sitemap-index-xsd', indexPath, SITEINDEX_XSD, SITEMAP_INDEX_URL))
 
-  const childSitemapUrls = extractLocs(indexXml);
+  const childSitemapUrls = extractLocs(indexXml)
   if (childSitemapUrls.length === 0) {
-    findings.push({
-      severity: 'fail',
-      id: 'sitemap-index-empty',
-      message: `${SITEMAP_INDEX_URL} contains no <sitemap><loc> entries`,
-    });
+    findings.push({severity: 'fail', id: 'sitemap-index-empty', message: `${SITEMAP_INDEX_URL} contains no <sitemap><loc> entries`})
   }
 
   // Validate every child urlset file against the sitemap.xsd, and collect
   // every page <loc> across all of them for the same-origin + 200 sweep.
-  const allPageLocs = [];
+  const allPageLocs = []
   for (const [idx, childUrl] of childSitemapUrls.entries()) {
-    let childRes;
+    let childRes
     try {
-      childRes = await fetchStable(childUrl);
+      childRes = await fetchStable(childUrl)
     } catch (err) {
-      findings.push({
-        severity: 'fail',
-        id: 'sitemap-child-fetch',
-        message: `${childUrl}: fetch failed: ${err.message}`,
-      });
-      continue;
+      findings.push({severity: 'fail', id: 'sitemap-child-fetch', message: `${childUrl}: fetch failed: ${err.message}`})
+      continue
     }
     if (!childRes.ok) {
-      findings.push({ severity: 'fail', id: 'sitemap-child-fetch', message: `${childUrl}: HTTP ${childRes.status}` });
-      continue;
+      findings.push({severity: 'fail', id: 'sitemap-child-fetch', message: `${childUrl}: HTTP ${childRes.status}`})
+      continue
     }
-    const childXml = await childRes.text();
-    const childPath = path.join(tmpDir, `sitemap-child-${idx}.xml`);
-    writeFileSync(childPath, childXml);
-    findings.push(...validateAgainstXsd('sitemap-child-xsd', childPath, URLSET_XSD, childUrl));
-    allPageLocs.push(...extractLocs(childXml));
+    const childXml = await childRes.text()
+    const childPath = path.join(tmpDir, `sitemap-child-${idx}.xml`)
+    writeFileSync(childPath, childXml)
+    findings.push(...validateAgainstXsd('sitemap-child-xsd', childPath, URLSET_XSD, childUrl))
+    allPageLocs.push(...extractLocs(childXml))
   }
 
   if (allPageLocs.length === 0 && childSitemapUrls.length > 0) {
-    findings.push({
-      severity: 'fail',
-      id: 'sitemap-no-urls',
-      message: 'no <url><loc> entries found across any child sitemap',
-    });
+    findings.push({severity: 'fail', id: 'sitemap-no-urls', message: 'no <url><loc> entries found across any child sitemap'})
   }
 
   // Same-origin + reachability sweep. Sequential (not Promise.all) to avoid
   // hammering the live origin with a burst of concurrent HEAD requests.
   for (const loc of allPageLocs) {
-    let originOk = false;
+    let originOk
     try {
-      originOk = new URL(loc).origin === SITE_ORIGIN;
+      originOk = new URL(loc).origin === SITE_ORIGIN
     } catch {
-      findings.push({ severity: 'fail', id: 'sitemap-loc-invalid-url', message: `not a valid absolute URL: ${loc}` });
-      continue;
+      findings.push({severity: 'fail', id: 'sitemap-loc-invalid-url', message: `not a valid absolute URL: ${loc}`})
+      continue
     }
     if (!originOk) {
-      findings.push({
-        severity: 'fail',
-        id: 'sitemap-loc-cross-origin',
-        message: `<loc> is not same-origin as ${SITE_ORIGIN}: ${loc}`,
-      });
-      continue;
+      findings.push({severity: 'fail', id: 'sitemap-loc-cross-origin', message: `<loc> is not same-origin as ${SITE_ORIGIN}: ${loc}`})
+      continue
     }
-    const head = await headStable(loc);
+    const head = await headStable(loc)
     if (!head.ok) {
-      findings.push({
-        severity: 'fail',
-        id: 'sitemap-loc-unreachable',
-        message: `${loc} returned HTTP ${head.status} on HEAD`,
-      });
+      findings.push({severity: 'fail', id: 'sitemap-loc-unreachable', message: `${loc} returned HTTP ${head.status} on HEAD`})
     }
   }
 
-  process.exit(report('validate-sitemap', findings));
+  process.exit(report('validate-sitemap', findings))
 }
 
 if (isMain(import.meta.url)) {
-  main();
+  main()
 }

--- a/scripts/check-contract-lock.mjs
+++ b/scripts/check-contract-lock.mjs
@@ -17,111 +17,117 @@
 //
 // The generator (generate-contract-lock.mjs) is intentionally left unchanged
 // (Plan #11 Constraint #3 / Out-of-Scope).
-import { createHash } from 'node:crypto';
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import {createHash} from 'node:crypto'
+import {existsSync, readdirSync, readFileSync} from 'node:fs'
+import {dirname, join} from 'node:path'
+import {fileURLToPath} from 'node:url'
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = join(__dirname, '..');
-const LOCK_FILE = join(REPO_ROOT, '.contract-lock.json');
-const SCHEMAS_PKG = join(REPO_ROOT, '.yalc', '@lifegames', 'schemas');
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '..')
+const LOCK_FILE = join(REPO_ROOT, '.contract-lock.json')
+const SCHEMAS_PKG = join(REPO_ROOT, '.yalc', '@lifegames', 'schemas')
 // Raw export schemas moved to the backend-owned @lifegames/portal-contract package.
-const PORTAL_CONTRACT_PKG = join(REPO_ROOT, '.yalc', '@lifegames', 'portal-contract');
+const PORTAL_CONTRACT_PKG = join(REPO_ROOT, '.yalc', '@lifegames', 'portal-contract')
 
 // Fields the generator writes non-deterministically -- excluded from the diff.
-const VOLATILE = new Set(['generatedAt', 'generatedFrom.sha']);
+const VOLATILE = new Set(['generatedAt', 'generatedFrom.sha'])
 
 function sha256(content) {
-  return createHash('sha256').update(content, 'utf-8').digest('hex');
+  return createHash('sha256').update(content, 'utf-8').digest('hex')
 }
 
 function fail(lines) {
-  console.error('');
-  console.error('ERROR: .contract-lock.json drift detected.');
-  for (const l of lines) console.error('  ' + l);
-  console.error('');
-  console.error('  Hand-edits to this file are forbidden.');
-  console.error('  To fix: node scripts/generate-contract-lock.mjs && git add .contract-lock.json');
-  console.error('');
-  process.exit(1);
+  console.error('')
+  console.error('ERROR: .contract-lock.json drift detected.')
+  for (const l of lines) {
+    console.error('  ' + l)
+  }
+  console.error('')
+  console.error('  Hand-edits to this file are forbidden.')
+  console.error('  To fix: node scripts/generate-contract-lock.mjs && git add .contract-lock.json')
+  console.error('')
+  process.exit(1)
 }
 
 if (!existsSync(LOCK_FILE)) {
-  fail(['.contract-lock.json is missing.']);
+  fail(['.contract-lock.json is missing.'])
 }
 if (!existsSync(SCHEMAS_PKG)) {
   // Cannot recompute -- environment problem, not a hand-edit. Surface clearly.
-  console.error('[check-contract-lock] ERROR: .yalc/@lifegames/schemas not found.');
-  console.error('  Run `pnpm yalc:publish` from design-system-Lifegames first (or `bash scripts/ci-setup.sh` in CI).');
-  process.exit(1);
+  console.error('[check-contract-lock] ERROR: .yalc/@lifegames/schemas not found.')
+  console.error('  Run `pnpm yalc:publish` from design-system-Lifegames first (or `bash scripts/ci-setup.sh` in CI).')
+  process.exit(1)
 }
 
 // --- Recompute the expected lock exactly as generate-contract-lock.mjs does ---
 const filePatterns = [
-  { dir: join(PORTAL_CONTRACT_PKG, 'raw-schemas'), prefix: 'raw-schemas', filter: (f) => f.endsWith('.schema.json') },
-  { dir: join(SCHEMAS_PKG, 'authored'), prefix: 'authored', filter: (f) => f.endsWith('.schema.json') },
-  { dir: join(SCHEMAS_PKG, 'generated'), prefix: 'generated', filter: (f) => f.endsWith('.schema.json') },
-];
+  {dir: join(PORTAL_CONTRACT_PKG, 'raw-schemas'), prefix: 'raw-schemas', filter: (f) => f.endsWith('.schema.json')},
+  {dir: join(SCHEMAS_PKG, 'authored'), prefix: 'authored', filter: (f) => f.endsWith('.schema.json')},
+  {dir: join(SCHEMAS_PKG, 'generated'), prefix: 'generated', filter: (f) => f.endsWith('.schema.json')}
+]
 
-const expectedFiles = {};
-const allContents = [];
-for (const { dir, prefix, filter } of filePatterns) {
-  if (!existsSync(dir)) continue;
-  const files = readdirSync(dir).filter(filter).sort();
+const expectedFiles = {}
+const allContents = []
+for (const {dir, prefix, filter} of filePatterns) {
+  if (!existsSync(dir)) {
+    continue
+  }
+  const files = readdirSync(dir).filter(filter).sort()
   for (const file of files) {
-    const relPath = `${prefix}/${file}`;
-    const content = readFileSync(join(dir, file), 'utf-8');
-    expectedFiles[relPath] = `sha256:${sha256(content)}`;
-    allContents.push(content);
+    const relPath = `${prefix}/${file}`
+    const content = readFileSync(join(dir, file), 'utf-8')
+    expectedFiles[relPath] = `sha256:${sha256(content)}`
+    allContents.push(content)
   }
 }
-const expectedAggregate = `sha256:${sha256(allContents.join(''))}`;
+const expectedAggregate = `sha256:${sha256(allContents.join(''))}`
 
 // The deterministic, hand-edit-relevant shape of the lock.
 const expected = {
   'generatedFrom.repo': 'j0nathan-ll0yd/design-system-Lifegames',
   'generatedFrom.checksum': expectedAggregate,
   generatorVersion: '1.0.0',
-  files: expectedFiles,
-};
+  files: expectedFiles
+}
 
 // --- Read the committed lock and project it into the same shape ---
-const lock = JSON.parse(readFileSync(LOCK_FILE, 'utf-8'));
+const lock = JSON.parse(readFileSync(LOCK_FILE, 'utf-8'))
 const actual = {
   'generatedFrom.repo': lock.generatedFrom?.repo,
   'generatedFrom.checksum': lock.generatedFrom?.checksum,
   generatorVersion: lock.generatorVersion,
-  files: lock.files ?? {},
-};
+  files: lock.files ?? {}
+}
 
-const drift = [];
+const drift = []
 
 // Scalar fields (skip volatile ones).
 for (const key of ['generatedFrom.repo', 'generatedFrom.checksum', 'generatorVersion']) {
-  if (VOLATILE.has(key)) continue;
+  if (VOLATILE.has(key)) {
+    continue
+  }
   if (actual[key] !== expected[key]) {
-    drift.push(`${key}: lock "${actual[key]}" != expected "${expected[key]}"`);
+    drift.push(`${key}: lock "${actual[key]}" != expected "${expected[key]}"`)
   }
 }
 
 // Per-file checksums.
 for (const [file, exp] of Object.entries(expected.files)) {
-  const act = actual.files[file];
+  const act = actual.files[file]
   if (act === undefined) {
-    drift.push(`REMOVED: ${file} present on disk but absent from lock`);
+    drift.push(`REMOVED: ${file} present on disk but absent from lock`)
   } else if (act !== exp) {
-    drift.push(`CHANGED: ${file} (lock ${act} != expected ${exp})`);
+    drift.push(`CHANGED: ${file} (lock ${act} != expected ${exp})`)
   }
 }
 for (const file of Object.keys(actual.files)) {
   if (expected.files[file] === undefined) {
-    drift.push(`EXTRA: ${file} present in lock but absent on disk`);
+    drift.push(`EXTRA: ${file} present in lock but absent on disk`)
   }
 }
 
 if (drift.length > 0) {
-  fail(['Lock does not match the regenerated contract:', ...drift]);
+  fail(['Lock does not match the regenerated contract:', ...drift])
 }
 
-console.log('[check-contract-lock] OK: .contract-lock.json matches the current schemas.');
+console.log('[check-contract-lock] OK: .contract-lock.json matches the current schemas.')

--- a/scripts/check-live-data-bundle.mjs
+++ b/scripts/check-live-data-bundle.mjs
@@ -18,71 +18,71 @@
 // robust to chunking changes (e.g. when an updater grows past the inline
 // threshold) while still catching genuine tree-shaking (the token vanishing from
 // the whole reachable graph).
-import { readdirSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import {readdirSync, readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
 
-const astroDir = resolve(process.cwd(), 'dist', '_astro');
-const BUNDLE_RE = /^index\.astro_astro_type_script_index_\d+_lang\.[A-Za-z0-9_-]+\.js$/;
-const REQUIRED = ['cardTheatreReviews', 'systemStatus', 'theatreReviews'];
+const astroDir = resolve(process.cwd(), 'dist', '_astro')
+const BUNDLE_RE = /^index\.astro_astro_type_script_index_\d+_lang\.[A-Za-z0-9_-]+\.js$/
+const REQUIRED = ['cardTheatreReviews', 'systemStatus', 'theatreReviews']
 // Matches a relative chunk reference (`"./updaters.fDuJCGys.js"`) in minified output,
 // whether via static import, dynamic import, or re-export.
-const CHUNK_REF_RE = /\.\/([A-Za-z0-9_.-]+\.js)/g;
+const CHUNK_REF_RE = /\.\/([A-Za-z0-9_.-]+\.js)/g
 
-let files;
+let files
 try {
-  files = readdirSync(astroDir);
+  files = readdirSync(astroDir)
 } catch (err) {
-  console.error('[check-live-data-bundle] Could not read', astroDir, ':', err.message);
-  process.exit(1);
+  console.error('[check-live-data-bundle] Could not read', astroDir, ':', err.message)
+  process.exit(1)
 }
 
-const fileSet = new Set(files);
-const entryBundles = files.filter((f) => BUNDLE_RE.test(f));
+const fileSet = new Set(files)
+const entryBundles = files.filter((f) => BUNDLE_RE.test(f))
 if (entryBundles.length === 0) {
-  console.error('[check-live-data-bundle] No index.astro module bundles found in', astroDir);
-  process.exit(1);
+  console.error('[check-live-data-bundle] No index.astro module bundles found in', astroDir)
+  process.exit(1)
 }
 
 // Transitively collect every chunk reachable from the entry bundle(s).
-const reachable = new Set();
-const queue = [...entryBundles];
+const reachable = new Set()
+const queue = [...entryBundles]
 while (queue.length > 0) {
-  const file = queue.pop();
-  if (reachable.has(file) || !fileSet.has(file)) continue;
-  reachable.add(file);
-  const content = readFileSync(resolve(astroDir, file), 'utf-8');
+  const file = queue.pop()
+  if (reachable.has(file) || !fileSet.has(file)) {
+    continue
+  }
+  reachable.add(file)
+  const content = readFileSync(resolve(astroDir, file), 'utf-8')
   for (const m of content.matchAll(CHUNK_REF_RE)) {
-    if (!reachable.has(m[1])) queue.push(m[1]);
+    if (!reachable.has(m[1])) {
+      queue.push(m[1])
+    }
   }
 }
 
-const found = Object.fromEntries(REQUIRED.map((t) => [t, null]));
+const found = Object.fromEntries(REQUIRED.map((t) => [t, null]))
 for (const file of reachable) {
-  const content = readFileSync(resolve(astroDir, file), 'utf-8');
+  const content = readFileSync(resolve(astroDir, file), 'utf-8')
   for (const token of REQUIRED) {
-    if (found[token] === null && content.includes(token)) found[token] = file;
+    if (found[token] === null && content.includes(token)) {
+      found[token] = file
+    }
   }
 }
 
-const missing = REQUIRED.filter((t) => found[t] === null);
+const missing = REQUIRED.filter((t) => found[t] === null)
 if (missing.length > 0) {
-  console.error('[check-live-data-bundle] Live-data bundle missing required identifiers:');
-  for (const t of missing) console.error('  -', t);
-  console.error('');
-  console.error('Likely cause: src/lib/runtime/live-data was tree-shaken or is no longer imported.');
-  console.error("Verify src/pages/index.astro still has `import '../lib/runtime/live-data'` and");
-  console.error('that the module retains its top-level side effects (skeleton removal, polling, WS).');
-  console.error('Inspected', reachable.size, 'reachable chunk(s) from:', entryBundles.join(', '));
-  process.exit(1);
+  console.error('[check-live-data-bundle] Live-data bundle missing required identifiers:')
+  for (const t of missing) {
+    console.error('  -', t)
+  }
+  console.error('')
+  console.error('Likely cause: src/lib/runtime/live-data was tree-shaken or is no longer imported.')
+  console.error("Verify src/pages/index.astro still has `import '../lib/runtime/live-data'` and")
+  console.error('that the module retains its top-level side effects (skeleton removal, polling, WS).')
+  console.error('Inspected', reachable.size, 'reachable chunk(s) from:', entryBundles.join(', '))
+  process.exit(1)
 }
 
-const uniqueFiles = new Set(Object.values(found));
-console.log(
-  '[check-live-data-bundle] OK —',
-  REQUIRED.length,
-  'identifiers present across',
-  uniqueFiles.size,
-  'chunk(s), from',
-  reachable.size,
-  'reachable.',
-);
+const uniqueFiles = new Set(Object.values(found))
+console.log('[check-live-data-bundle] OK —', REQUIRED.length, 'identifiers present across', uniqueFiles.size, 'chunk(s), from', reachable.size, 'reachable.')

--- a/scripts/check-sa-proxy-path.mjs
+++ b/scripts/check-sa-proxy-path.mjs
@@ -22,110 +22,92 @@
  *
  * Wired into package.json prebuild via `audit:sa-path`.
  */
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
 
-var __dirname = path.dirname(fileURLToPath(import.meta.url));
-var repoRoot = path.resolve(__dirname, '..');
+var __dirname = path.dirname(fileURLToPath(import.meta.url))
+var repoRoot = path.resolve(__dirname, '..')
 
 // 1. Derive the route prefix from the filesystem by discovering the catch-all
 // collection Function: functions/<dir>/[[path]].ts → routePrefix = /<dir>.
 // Discovered (not hardcoded) so a rename of the route directory is caught.
-var functionsDir = path.join(repoRoot, 'functions');
-var catchAllDirs = fs
-  .readdirSync(functionsDir, { withFileTypes: true })
-  .filter(
-    (d) => d.isDirectory() && fs.existsSync(path.join(functionsDir, d.name, '[[path]].ts')),
-  )
-  .map((d) => d.name);
+var functionsDir = path.join(repoRoot, 'functions')
+var catchAllDirs = fs.readdirSync(functionsDir, {withFileTypes: true}).filter((d) =>
+  d.isDirectory() && fs.existsSync(path.join(functionsDir, d.name, '[[path]].ts'))
+).map((d) => d.name)
 
 if (catchAllDirs.length !== 1) {
   console.error(
-    '✗ check-sa-proxy-path: expected exactly ONE catch-all collection Function '
-      + 'at functions/<dir>/[[path]].ts, found '
-      + catchAllDirs.length
-      + ' ['
-      + catchAllDirs.join(', ')
-      + '].',
-  );
-  console.error(
-    '  This assertion derives the SA collection route from that directory; '
-      + 'disambiguate before building.',
-  );
-  process.exit(1);
+    '✗ check-sa-proxy-path: expected exactly ONE catch-all collection Function ' +
+      'at functions/<dir>/[[path]].ts, found ' +
+      catchAllDirs.length +
+      ' [' +
+      catchAllDirs.join(', ') +
+      '].'
+  )
+  console.error('  This assertion derives the SA collection route from that directory; ' + 'disambiguate before building.')
+  process.exit(1)
 }
-var routePrefix = '/' + catchAllDirs[0];
+var routePrefix = '/' + catchAllDirs[0]
 
 // 2. Extract SA_COLLECTION_PATH from functions/sa.ts (read as text — no TS import)
-var saFunctionPath = path.join(repoRoot, 'functions', 'sa.ts');
+var saFunctionPath = path.join(repoRoot, 'functions', 'sa.ts')
 if (!fs.existsSync(saFunctionPath)) {
-  console.error('✗ check-sa-proxy-path: functions/sa.ts not found.');
-  process.exit(1);
+  console.error('✗ check-sa-proxy-path: functions/sa.ts not found.')
+  process.exit(1)
 }
 
-var saSource = fs.readFileSync(saFunctionPath, 'utf-8');
+var saSource = fs.readFileSync(saFunctionPath, 'utf-8')
 
 // Match: export const SA_COLLECTION_PATH = '/simple';
-var match = saSource.match(/export\s+const\s+SA_COLLECTION_PATH\s*=\s*['"]([^'"]+)['"]/);
+var match = saSource.match(/export\s+const\s+SA_COLLECTION_PATH\s*=\s*['"]([^'"]+)['"]/)
 if (!match) {
-  console.error('✗ check-sa-proxy-path: SA_COLLECTION_PATH not found in functions/sa.ts.');
-  console.error("  Add: export const SA_COLLECTION_PATH = '/simple';");
-  process.exit(1);
+  console.error('✗ check-sa-proxy-path: SA_COLLECTION_PATH not found in functions/sa.ts.')
+  console.error("  Add: export const SA_COLLECTION_PATH = '/simple';")
+  process.exit(1)
 }
-var collectionPath = match[1];
+var collectionPath = match[1]
 
 // 3. Also verify the path= query param in the proxy script URL matches.
 // Match only inside a quoted string literal (opening quote before the URL, closing
 // quote at end) so the comment-line occurrence of the URL is ignored.
-var urlMatch = saSource.match(/['"`]https:\/\/simpleanalyticsexternal\.com\/proxy\.js\?[^'"`]*path=([^&'"`\n]+)/);
+var urlMatch = saSource.match(/['"`]https:\/\/simpleanalyticsexternal\.com\/proxy\.js\?[^'"`]*path=([^&'"`\n]+)/)
 if (!urlMatch) {
-  console.error('✗ check-sa-proxy-path: proxy.js URL with path= param not found in functions/sa.ts.');
-  process.exit(1);
+  console.error('✗ check-sa-proxy-path: proxy.js URL with path= param not found in functions/sa.ts.')
+  process.exit(1)
 }
-var queryPath = '/' + urlMatch[1].replace(/^\//, '');
+var queryPath = '/' + urlMatch[1].replace(/^\//, '')
 
 // 4. Assert all three agree
-var ok = true;
+var ok = true
 
 if (collectionPath !== routePrefix) {
+  console.error('✗ check-sa-proxy-path: MISMATCH — SA_COLLECTION_PATH (' + collectionPath + ') !== route prefix (' + routePrefix + ').')
+  console.error('  SA beacons will be sent to ' + collectionPath + ' but the Function handles ' + routePrefix + '.')
   console.error(
-    '✗ check-sa-proxy-path: MISMATCH — SA_COLLECTION_PATH (' + collectionPath
-      + ') !== route prefix (' + routePrefix + ').',
-  );
-  console.error('  SA beacons will be sent to ' + collectionPath + ' but the Function handles ' + routePrefix + '.');
-  console.error(
-    '  Fix: rename functions/' + collectionPath.replace(/^\//, '')
-      + ' OR update SA_COLLECTION_PATH + the proxy.js path= param in functions/sa.ts.',
-  );
-  ok = false;
+    '  Fix: rename functions/' + collectionPath.replace(/^\//, '') + ' OR update SA_COLLECTION_PATH + the proxy.js path= param in functions/sa.ts.'
+  )
+  ok = false
 }
 
 if (queryPath !== routePrefix) {
-  console.error(
-    '✗ check-sa-proxy-path: MISMATCH — proxy.js path= param (' + queryPath
-      + ') !== route prefix (' + routePrefix + ').',
-  );
-  console.error(
-    '  The SA script will bake ' + queryPath + ' as the collection path but the Function handles ' + routePrefix + '.',
-  );
-  ok = false;
+  console.error('✗ check-sa-proxy-path: MISMATCH — proxy.js path= param (' + queryPath + ') !== route prefix (' + routePrefix + ').')
+  console.error('  The SA script will bake ' + queryPath + ' as the collection path but the Function handles ' + routePrefix + '.')
+  ok = false
 }
 
 if (collectionPath !== queryPath) {
-  console.error(
-    '✗ check-sa-proxy-path: MISMATCH — SA_COLLECTION_PATH (' + collectionPath
-      + ') !== proxy.js path= param (' + queryPath + ').',
-  );
-  console.error('  Keep SA_COLLECTION_PATH and the proxy.js URL path= param in sync.');
-  ok = false;
+  console.error('✗ check-sa-proxy-path: MISMATCH — SA_COLLECTION_PATH (' + collectionPath + ') !== proxy.js path= param (' + queryPath + ').')
+  console.error('  Keep SA_COLLECTION_PATH and the proxy.js URL path= param in sync.')
+  ok = false
 }
 
 if (!ok) {
-  process.exit(1);
+  process.exit(1)
 }
 
-console.log('check-sa-proxy-path: path invariant verified ✓');
-console.log('  SA_COLLECTION_PATH = ' + collectionPath);
-console.log('  proxy.js path=     = ' + queryPath);
-console.log('  route prefix       = ' + routePrefix);
+console.log('check-sa-proxy-path: path invariant verified ✓')
+console.log('  SA_COLLECTION_PATH = ' + collectionPath)
+console.log('  proxy.js path=     = ' + queryPath)
+console.log('  route prefix       = ' + routePrefix)

--- a/scripts/fetch-images.mjs
+++ b/scripts/fetch-images.mjs
@@ -10,44 +10,46 @@
  * No npm dependencies required (uses Node built-ins).
  */
 
-import { mkdir, access, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { CLOUDFRONT_BASE } from '@lifegames/portal-contract/constants';
+import {access, mkdir, writeFile} from 'node:fs/promises'
+import {dirname, join} from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {CLOUDFRONT_BASE} from '@lifegames/portal-contract/constants'
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const PUBLIC_DIR = join(__dirname, '..', 'public');
-const CONCURRENCY = 5;
-const CHECK_ONLY = process.argv.includes('--check-only');
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PUBLIC_DIR = join(__dirname, '..', 'public')
+const CONCURRENCY = 5
+const CHECK_ONLY = process.argv.includes('--check-only')
 
 async function fetchJson(endpoint) {
-  const res = await fetch(`${CLOUDFRONT_BASE}/${endpoint}`);
-  if (!res.ok) throw new Error(`Failed to fetch ${endpoint}: ${res.status}`);
-  return res.json();
+  const res = await fetch(`${CLOUDFRONT_BASE}/${endpoint}`)
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${endpoint}: ${res.status}`)
+  }
+  return res.json()
 }
 
 function extractImageUrls(booksData, theatreData) {
-  const urls = [];
+  const urls = []
 
   if (booksData?.books) {
     for (const book of booksData.books) {
       if (book.mainImage?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
-        urls.push(book.mainImage);
+        urls.push(book.mainImage)
       }
       if (book.mainImageAvif?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
-        urls.push(book.mainImageAvif);
+        urls.push(book.mainImageAvif)
       }
       if (book.mainImageThumb?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
-        urls.push(book.mainImageThumb);
+        urls.push(book.mainImageThumb)
       }
       if (book.mainImageThumbAvif?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
-        urls.push(book.mainImageThumbAvif);
+        urls.push(book.mainImageThumbAvif)
       }
       if (book.mainImageCard?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
-        urls.push(book.mainImageCard);
+        urls.push(book.mainImageCard)
       }
       if (book.mainImageCardAvif?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
-        urls.push(book.mainImageCardAvif);
+        urls.push(book.mainImageCardAvif)
       }
     }
   }
@@ -55,124 +57,128 @@ function extractImageUrls(booksData, theatreData) {
   if (theatreData?.reviews) {
     for (const review of theatreData.reviews) {
       if (review.imageUrl?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
-        urls.push(review.imageUrl);
+        urls.push(review.imageUrl)
       }
       if (review.imageUrlAvif?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
-        urls.push(review.imageUrlAvif);
+        urls.push(review.imageUrlAvif)
       }
       if (review.imageUrlCard?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
-        urls.push(review.imageUrlCard);
+        urls.push(review.imageUrlCard)
       }
       if (review.imageUrlCardAvif?.startsWith(`${CLOUDFRONT_BASE}/images/`)) {
-        urls.push(review.imageUrlCardAvif);
+        urls.push(review.imageUrlCardAvif)
       }
     }
   }
 
-  return [...new Set(urls)];
+  return [...new Set(urls)]
 }
 
 function urlToLocalPath(url) {
-  const path = url.slice(CLOUDFRONT_BASE.length);
-  return join(PUBLIC_DIR, path);
+  const path = url.slice(CLOUDFRONT_BASE.length)
+  return join(PUBLIC_DIR, path)
 }
 
 async function fileExists(path) {
   try {
-    await access(path);
-    return true;
+    await access(path)
+    return true
   } catch {
-    return false;
+    return false
   }
 }
 
 async function downloadImage(url) {
-  const localPath = urlToLocalPath(url);
+  const localPath = urlToLocalPath(url)
 
   if (await fileExists(localPath)) {
-    return 'skipped';
+    return 'skipped'
   }
 
   if (CHECK_ONLY) {
-    return 'missing';
+    return 'missing'
   }
 
-  await mkdir(dirname(localPath), { recursive: true });
+  await mkdir(dirname(localPath), {recursive: true})
 
-  const res = await fetch(url);
+  const res = await fetch(url)
   if (!res.ok) {
-    console.error(`  ✗ ${url} (${res.status})`);
-    return 'failed';
+    console.error(`  ✗ ${url} (${res.status})`)
+    return 'failed'
   }
 
-  const buffer = Buffer.from(await res.arrayBuffer());
-  await writeFile(localPath, buffer);
-  return 'downloaded';
+  const buffer = Buffer.from(await res.arrayBuffer())
+  await writeFile(localPath, buffer)
+  return 'downloaded'
 }
 
 async function runWithConcurrency(items, fn, limit) {
-  const results = [];
-  let index = 0;
+  const results = []
+  let index = 0
 
   async function worker() {
     while (index < items.length) {
-      const i = index++;
-      results[i] = await fn(items[i]);
+      const i = index++
+      results[i] = await fn(items[i])
     }
   }
 
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
-  return results;
+  await Promise.all(Array.from({length: Math.min(limit, items.length)}, worker))
+  return results
 }
 
 async function main() {
-  console.log('Fetching image manifests from CloudFront...');
+  console.log('Fetching image manifests from CloudFront...')
 
   const [booksData, theatreData] = await Promise.allSettled([
     fetchJson('books.json'),
-    fetchJson('theatre-reviews.json'),
-  ]);
+    fetchJson('theatre-reviews.json')
+  ])
 
-  const books = booksData.status === 'fulfilled' ? booksData.value : null;
-  const theatre = theatreData.status === 'fulfilled' ? theatreData.value : null;
+  const books = booksData.status === 'fulfilled' ? booksData.value : null
+  const theatre = theatreData.status === 'fulfilled' ? theatreData.value : null
 
   if (!books && !theatre) {
-    console.log('No JSON data available. Skipping image check.');
-    return;
+    console.log('No JSON data available. Skipping image check.')
+    return
   }
 
-  const urls = extractImageUrls(books, theatre);
-  console.log(`Found ${urls.length} images in CloudFront manifests.`);
+  const urls = extractImageUrls(books, theatre)
+  console.log(`Found ${urls.length} images in CloudFront manifests.`)
 
-  if (urls.length === 0) return;
+  if (urls.length === 0) {
+    return
+  }
 
-  const results = await runWithConcurrency(urls, downloadImage, CONCURRENCY);
+  const results = await runWithConcurrency(urls, downloadImage, CONCURRENCY)
 
-  const missing = results.filter((r) => r === 'missing');
-  const downloaded = results.filter((r) => r === 'downloaded').length;
-  const skipped = results.filter((r) => r === 'skipped').length;
-  const failed = results.filter((r) => r === 'failed').length;
+  const missing = results.filter((r) => r === 'missing')
+  const downloaded = results.filter((r) => r === 'downloaded').length
+  const skipped = results.filter((r) => r === 'skipped').length
+  const failed = results.filter((r) => r === 'failed').length
 
   if (CHECK_ONLY) {
     if (missing.length > 0) {
-      const missingUrls = urls.filter((_, i) => results[i] === 'missing');
-      console.log(`\n${missing.length} new image(s) detected:`);
-      missingUrls.forEach((u) => console.log(`  ${u}`));
+      const missingUrls = urls.filter((_, i) => results[i] === 'missing')
+      console.log(`\n${missing.length} new image(s) detected:`)
+      missingUrls.forEach((u) => console.log(`  ${u}`))
       // Write missing URLs to file for CI to read
-      const outputFile = join(__dirname, '..', 'missing-images.txt');
-      await writeFile(outputFile, missingUrls.join('\n'));
-      process.exit(1);
+      const outputFile = join(__dirname, '..', 'missing-images.txt')
+      await writeFile(outputFile, missingUrls.join('\n'))
+      process.exit(1)
     } else {
-      console.log('All images are up to date.');
+      console.log('All images are up to date.')
     }
   } else {
-    console.log(`Done: ${downloaded} downloaded, ${skipped} skipped, ${failed} failed.`);
+    console.log(`Done: ${downloaded} downloaded, ${skipped} skipped, ${failed} failed.`)
   }
 }
 
 main().catch((err) => {
-  console.error('Image check failed:', err.message);
+  console.error('Image check failed:', err.message)
   // Exit 0 in download mode (graceful degradation)
   // Exit 1 in check mode (surface the error)
-  if (CHECK_ONLY) process.exit(1);
-});
+  if (CHECK_ONLY) {
+    process.exit(1)
+  }
+})

--- a/scripts/generate-contract-lock.mjs
+++ b/scripts/generate-contract-lock.mjs
@@ -1,85 +1,83 @@
 #!/usr/bin/env node
 // generate-contract-lock.mjs — Generate .contract-lock.json for the web repo.
 // Tracks the @lifegames/schemas package consumed via yalc from design-system-Lifegames.
-import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { execSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import {createHash} from 'node:crypto'
+import {existsSync, readdirSync, readFileSync, writeFileSync} from 'node:fs'
+import {dirname, join} from 'node:path'
+import {execSync} from 'node:child_process'
+import {fileURLToPath} from 'node:url'
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = join(__dirname, '..');
-const LOCK_FILE = join(REPO_ROOT, '.contract-lock.json');
-const SCHEMAS_PKG = join(REPO_ROOT, '.yalc', '@lifegames', 'schemas');
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '..')
+const LOCK_FILE = join(REPO_ROOT, '.contract-lock.json')
+const SCHEMAS_PKG = join(REPO_ROOT, '.yalc', '@lifegames', 'schemas')
 // Raw export schemas moved to the backend-owned @lifegames/portal-contract package.
-const PORTAL_CONTRACT_PKG = join(REPO_ROOT, '.yalc', '@lifegames', 'portal-contract');
+const PORTAL_CONTRACT_PKG = join(REPO_ROOT, '.yalc', '@lifegames', 'portal-contract')
 
 function sha256(content) {
-  return createHash('sha256').update(content, 'utf-8').digest('hex');
+  return createHash('sha256').update(content, 'utf-8').digest('hex')
 }
 
 if (!existsSync(SCHEMAS_PKG)) {
-  console.error('[contract-lock] ERROR: .yalc/@lifegames/schemas not found.');
-  console.error('  Run `pnpm yalc:publish` from design-system-Lifegames first.');
-  process.exit(1);
+  console.error('[contract-lock] ERROR: .yalc/@lifegames/schemas not found.')
+  console.error('  Run `pnpm yalc:publish` from design-system-Lifegames first.')
+  process.exit(1)
 }
 
 // Read the DS SHA from the yalc package's .lp-sync-manifest.json or yalc.lock
-let dsSha = null;
-const manifestPath = join(SCHEMAS_PKG, 'vendored', '.lp-sync-manifest.json');
+let dsSha = null
+const manifestPath = join(SCHEMAS_PKG, 'vendored', '.lp-sync-manifest.json')
 if (existsSync(manifestPath)) {
-  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
-  dsSha = manifest.lpGitSha ?? null;
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+  dsSha = manifest.lpGitSha ?? null
 }
 
 // Also try to get DS repo HEAD directly if available as a sibling
-const dsRepoRoot = join(REPO_ROOT, '..', 'design-system-Lifegames');
-let dsRepoSha = null;
+const dsRepoRoot = join(REPO_ROOT, '..', 'design-system-Lifegames')
+let dsRepoSha = null
 try {
-  dsRepoSha = execSync('git rev-parse HEAD', { cwd: dsRepoRoot, encoding: 'utf-8' }).trim();
+  dsRepoSha = execSync('git rev-parse HEAD', {cwd: dsRepoRoot, encoding: 'utf-8'}).trim()
 } catch {
   // DS repo not available as sibling — use manifest SHA
 }
 
-const upstreamSha = dsRepoSha ?? dsSha ?? 'unknown';
+const upstreamSha = dsRepoSha ?? dsSha ?? 'unknown'
 
 // Collect all schema-relevant files from the yalc package
 // Include vendored schemas, authored schemas, generated schemas, and dist types
 const filePatterns = [
-  { dir: join(PORTAL_CONTRACT_PKG, 'raw-schemas'), key: 'raw-schemas', filter: (f) => f.endsWith('.schema.json') },
-  { dir: join(SCHEMAS_PKG, 'authored'), key: 'authored', filter: (f) => f.endsWith('.schema.json') },
-  { dir: join(SCHEMAS_PKG, 'generated'), key: 'generated', filter: (f) => f.endsWith('.schema.json') },
-];
+  {dir: join(PORTAL_CONTRACT_PKG, 'raw-schemas'), key: 'raw-schemas', filter: (f) => f.endsWith('.schema.json')},
+  {dir: join(SCHEMAS_PKG, 'authored'), key: 'authored', filter: (f) => f.endsWith('.schema.json')},
+  {dir: join(SCHEMAS_PKG, 'generated'), key: 'generated', filter: (f) => f.endsWith('.schema.json')}
+]
 
-const checksums = {};
-const allContents = [];
+const checksums = {}
+const allContents = []
 
-for (const { dir, key, filter } of filePatterns) {
-  if (!existsSync(dir)) continue;
-  const files = readdirSync(dir).filter(filter).sort();
+for (const {dir, key, filter} of filePatterns) {
+  if (!existsSync(dir)) {
+    continue
+  }
+  const files = readdirSync(dir).filter(filter).sort()
   for (const file of files) {
-    const relPath = `${key}/${file}`;
-    const content = readFileSync(join(dir, file), 'utf-8');
-    checksums[relPath] = `sha256:${sha256(content)}`;
-    allContents.push(content);
+    const relPath = `${key}/${file}`
+    const content = readFileSync(join(dir, file), 'utf-8')
+    checksums[relPath] = `sha256:${sha256(content)}`
+    allContents.push(content)
   }
 }
 
-const aggregateChecksum = `sha256:${sha256(allContents.join(''))}`;
+const aggregateChecksum = `sha256:${sha256(allContents.join(''))}`
 
 const lock = {
-  generatedFrom: {
-    repo: 'j0nathan-ll0yd/design-system-Lifegames',
-    sha: upstreamSha,
-    checksum: aggregateChecksum,
-  },
+  generatedFrom: {repo: 'j0nathan-ll0yd/design-system-Lifegames', sha: upstreamSha, checksum: aggregateChecksum},
   generatedAt: new Date().toISOString(),
   generatorVersion: '1.0.0',
-  files: checksums,
-};
+  files: checksums
+}
 
-writeFileSync(LOCK_FILE, JSON.stringify(lock, null, 2) + '\n');
-console.log(`[contract-lock] Generated ${LOCK_FILE}`);
-console.log(`  upstream: j0nathan-ll0yd/design-system-Lifegames@${upstreamSha.slice(0, 8)}`);
-console.log(`  aggregate: ${aggregateChecksum}`);
-console.log(`  files: ${Object.keys(checksums).length}`);
+writeFileSync(LOCK_FILE, JSON.stringify(lock, null, 2) + '\n')
+console.log(`[contract-lock] Generated ${LOCK_FILE}`)
+console.log(`  upstream: j0nathan-ll0yd/design-system-Lifegames@${upstreamSha.slice(0, 8)}`)
+console.log(`  aggregate: ${aggregateChecksum}`)
+console.log(`  files: ${Object.keys(checksums).length}`)

--- a/scripts/generate-webmcp.mjs
+++ b/scripts/generate-webmcp.mjs
@@ -7,74 +7,54 @@
 //
 // All customer-facing prose is sourced from @lifegames/copy (identity + llm
 // namespaces). Zero prose is hardcoded in this file.
-import { writeFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-import { createRequire } from 'node:module';
-import { CLOUDFRONT_BASE, ENDPOINTS, LLM_CONTENT_PATHS, SITE_URL } from '@lifegames/portal-contract/constants';
+import {writeFileSync} from 'node:fs'
+import {fileURLToPath} from 'node:url'
+import {dirname, join} from 'node:path'
+import {createRequire} from 'node:module'
+import {CLOUDFRONT_BASE, ENDPOINTS, LLM_CONTENT_PATHS, SITE_URL} from '@lifegames/portal-contract/constants'
 
 // Copy flat JSON — prose sourced from @lifegames/copy so wording is never duplicated.
-const req = createRequire(import.meta.url);
-const copyIdentity = req('@lifegames/copy/identity.flat.json');
-const copyLlm = req('@lifegames/copy/llm.flat.json');
+const req = createRequire(import.meta.url)
+const copyIdentity = req('@lifegames/copy/identity.flat.json')
+const copyLlm = req('@lifegames/copy/llm.flat.json')
 
-const cf = (path) => `${CLOUDFRONT_BASE}${path}`;
+const cf = (path) => `${CLOUDFRONT_BASE}${path}`
 
 // Data sources advertised by the get_data_sources tool and server-card resources[].
 // Name and description come from copy (mcp.ds*Name / mcp.ds*Desc) so both surfaces
 // share the same canonical wording. URLs derived from the contract.
 const dataSources = [
-  { name: copyLlm.mcp.dsHealthName, url: cf(ENDPOINTS.health), description: copyLlm.mcp.dsHealthDesc },
-  { name: copyLlm.mcp.dsSleepName, url: cf(ENDPOINTS.sleep), description: copyLlm.mcp.dsSleepDesc },
-  { name: copyLlm.mcp.dsFocusName, url: cf(ENDPOINTS.focus), description: copyLlm.mcp.dsFocusDesc },
-  {
-    name: copyLlm.mcp.dsGithubEventsName,
-    url: cf(ENDPOINTS.githubEvents),
-    description: copyLlm.mcp.dsGithubEventsDesc,
-  },
-  {
-    name: copyLlm.mcp.dsStarredReposName,
-    url: cf(ENDPOINTS.starredRepos),
-    description: copyLlm.mcp.dsStarredReposDesc,
-  },
-  { name: copyLlm.mcp.dsBooksName, url: cf(ENDPOINTS.books), description: copyLlm.mcp.dsBooksDesc },
-  { name: copyLlm.mcp.dsArticlesName, url: cf(ENDPOINTS.articles), description: copyLlm.mcp.dsArticlesDesc },
-  {
-    name: copyLlm.mcp.dsTheatreReviewsName,
-    url: cf(ENDPOINTS.theatreReviews),
-    description: copyLlm.mcp.dsTheatreReviewsDesc,
-  },
-  { name: copyLlm.mcp.dsWorkoutsName, url: cf(ENDPOINTS.workouts), description: copyLlm.mcp.dsWorkoutsDesc },
-  { name: copyLlm.mcp.dsLocationName, url: cf(ENDPOINTS.location), description: copyLlm.mcp.dsLocationDesc },
-];
+  {name: copyLlm.mcp.dsHealthName, url: cf(ENDPOINTS.health), description: copyLlm.mcp.dsHealthDesc},
+  {name: copyLlm.mcp.dsSleepName, url: cf(ENDPOINTS.sleep), description: copyLlm.mcp.dsSleepDesc},
+  {name: copyLlm.mcp.dsFocusName, url: cf(ENDPOINTS.focus), description: copyLlm.mcp.dsFocusDesc},
+  {name: copyLlm.mcp.dsGithubEventsName, url: cf(ENDPOINTS.githubEvents), description: copyLlm.mcp.dsGithubEventsDesc},
+  {name: copyLlm.mcp.dsStarredReposName, url: cf(ENDPOINTS.starredRepos), description: copyLlm.mcp.dsStarredReposDesc},
+  {name: copyLlm.mcp.dsBooksName, url: cf(ENDPOINTS.books), description: copyLlm.mcp.dsBooksDesc},
+  {name: copyLlm.mcp.dsArticlesName, url: cf(ENDPOINTS.articles), description: copyLlm.mcp.dsArticlesDesc},
+  {name: copyLlm.mcp.dsTheatreReviewsName, url: cf(ENDPOINTS.theatreReviews), description: copyLlm.mcp.dsTheatreReviewsDesc},
+  {name: copyLlm.mcp.dsWorkoutsName, url: cf(ENDPOINTS.workouts), description: copyLlm.mcp.dsWorkoutsDesc},
+  {name: copyLlm.mcp.dsLocationName, url: cf(ENDPOINTS.location), description: copyLlm.mcp.dsLocationDesc}
+]
 
-const booksUrl = cf(ENDPOINTS.books);
+const booksUrl = cf(ENDPOINTS.books)
 // llms-full.txt is advertised at its prod-domain path (proxied by
 // functions/llms-full.txt.ts), keeping agents on jonathanlloyd.me; the raw
 // JSON dataSources above stay on CloudFront (no prod-domain proxy exists for them).
-const llmsFullUrl = `${SITE_URL}${LLM_CONTENT_PATHS.llmsFull}`;
+const llmsFullUrl = `${SITE_URL}${LLM_CONTENT_PATHS.llmsFull}`
 
 // Single-quoted JS string literal to match the served file's existing style.
-const sq = (v) => `'${String(v).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+const sq = (v) => `'${String(v).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
 
 // GitHub and LinkedIn URLs come from person.sameAs (canonical profile URLs).
 // Convention: sameAs[0] = LinkedIn, sameAs[1] = GitHub.
-const linkedinUrl = copyIdentity.person.sameAs[0];
-const githubUrl = copyIdentity.person.sameAs[1];
+const linkedinUrl = copyIdentity.person.sameAs[0]
+const githubUrl = copyIdentity.person.sameAs[1]
 
-const dataSourceLines = dataSources
-  .map(
-    (s) => `      { name: ${sq(s.name)}, url: ${sq(s.url)}, description: ${sq(s.description)} }`,
-  )
-  .join(',\n');
+const dataSourceLines = dataSources.map((s) => `      { name: ${sq(s.name)}, url: ${sq(s.url)}, description: ${sq(s.description)} }`).join(',\n')
 
-const expertiseLines = copyIdentity.seo.expertise
-  .map((e) => sq(e))
-  .join(', ');
+const expertiseLines = copyIdentity.seo.expertise.map((e) => sq(e)).join(', ')
 
-const interestsLines = copyIdentity.person.interests
-  .map((i) => sq(i))
-  .join(', ');
+const interestsLines = copyIdentity.person.interests.map((i) => sq(i)).join(', ')
 
 const output = `(function() {
   if (typeof navigator !== 'undefined' && navigator.modelContext && navigator.modelContext.provideContext) {
@@ -154,16 +134,16 @@ ${dataSourceLines}
     });
   }
 })();
-`;
+`
 
-const outPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'public', 'js', 'webmcp.js');
-writeFileSync(outPath, output);
-console.log(`Generated ${outPath}`);
+const outPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'public', 'js', 'webmcp.js')
+writeFileSync(outPath, output)
+console.log(`Generated ${outPath}`)
 
 // Generate .well-known files from SITE_URL so the URL never drifts from the
 // portal-contract constant. Content is byte-identical to the committed files
 // except the URL field is now contract-sourced.
-const publicDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'public');
+const publicDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'public')
 
 const serverCard = {
   name: 'human-datastream',
@@ -173,102 +153,44 @@ const serverCard = {
     name: copyIdentity.site.name,
     version: '1.0.0',
     contactUrl: SITE_URL,
-    documentationUrl: 'https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec',
+    documentationUrl: 'https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec'
   },
-  capabilities: {
-    resources: { list: true, read: true, subscribe: false },
-    tools: { list: false, call: false },
-    prompts: { list: false, get: false },
-  },
-  transport: {
-    type: 'http',
-    url: CLOUDFRONT_BASE + '/',
-    auth: { type: 'none' },
-  },
+  capabilities: {resources: {list: true, read: true, subscribe: false}, tools: {list: false, call: false}, prompts: {list: false, get: false}},
+  transport: {type: 'http', url: CLOUDFRONT_BASE + '/', auth: {type: 'none'}},
   resources: [
-    {
-      uri: cf(ENDPOINTS.health),
-      name: copyLlm.mcp.dsHealthName,
-      description: copyLlm.mcp.dsHealthDesc,
-      mimeType: 'application/json',
-    },
-    {
-      uri: cf(ENDPOINTS.sleep),
-      name: copyLlm.mcp.dsSleepName,
-      description: copyLlm.mcp.dsSleepDesc,
-      mimeType: 'application/json',
-    },
-    {
-      uri: cf(ENDPOINTS.focus),
-      name: copyLlm.mcp.dsFocusName,
-      description: copyLlm.mcp.dsFocusDesc,
-      mimeType: 'application/json',
-    },
-    {
-      uri: cf(ENDPOINTS.githubEvents),
-      name: copyLlm.mcp.dsGithubEventsName,
-      description: copyLlm.mcp.dsGithubEventsDesc,
-      mimeType: 'application/json',
-    },
-    {
-      uri: cf(ENDPOINTS.starredRepos),
-      name: copyLlm.mcp.dsStarredReposName,
-      description: copyLlm.mcp.dsStarredReposDesc,
-      mimeType: 'application/json',
-    },
-    {
-      uri: cf(ENDPOINTS.books),
-      name: copyLlm.mcp.dsBooksName,
-      description: copyLlm.mcp.dsBooksDesc,
-      mimeType: 'application/json',
-    },
-    {
-      uri: cf(ENDPOINTS.articles),
-      name: copyLlm.mcp.dsArticlesName,
-      description: copyLlm.mcp.dsArticlesDesc,
-      mimeType: 'application/json',
-    },
-    {
-      uri: cf(ENDPOINTS.theatreReviews),
-      name: copyLlm.mcp.dsTheatreReviewsName,
-      description: copyLlm.mcp.dsTheatreReviewsDesc,
-      mimeType: 'application/json',
-    },
-    {
-      uri: cf(ENDPOINTS.workouts),
-      name: copyLlm.mcp.dsWorkoutsName,
-      description: copyLlm.mcp.dsWorkoutsDesc,
-      mimeType: 'application/json',
-    },
-    {
-      uri: cf(ENDPOINTS.location),
-      name: copyLlm.mcp.dsLocationName,
-      description: copyLlm.mcp.dsLocationDesc,
-      mimeType: 'application/json',
-    },
-  ],
-};
+    {uri: cf(ENDPOINTS.health), name: copyLlm.mcp.dsHealthName, description: copyLlm.mcp.dsHealthDesc, mimeType: 'application/json'},
+    {uri: cf(ENDPOINTS.sleep), name: copyLlm.mcp.dsSleepName, description: copyLlm.mcp.dsSleepDesc, mimeType: 'application/json'},
+    {uri: cf(ENDPOINTS.focus), name: copyLlm.mcp.dsFocusName, description: copyLlm.mcp.dsFocusDesc, mimeType: 'application/json'},
+    {uri: cf(ENDPOINTS.githubEvents), name: copyLlm.mcp.dsGithubEventsName, description: copyLlm.mcp.dsGithubEventsDesc, mimeType: 'application/json'},
+    {uri: cf(ENDPOINTS.starredRepos), name: copyLlm.mcp.dsStarredReposName, description: copyLlm.mcp.dsStarredReposDesc, mimeType: 'application/json'},
+    {uri: cf(ENDPOINTS.books), name: copyLlm.mcp.dsBooksName, description: copyLlm.mcp.dsBooksDesc, mimeType: 'application/json'},
+    {uri: cf(ENDPOINTS.articles), name: copyLlm.mcp.dsArticlesName, description: copyLlm.mcp.dsArticlesDesc, mimeType: 'application/json'},
+    {uri: cf(ENDPOINTS.theatreReviews), name: copyLlm.mcp.dsTheatreReviewsName, description: copyLlm.mcp.dsTheatreReviewsDesc, mimeType: 'application/json'},
+    {uri: cf(ENDPOINTS.workouts), name: copyLlm.mcp.dsWorkoutsName, description: copyLlm.mcp.dsWorkoutsDesc, mimeType: 'application/json'},
+    {uri: cf(ENDPOINTS.location), name: copyLlm.mcp.dsLocationName, description: copyLlm.mcp.dsLocationDesc, mimeType: 'application/json'}
+  ]
+}
 
-const serverCardPath = join(publicDir, '.well-known', 'mcp', 'server-card.json');
-writeFileSync(serverCardPath, JSON.stringify(serverCard, null, 2) + '\n');
-console.log(`Generated ${serverCardPath}`);
+const serverCardPath = join(publicDir, '.well-known', 'mcp', 'server-card.json')
+writeFileSync(serverCardPath, JSON.stringify(serverCard, null, 2) + '\n')
+console.log(`Generated ${serverCardPath}`)
 
 const agentSkills = {
-  '$schema': 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+  $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
   skills: [
     {
       name: 'portfolio-expert',
       description: copyLlm.mcp.agentSkillDescription,
       type: 'skill-md',
       url: `${SITE_URL}/.well-known/agent-skills/portfolio-expert/SKILL.md`,
-      digest: 'sha256:de0b3c87b52024f93139a078be314c2d879def1170bb1659b52086aa1067e084',
-    },
-  ],
-};
+      digest: 'sha256:de0b3c87b52024f93139a078be314c2d879def1170bb1659b52086aa1067e084'
+    }
+  ]
+}
 
-const agentSkillsPath = join(publicDir, '.well-known', 'agent-skills', 'index.json');
-writeFileSync(agentSkillsPath, JSON.stringify(agentSkills, null, 2) + '\n');
-console.log(`Generated ${agentSkillsPath}`);
+const agentSkillsPath = join(publicDir, '.well-known', 'agent-skills', 'index.json')
+writeFileSync(agentSkillsPath, JSON.stringify(agentSkills, null, 2) + '\n')
+console.log(`Generated ${agentSkillsPath}`)
 
 // Generate agent-card.json — A2A v1.0 AgentCard (normative source: a2aproject/A2A
 // specification/a2a.proto). Prose from @lifegames/copy; structure/URLs from portal-contract.
@@ -282,16 +204,9 @@ const agentCard = {
   description: copyLlm.agentDiscovery.agentCardDescription,
   version: '1.0.0',
   supportedInterfaces: [
-    {
-      url: `${SITE_URL}/.well-known/mcp/server-card.json`,
-      protocolBinding: 'HTTP+JSON',
-      protocolVersion: '1.0',
-    },
+    {url: `${SITE_URL}/.well-known/mcp/server-card.json`, protocolBinding: 'HTTP+JSON', protocolVersion: '1.0'}
   ],
-  capabilities: {
-    streaming: false,
-    pushNotifications: false,
-  },
+  capabilities: {streaming: false, pushNotifications: false},
   defaultInputModes: ['text/plain', 'application/json'],
   defaultOutputModes: ['application/json', 'text/markdown'],
   skills: [
@@ -300,14 +215,14 @@ const agentCard = {
       name: copyLlm.agentDiscovery.agentCardSkillName,
       description: copyLlm.agentDiscovery.agentCardSkillDescription,
       tags: ['personal', 'health', 'github', 'reading', 'biometrics'],
-      examples: copyLlm.agentDiscovery.agentCardSkillExamples,
-    },
-  ],
-};
+      examples: copyLlm.agentDiscovery.agentCardSkillExamples
+    }
+  ]
+}
 
-const agentCardPath = join(publicDir, '.well-known', 'agent-card.json');
-writeFileSync(agentCardPath, JSON.stringify(agentCard, null, 2) + '\n');
-console.log(`Generated ${agentCardPath}`);
+const agentCardPath = join(publicDir, '.well-known', 'agent-card.json')
+writeFileSync(agentCardPath, JSON.stringify(agentCard, null, 2) + '\n')
+console.log(`Generated ${agentCardPath}`)
 
 // Generate ai-catalog.json — ARD AI Catalog v1.0 (normative source: agenticresourcediscovery/
 // ard-spec spec/schemas/ai-catalog.schema.json). Prose from @lifegames/copy; URLs/identifiers
@@ -315,13 +230,13 @@ console.log(`Generated ${agentCardPath}`);
 // (RFC 8141 urn:air:<publisher>:<namespace>:<name>), displayName, type (IANA media type), and
 // exactly one of url/data. host + entries are additionalProperties:false — no stray fields.
 // Pinned to ARD specVersion 1.0, verified 2026-07-07. See docs/discovery-surface.md.
-const air = (namespace, name) => `urn:air:jonathanlloyd.me:${namespace}:${name}`;
+const air = (namespace, name) => `urn:air:jonathanlloyd.me:${namespace}:${name}`
 const aiCatalog = {
   specVersion: '1.0',
   host: {
     displayName: copyIdentity.site.fullName,
     identifier: 'did:web:jonathanlloyd.me',
-    documentationUrl: 'https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec',
+    documentationUrl: 'https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/wiki/LLM-Content-Spec'
   },
   entries: [
     {
@@ -330,7 +245,7 @@ const aiCatalog = {
       type: 'application/mcp-server-card+json',
       url: `${SITE_URL}/.well-known/mcp/server-card.json`,
       description: copyLlm.agentDiscovery.aiCatalogMcpDescription,
-      representativeQueries: copyLlm.agentDiscovery.aiCatalogMcpQueries,
+      representativeQueries: copyLlm.agentDiscovery.aiCatalogMcpQueries
     },
     {
       // ARD defines no dedicated media type for an agent-skills index; typed as generic JSON.
@@ -339,7 +254,7 @@ const aiCatalog = {
       type: 'application/json',
       url: `${SITE_URL}/.well-known/agent-skills/index.json`,
       description: copyLlm.agentDiscovery.aiCatalogSkillsDescription,
-      representativeQueries: copyLlm.agentDiscovery.aiCatalogSkillsQueries,
+      representativeQueries: copyLlm.agentDiscovery.aiCatalogSkillsQueries
     },
     {
       identifier: air('agent', 'human-datastream'),
@@ -347,11 +262,11 @@ const aiCatalog = {
       type: 'application/a2a-agent-card+json',
       url: `${SITE_URL}/.well-known/agent-card.json`,
       description: copyLlm.agentDiscovery.aiCatalogA2aDescription,
-      representativeQueries: copyLlm.agentDiscovery.aiCatalogA2aQueries,
-    },
-  ],
-};
+      representativeQueries: copyLlm.agentDiscovery.aiCatalogA2aQueries
+    }
+  ]
+}
 
-const aiCatalogPath = join(publicDir, '.well-known', 'ai-catalog.json');
-writeFileSync(aiCatalogPath, JSON.stringify(aiCatalog, null, 2) + '\n');
-console.log(`Generated ${aiCatalogPath}`);
+const aiCatalogPath = join(publicDir, '.well-known', 'ai-catalog.json')
+writeFileSync(aiCatalogPath, JSON.stringify(aiCatalog, null, 2) + '\n')
+console.log(`Generated ${aiCatalogPath}`)

--- a/scripts/write-version.mjs
+++ b/scripts/write-version.mjs
@@ -8,11 +8,11 @@
  * cannot. Served no-store via functions/_middleware.ts.
  *
  * Plan: .omc/plans/graceful-deploy-auto-update-plan.md (Phase 2). */
-import { writeFileSync } from 'node:fs';
-import path from 'node:path';
+import {writeFileSync} from 'node:fs'
+import path from 'node:path'
 
-const build = process.env.GITHUB_SHA || process.env.CF_PAGES_COMMIT_SHA || 'dev';
-const outPath = path.resolve(process.cwd(), 'dist', 'version.json');
+const build = process.env.GITHUB_SHA || process.env.CF_PAGES_COMMIT_SHA || 'dev'
+const outPath = path.resolve(process.cwd(), 'dist', 'version.json')
 
-writeFileSync(outPath, JSON.stringify({ build, builtAt: new Date().toISOString() }) + '\n');
-console.log(`[write-version] wrote dist/version.json (build=${build})`);
+writeFileSync(outPath, JSON.stringify({build, builtAt: new Date().toISOString()}) + '\n')
+console.log(`[write-version] wrote dist/version.json (build=${build})`)

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,9 +1,9 @@
-import { defineCollection } from 'astro:content';
-import { file } from 'astro/loaders';
-import { fileURLToPath } from 'node:url';
-import { identitySchema } from '@lifegames/copy/identity.zod';
+import {defineCollection} from 'astro:content'
+import {file} from 'astro/loaders'
+import {fileURLToPath} from 'node:url'
+import {identitySchema} from '@lifegames/copy/identity.zod'
 
-const identityPath = fileURLToPath(import.meta.resolve('@lifegames/copy/identity.flat.json'));
+const identityPath = fileURLToPath(import.meta.resolve('@lifegames/copy/identity.flat.json'))
 
 const copy = defineCollection({
   // file() does not natively handle a single flat object, so wrap it under one
@@ -12,8 +12,8 @@ const copy = defineCollection({
   // the key as the entry id and validates the untouched value, which the
   // generated `.strict()` identitySchema requires (an injected `id` key would
   // be rejected as an unrecognized property).
-  loader: file(identityPath, { parser: (text) => ({ identity: JSON.parse(text) }) }),
-  schema: identitySchema,
-});
+  loader: file(identityPath, {parser: (text) => ({identity: JSON.parse(text)})}),
+  schema: identitySchema
+})
 
-export const collections = { copy };
+export const collections = {copy}

--- a/src/lib/load-dashboard-data.ts
+++ b/src/lib/load-dashboard-data.ts
@@ -1,4 +1,4 @@
-import { getDashboardFixture, fixtures, type DashboardFixture, type FixtureVariation } from '@lifegames/fixtures';
+import {type DashboardFixture, fixtures, type FixtureVariation, getDashboardFixture} from '@lifegames/fixtures'
 
 /**
  * The dashboard payload that backs the SSR build output. This is the exact
@@ -7,15 +7,15 @@ import { getDashboardFixture, fixtures, type DashboardFixture, type FixtureVaria
  * the single source of truth for representative content; this repo no longer
  * hand-bakes `data/*.json`.
  */
-export type DashboardData = DashboardFixture;
+export type DashboardData = DashboardFixture
 
 /** Known post-adapter variation keys (e.g. 'baseline', 'empty'). */
-const VARIATIONS = Object.keys(fixtures.profile) as FixtureVariation[];
+const VARIATIONS = Object.keys(fixtures.profile) as FixtureVariation[]
 
 function resolveVariation(value: string | undefined): FixtureVariation {
   return value && (VARIATIONS as string[]).includes(value)
     ? (value as FixtureVariation)
-    : 'baseline';
+    : 'baseline'
 }
 
 /**
@@ -28,5 +28,5 @@ function resolveVariation(value: string | undefined): FixtureVariation {
  * value also falls back to `baseline`.
  */
 export async function loadDashboardData(): Promise<DashboardData> {
-  return getDashboardFixture(resolveVariation(import.meta.env.FIXTURE_VARIATION));
+  return getDashboardFixture(resolveVariation(import.meta.env.FIXTURE_VARIATION))
 }

--- a/src/lib/mobile-bg.ts
+++ b/src/lib/mobile-bg.ts
@@ -16,7 +16,7 @@
 //     and magnitude-scaled brightness, with the Beehive Cluster (M44) at its heart —
 //     anchored (fixed) within the drifting field. Data: Wikipedia / Stellarium.
 
-type Mode = 'lite' | 'svg';
+type Mode = 'lite' | 'svg'
 
 // Real stellar colors (sRGB blackbody chromaticity) + population weights (sum 100).
 const STAR_COLORS: ReadonlyArray<readonly [string, number]> = [
@@ -27,112 +27,124 @@ const STAR_COLORS: ReadonlyArray<readonly [string, number]> = [
   ['#fff4ea', 12], // G  — warm white (the Sun)
   ['#ffd2a1', 24], // K  — orange
   ['#ffcc6f', 13], // M dwarf — orange
-  ['#ff9966', 8], // M giant — orange-red (Betelgeuse, Antares)
-];
+  ['#ff9966', 8] // M giant — orange-red (Betelgeuse, Antares)
+]
 
 // Cancer, the Crab — real stars normalized to a 0..1 box (north up). J2000 positions
 // from Wikipedia/Stellarium; colors from spectral type; mag = apparent V.
-const CANCER_STARS: ReadonlyArray<{ x: number; y: number; mag: number; c: string; }> = [
-  { x: 0.00, y: 1.00, mag: 3.53, c: '#ffd2a1' }, // 0 Tarf (β, K4III, orange)
-  { x: 0.67, y: 0.54, mag: 3.94, c: '#ffd2a1' }, // 1 Asellus Australis (δ, K0III, orange)
-  { x: 0.72, y: 0.00, mag: 4.03, c: '#fff4ea' }, // 2 Iota Cancri (ι, G8III, yellow)
-  { x: 1.00, y: 0.86, mag: 4.25, c: '#cad7ff' }, // 3 Acubens (α, A7, white)
-  { x: 0.64, y: 0.37, mag: 4.67, c: '#cad7ff' }, // 4 Asellus Borealis (γ, A1IV, white)
-  { x: 0.085, y: 0.08, mag: 5.14, c: '#f8f7ff' }, // 5 Chi Cancri (χ, F6V, yellow-white)
-];
+const CANCER_STARS: ReadonlyArray<{x: number; y: number; mag: number; c: string}> = [
+  {x: 0.00, y: 1.00, mag: 3.53, c: '#ffd2a1'}, // 0 Tarf (β, K4III, orange)
+  {x: 0.67, y: 0.54, mag: 3.94, c: '#ffd2a1'}, // 1 Asellus Australis (δ, K0III, orange)
+  {x: 0.72, y: 0.00, mag: 4.03, c: '#fff4ea'}, // 2 Iota Cancri (ι, G8III, yellow)
+  {x: 1.00, y: 0.86, mag: 4.25, c: '#cad7ff'}, // 3 Acubens (α, A7, white)
+  {x: 0.64, y: 0.37, mag: 4.67, c: '#cad7ff'}, // 4 Asellus Borealis (γ, A1IV, white)
+  {x: 0.085, y: 0.08, mag: 5.14, c: '#f8f7ff'} // 5 Chi Cancri (χ, F6V, yellow-white)
+]
 // Stellarium stick figure: ι–γ, γ–χ, γ–δ, δ–β, δ–α.
-const CANCER_LINES: ReadonlyArray<readonly [number, number]> = [[2, 4], [4, 5], [4, 1], [1, 0], [1, 3]];
-const BEEHIVE = { x: 0.57, y: 0.45 }; // M44 / Praesepe, at the crab's heart
+const CANCER_LINES: ReadonlyArray<readonly [number, number]> = [[2, 4], [4, 5], [4, 1], [1, 0], [1, 3]]
+const BEEHIVE = {x: 0.57, y: 0.45} // M44 / Praesepe, at the crab's heart
 
-const FRAME_MS = 1000 / 30; // 30fps
-const LINE_DIST = 78;
-const MAX_LINES = 90;
-const NS = 'http://www.w3.org/2000/svg';
+const FRAME_MS = 1000 / 30 // 30fps
+const LINE_DIST = 78
+const MAX_LINES = 90
+const NS = 'http://www.w3.org/2000/svg'
 
 function pickStarColor(): string {
-  let r = Math.random() * 100;
+  let r = Math.random() * 100
   for (const [c, weight] of STAR_COLORS) {
-    r -= weight;
-    if (r <= 0) return c;
+    r -= weight
+    if (r <= 0) {
+      return c
+    }
   }
-  return STAR_COLORS[STAR_COLORS.length - 1][0];
+  const last = STAR_COLORS[STAR_COLORS.length - 1]
+  return last ? last[0] : '#fff4ea'
 }
 
 function countFor(w: number, h: number): number {
-  return Math.max(40, Math.min(64, Math.floor((w * h) / 6200)));
+  return Math.max(40, Math.min(64, Math.floor((w * h) / 6200)))
 }
 
 // Pogson: brighter (lower) magnitude → larger flux. Returns 0..1.
 function magBrightness(mag: number, ref: number): number {
-  return Math.min(Math.pow(10, -0.4 * (mag - ref)), 1);
+  return Math.min(Math.pow(10, -0.4 * (mag - ref)), 1)
 }
 
 export function initMobileBg(mode: Mode): void {
-  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-  const canvas = document.getElementById('particle-canvas') as HTMLCanvasElement | null;
-  if (!canvas) return;
-  if (mode === 'lite') initLiteCanvas(canvas);
-  else initSvg(canvas);
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return
+  }
+  const canvas = document.getElementById('particle-canvas') as HTMLCanvasElement | null
+  if (!canvas) {
+    return
+  }
+  if (mode === 'lite') {
+    initLiteCanvas(canvas)
+  } else {
+    initSvg(canvas)
+  }
 }
 
 function circle(fill: string, r: number, op?: number): SVGCircleElement {
-  const c = document.createElementNS(NS, 'circle');
-  c.setAttribute('r', r.toFixed(1));
-  c.setAttribute('fill', fill);
-  if (op !== undefined) c.setAttribute('fill-opacity', op.toFixed(2));
-  return c;
+  const c = document.createElementNS(NS, 'circle')
+  c.setAttribute('r', r.toFixed(1))
+  c.setAttribute('fill', fill)
+  if (op !== undefined) {
+    c.setAttribute('fill-opacity', op.toFixed(2))
+  }
+  return c
 }
 
 // --- svg: drifting real starfield + the fixed Cancer constellation (no canvas) ---
 function initSvg(canvas: HTMLCanvasElement): void {
-  let w = window.innerWidth;
-  let h = window.innerHeight;
+  let w = window.innerWidth
+  let h = window.innerHeight
 
-  const svg = document.createElementNS(NS, 'svg');
-  svg.setAttribute('aria-hidden', 'true');
-  const cs = getComputedStyle(canvas);
-  svg.style.cssText = 'position:fixed;inset:0;width:100%;height:100%;pointer-events:none;z-index:'
-    + (cs.zIndex && cs.zIndex !== 'auto' ? cs.zIndex : '0') + ';';
-  canvas.style.display = 'none';
-  canvas.parentNode!.insertBefore(svg, canvas.nextSibling);
+  const svg = document.createElementNS(NS, 'svg')
+  svg.setAttribute('aria-hidden', 'true')
+  const cs = getComputedStyle(canvas)
+  svg.style.cssText = 'position:fixed;inset:0;width:100%;height:100%;pointer-events:none;z-index:' +
+    (cs.zIndex && cs.zIndex !== 'auto' ? cs.zIndex : '0') + ';'
+  canvas.style.display = 'none'
+  canvas.parentNode!.insertBefore(svg, canvas.nextSibling)
 
   interface Field {
-    x: number;
-    y: number;
-    vx: number;
-    vy: number;
-    c: string;
-    glow: SVGCircleElement;
-    core: SVGCircleElement;
-    baseOp: number;
-    twPhase: number;
-    twAmp: number;
-    twSpeed: number;
+    x: number
+    y: number
+    vx: number
+    vy: number
+    c: string
+    glow: SVGCircleElement
+    core: SVGCircleElement
+    baseOp: number
+    twPhase: number
+    twAmp: number
+    twSpeed: number
   }
 
   // ---- ambient drifting field (a bit sparser so Cancer reads as the figure) ----
-  const fieldCount = Math.round(countFor(w, h) * 0.7);
-  const fieldLines: SVGLineElement[] = [];
+  const fieldCount = Math.round(countFor(w, h) * 0.7)
+  const fieldLines: SVGLineElement[] = []
   for (let i = 0; i < MAX_LINES; i++) {
-    const l = document.createElementNS(NS, 'line');
-    l.setAttribute('stroke-width', '0.6');
-    l.style.visibility = 'hidden';
-    svg.appendChild(l);
-    fieldLines.push(l);
+    const l = document.createElementNS(NS, 'line')
+    l.setAttribute('stroke-width', '0.6')
+    l.style.visibility = 'hidden'
+    svg.appendChild(l)
+    fieldLines.push(l)
   }
-  const field: Field[] = [];
+  const field: Field[] = []
   for (let i = 0; i < fieldCount; i++) {
-    const c = pickStarColor();
-    const b = Math.pow(Math.random(), 2.6);
-    const rCore = 0.8 + b * 2.9;
-    const baseOp = 0.12 + b * 0.4;
-    const pm = Math.pow(Math.random(), 3);
-    const speed = 0.26 + pm * 1.0;
-    const ang = Math.random() * Math.PI * 2;
-    const glow = circle(c, rCore * (2.2 + b * 1.5), baseOp);
-    const core = circle(c, rCore);
-    svg.appendChild(glow);
-    svg.appendChild(core);
+    const c = pickStarColor()
+    const b = Math.pow(Math.random(), 2.6)
+    const rCore = 0.8 + b * 2.9
+    const baseOp = 0.12 + b * 0.4
+    const pm = Math.pow(Math.random(), 3)
+    const speed = 0.26 + pm * 1.0
+    const ang = Math.random() * Math.PI * 2
+    const glow = circle(c, rCore * (2.2 + b * 1.5), baseOp)
+    const core = circle(c, rCore)
+    svg.appendChild(glow)
+    svg.appendChild(core)
     field.push({
       x: Math.random() * w,
       y: Math.random() * h,
@@ -144,237 +156,275 @@ function initSvg(canvas: HTMLCanvasElement): void {
       baseOp,
       twPhase: Math.random() * Math.PI * 2,
       twAmp: 0.12 + Math.random() * 0.22,
-      twSpeed: 1.8 + Math.random() * 4,
-    });
+      twSpeed: 1.8 + Math.random() * 4
+    })
   }
 
   // ---- Cancer: fixed figure at true relative positions ----
-  const figH = h * 0.58;
-  const figW = figH * 0.52; // sky aspect (RA span ~9.9° : Dec span ~19.6°)
-  const figX = (w - figW) / 2;
-  const figY = h * 0.15;
-  const place = (nx: number, ny: number): [number, number] => [figX + nx * figW, figY + ny * figH];
+  const figH = h * 0.58
+  const figW = figH * 0.52 // sky aspect (RA span ~9.9° : Dec span ~19.6°)
+  const figX = (w - figW) / 2
+  const figY = h * 0.15
+  const place = (nx: number, ny: number): [number, number] => [figX + nx * figW, figY + ny * figH]
 
   // constellation lines (brighter + steadier than the field web)
   for (const [a, b] of CANCER_LINES) {
-    const [x1, y1] = place(CANCER_STARS[a].x, CANCER_STARS[a].y);
-    const [x2, y2] = place(CANCER_STARS[b].x, CANCER_STARS[b].y);
-    const l = document.createElementNS(NS, 'line');
-    l.setAttribute('x1', x1.toFixed(1));
-    l.setAttribute('y1', y1.toFixed(1));
-    l.setAttribute('x2', x2.toFixed(1));
-    l.setAttribute('y2', y2.toFixed(1));
-    l.setAttribute('stroke', '#bcd4ff');
-    l.setAttribute('stroke-opacity', '0.42');
-    l.setAttribute('stroke-width', '1');
-    svg.appendChild(l);
+    const sa = CANCER_STARS[a]
+    const sb = CANCER_STARS[b]
+    if (!sa || !sb) {
+      continue
+    }
+    const [x1, y1] = place(sa.x, sa.y)
+    const [x2, y2] = place(sb.x, sb.y)
+    const l = document.createElementNS(NS, 'line')
+    l.setAttribute('x1', x1.toFixed(1))
+    l.setAttribute('y1', y1.toFixed(1))
+    l.setAttribute('x2', x2.toFixed(1))
+    l.setAttribute('y2', y2.toFixed(1))
+    l.setAttribute('stroke', '#bcd4ff')
+    l.setAttribute('stroke-opacity', '0.42')
+    l.setAttribute('stroke-width', '1')
+    svg.appendChild(l)
   }
 
   // Beehive Cluster (M44) — a faint swarm of blue-white dots at the crab's heart
-  const [bhx, bhy] = place(BEEHIVE.x, BEEHIVE.y);
-  svg.appendChild(circle('#cad7ff', figH * 0.05, 0.08)); // soft collective haze
-  (svg.lastChild as SVGCircleElement).setAttribute('cx', bhx.toFixed(1));
-  (svg.lastChild as SVGCircleElement).setAttribute('cy', bhy.toFixed(1));
+  const [bhx, bhy] = place(BEEHIVE.x, BEEHIVE.y)
+  svg.appendChild(circle('#cad7ff', figH * 0.05, 0.08)) // soft collective haze
+  ;(svg.lastChild as SVGCircleElement).setAttribute('cx', bhx.toFixed(1))
+  ;(svg.lastChild as SVGCircleElement).setAttribute('cy', bhy.toFixed(1))
   for (let i = 0; i < 9; i++) {
-    const a = Math.random() * Math.PI * 2;
-    const rad = Math.pow(Math.random(), 0.6) * figH * 0.045;
-    const d = circle(i % 3 === 0 ? '#aabfff' : '#cad7ff', 0.9 + Math.random() * 0.6, 0.55 + Math.random() * 0.3);
-    d.setAttribute('cx', (bhx + Math.cos(a) * rad).toFixed(1));
-    d.setAttribute('cy', (bhy + Math.sin(a) * rad * 1.3).toFixed(1));
-    svg.appendChild(d);
+    const a = Math.random() * Math.PI * 2
+    const rad = Math.pow(Math.random(), 0.6) * figH * 0.045
+    const d = circle(i % 3 === 0 ? '#aabfff' : '#cad7ff', 0.9 + Math.random() * 0.6, 0.55 + Math.random() * 0.3)
+    d.setAttribute('cx', (bhx + Math.cos(a) * rad).toFixed(1))
+    d.setAttribute('cy', (bhy + Math.sin(a) * rad * 1.3).toFixed(1))
+    svg.appendChild(d)
   }
 
   // constellation stars (bright glow + core, magnitude-scaled, gentle twinkle)
   interface Named {
-    glow: SVGCircleElement;
-    baseOp: number;
-    twPhase: number;
-    twSpeed: number;
+    glow: SVGCircleElement
+    baseOp: number
+    twPhase: number
+    twSpeed: number
   }
-  const named: Named[] = [];
+  const named: Named[] = []
   for (const s of CANCER_STARS) {
-    const [x, y] = place(s.x, s.y);
-    const b = magBrightness(s.mag, 3.5);
-    const rCore = 2.4 + b * 4.8;
-    const baseOp = 0.34 + b * 0.42;
-    const glow = circle(s.c, rCore * 2.5, baseOp);
-    const core = circle(s.c, rCore);
+    const [x, y] = place(s.x, s.y)
+    const b = magBrightness(s.mag, 3.5)
+    const rCore = 2.4 + b * 4.8
+    const baseOp = 0.34 + b * 0.42
+    const glow = circle(s.c, rCore * 2.5, baseOp)
+    const core = circle(s.c, rCore)
     for (const el of [glow, core]) {
-      el.setAttribute('cx', x.toFixed(1));
-      el.setAttribute('cy', y.toFixed(1));
-      svg.appendChild(el);
+      el.setAttribute('cx', x.toFixed(1))
+      el.setAttribute('cy', y.toFixed(1))
+      svg.appendChild(el)
     }
-    named.push({ glow, baseOp, twPhase: Math.random() * Math.PI * 2, twSpeed: 1.4 + Math.random() * 2.6 });
+    named.push({glow, baseOp, twPhase: Math.random() * Math.PI * 2, twSpeed: 1.4 + Math.random() * 2.6})
   }
 
-  let last = 0;
-  let rafId = 0;
-  let elapsed = 0;
+  let last = 0
+  let rafId = 0
+  let elapsed = 0
   function frame(ts: number): void {
-    rafId = requestAnimationFrame(frame);
-    if (ts - last < FRAME_MS) return;
-    elapsed += last ? (ts - last) / 1000 : 0.033;
-    last = ts;
+    rafId = requestAnimationFrame(frame)
+    if (ts - last < FRAME_MS) {
+      return
+    }
+    elapsed += last ? (ts - last) / 1000 : 0.033
+    last = ts
 
     for (const s of field) {
-      s.x += s.vx;
-      s.y += s.vy;
-      if (s.x < -6) s.x = w + 6;
-      else if (s.x > w + 6) s.x = -6;
-      if (s.y < -6) s.y = h + 6;
-      else if (s.y > h + 6) s.y = -6;
-      const x = s.x.toFixed(1);
-      const y = s.y.toFixed(1);
-      s.glow.setAttribute('cx', x);
-      s.glow.setAttribute('cy', y);
-      s.core.setAttribute('cx', x);
-      s.core.setAttribute('cy', y);
-      s.glow.setAttribute(
-        'fill-opacity',
-        (s.baseOp * (1 + s.twAmp * Math.sin(elapsed * s.twSpeed + s.twPhase))).toFixed(2),
-      );
+      s.x += s.vx
+      s.y += s.vy
+      if (s.x < -6) {
+        s.x = w + 6
+      } else if (s.x > w + 6) {
+        s.x = -6
+      }
+      if (s.y < -6) {
+        s.y = h + 6
+      } else if (s.y > h + 6) {
+        s.y = -6
+      }
+      const x = s.x.toFixed(1)
+      const y = s.y.toFixed(1)
+      s.glow.setAttribute('cx', x)
+      s.glow.setAttribute('cy', y)
+      s.core.setAttribute('cx', x)
+      s.core.setAttribute('cy', y)
+      s.glow.setAttribute('fill-opacity', (s.baseOp * (1 + s.twAmp * Math.sin(elapsed * s.twSpeed + s.twPhase))).toFixed(2))
     }
 
     // twinkle the named stars (fixed positions)
     for (const n of named) {
-      n.glow.setAttribute(
-        'fill-opacity',
-        (n.baseOp * (1 + 0.18 * Math.sin(elapsed * n.twSpeed + n.twPhase))).toFixed(2),
-      );
+      n.glow.setAttribute('fill-opacity', (n.baseOp * (1 + 0.18 * Math.sin(elapsed * n.twSpeed + n.twPhase))).toFixed(2))
     }
 
     // subtle ambient web among field stars
-    let li = 0;
-    const d2 = LINE_DIST * LINE_DIST;
+    let li = 0
+    const d2 = LINE_DIST * LINE_DIST
     for (let i = 0; i < field.length - 1 && li < MAX_LINES; i++) {
-      const a = field[i];
+      const a = field[i]
+      if (!a) {
+        continue
+      }
       for (let j = i + 1; j < field.length && li < MAX_LINES; j++) {
-        const s2 = field[j];
-        const dx = a.x - s2.x;
-        const dy = a.y - s2.y;
-        if (Math.abs(dx) > LINE_DIST || Math.abs(dy) > LINE_DIST) continue;
-        const dd = dx * dx + dy * dy;
-        if (dd > d2) continue;
-        const l = fieldLines[li++];
-        l.setAttribute('x1', a.x.toFixed(1));
-        l.setAttribute('y1', a.y.toFixed(1));
-        l.setAttribute('x2', s2.x.toFixed(1));
-        l.setAttribute('y2', s2.y.toFixed(1));
-        l.setAttribute('stroke', a.c);
-        l.setAttribute('stroke-opacity', ((1 - Math.sqrt(dd) / LINE_DIST) * 0.18).toFixed(2));
-        l.style.visibility = 'visible';
+        const s2 = field[j]
+        if (!s2) {
+          continue
+        }
+        const dx = a.x - s2.x
+        const dy = a.y - s2.y
+        if (Math.abs(dx) > LINE_DIST || Math.abs(dy) > LINE_DIST) {
+          continue
+        }
+        const dd = dx * dx + dy * dy
+        if (dd > d2) {
+          continue
+        }
+        const l = fieldLines[li++]
+        if (!l) {
+          continue
+        }
+        l.setAttribute('x1', a.x.toFixed(1))
+        l.setAttribute('y1', a.y.toFixed(1))
+        l.setAttribute('x2', s2.x.toFixed(1))
+        l.setAttribute('y2', s2.y.toFixed(1))
+        l.setAttribute('stroke', a.c)
+        l.setAttribute('stroke-opacity', ((1 - Math.sqrt(dd) / LINE_DIST) * 0.18).toFixed(2))
+        l.style.visibility = 'visible'
       }
     }
-    for (; li < MAX_LINES; li++) fieldLines[li].style.visibility = 'hidden';
+    for (; li < MAX_LINES; li++) {
+      const l = fieldLines[li]
+      if (l) {
+        l.style.visibility = 'hidden'
+      }
+    }
   }
 
   window.addEventListener('resize', () => {
-    w = window.innerWidth;
-    h = window.innerHeight;
-  });
+    w = window.innerWidth
+    h = window.innerHeight
+  })
   document.addEventListener('visibilitychange', () => {
     if (document.hidden) {
       if (rafId) {
-        cancelAnimationFrame(rafId);
-        rafId = 0;
+        cancelAnimationFrame(rafId)
+        rafId = 0
       }
     } else if (!rafId) {
-      last = 0;
-      rafId = requestAnimationFrame(frame);
+      last = 0
+      rafId = requestAnimationFrame(frame)
     }
-  });
-  rafId = requestAnimationFrame(frame);
+  })
+  rafId = requestAnimationFrame(frame)
 }
 
 // --- lite: lighter CANVAS field (debug via ?bg=lite; NOT default) ---
 interface P {
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  r: number;
-  c: string;
+  x: number
+  y: number
+  vx: number
+  vy: number
+  r: number
+  c: string
 }
 
 function initLiteCanvas(canvas: HTMLCanvasElement): void {
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return;
-  let w = 0;
-  let h = 0;
-  let ps: P[] = [];
-  let last = 0;
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    return
+  }
+  let w = 0
+  let h = 0
+  let ps: P[] = []
+  let last = 0
 
   function resize(): void {
-    w = window.innerWidth;
-    h = window.innerHeight;
-    canvas.width = w;
-    canvas.height = h;
-    canvas.style.width = w + 'px';
-    canvas.style.height = h + 'px';
-    ps = [];
-    const count = countFor(w, h);
+    w = window.innerWidth
+    h = window.innerHeight
+    canvas.width = w
+    canvas.height = h
+    canvas.style.width = w + 'px'
+    canvas.style.height = h + 'px'
+    ps = []
+    const count = countFor(w, h)
     for (let i = 0; i < count; i++) {
-      const b = Math.pow(Math.random(), 2.6);
-      const pm = Math.pow(Math.random(), 3);
-      const speed = 0.28 + pm * 1.05;
-      const ang = Math.random() * Math.PI * 2;
-      ps.push({
-        x: Math.random() * w,
-        y: Math.random() * h,
-        vx: Math.cos(ang) * speed,
-        vy: Math.sin(ang) * speed,
-        r: 0.9 + b * 3.4,
-        c: pickStarColor(),
-      });
+      const b = Math.pow(Math.random(), 2.6)
+      const pm = Math.pow(Math.random(), 3)
+      const speed = 0.28 + pm * 1.05
+      const ang = Math.random() * Math.PI * 2
+      ps.push({x: Math.random() * w, y: Math.random() * h, vx: Math.cos(ang) * speed, vy: Math.sin(ang) * speed, r: 0.9 + b * 3.4, c: pickStarColor()})
     }
   }
 
   function frame(ts: number): void {
-    requestAnimationFrame(frame);
-    if (ts - last < FRAME_MS) return;
-    last = ts;
-    ctx!.clearRect(0, 0, w, h);
-    for (const p of ps) {
-      p.x += p.vx;
-      p.y += p.vy;
-      if (p.x < -6) p.x = w + 6;
-      else if (p.x > w + 6) p.x = -6;
-      if (p.y < -6) p.y = h + 6;
-      else if (p.y > h + 6) p.y = -6;
+    requestAnimationFrame(frame)
+    if (ts - last < FRAME_MS) {
+      return
     }
-    const d2 = LINE_DIST * LINE_DIST;
-    for (let i = 0; i < ps.length - 1; i++) {
-      const a = ps[i];
-      for (let j = i + 1; j < ps.length; j++) {
-        const b = ps[j];
-        const dx = a.x - b.x;
-        const dy = a.y - b.y;
-        if (Math.abs(dx) > LINE_DIST || Math.abs(dy) > LINE_DIST) continue;
-        const dd = dx * dx + dy * dy;
-        if (dd > d2) continue;
-        ctx!.globalAlpha = (1 - Math.sqrt(dd) / LINE_DIST) * 0.2;
-        ctx!.strokeStyle = a.c;
-        ctx!.lineWidth = 0.7;
-        ctx!.beginPath();
-        ctx!.moveTo(a.x, a.y);
-        ctx!.lineTo(b.x, b.y);
-        ctx!.stroke();
+    last = ts
+    ctx!.clearRect(0, 0, w, h)
+    for (const p of ps) {
+      p.x += p.vx
+      p.y += p.vy
+      if (p.x < -6) {
+        p.x = w + 6
+      } else if (p.x > w + 6) {
+        p.x = -6
+      }
+      if (p.y < -6) {
+        p.y = h + 6
+      } else if (p.y > h + 6) {
+        p.y = -6
       }
     }
-    ctx!.globalAlpha = 1;
+    const d2 = LINE_DIST * LINE_DIST
+    for (let i = 0; i < ps.length - 1; i++) {
+      const a = ps[i]
+      if (!a) {
+        continue
+      }
+      for (let j = i + 1; j < ps.length; j++) {
+        const b = ps[j]
+        if (!b) {
+          continue
+        }
+        const dx = a.x - b.x
+        const dy = a.y - b.y
+        if (Math.abs(dx) > LINE_DIST || Math.abs(dy) > LINE_DIST) {
+          continue
+        }
+        const dd = dx * dx + dy * dy
+        if (dd > d2) {
+          continue
+        }
+        ctx!.globalAlpha = (1 - Math.sqrt(dd) / LINE_DIST) * 0.2
+        ctx!.strokeStyle = a.c
+        ctx!.lineWidth = 0.7
+        ctx!.beginPath()
+        ctx!.moveTo(a.x, a.y)
+        ctx!.lineTo(b.x, b.y)
+        ctx!.stroke()
+      }
+    }
+    ctx!.globalAlpha = 1
     for (const p of ps) {
-      ctx!.beginPath();
-      ctx!.fillStyle = p.c;
-      ctx!.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-      ctx!.fill();
+      ctx!.beginPath()
+      ctx!.fillStyle = p.c
+      ctx!.arc(p.x, p.y, p.r, 0, Math.PI * 2)
+      ctx!.fill()
     }
   }
 
-  let t: ReturnType<typeof setTimeout>;
+  let t: ReturnType<typeof setTimeout>
   window.addEventListener('resize', () => {
-    clearTimeout(t);
-    t = setTimeout(resize, 150);
-  });
-  resize();
-  requestAnimationFrame(frame);
+    clearTimeout(t)
+    t = setTimeout(resize, 150)
+  })
+  resize()
+  requestAnimationFrame(frame)
 }

--- a/src/lib/runtime/api.ts
+++ b/src/lib/runtime/api.ts
@@ -1,49 +1,48 @@
-import { CLOUDFRONT_BASE, ENDPOINTS } from '@lifegames/portal-contract/constants';
+import {CLOUDFRONT_BASE, ENDPOINTS} from '@lifegames/portal-contract/constants'
 import type {
-  HealthExport,
-  SleepExport,
-  WorkoutsExport,
+  ArticlesExport,
   BooksExport,
+  FocusExport,
   GithubEventsExport,
   GithubStarredReposExport,
-  ArticlesExport,
+  HealthExport,
   LocationExport,
-  FocusExport,
+  SleepExport,
   TheatreReviewsExport,
-} from '@lifegames/web/types/exports';
+  WorkoutsExport
+} from '@lifegames/web/types/exports'
 
 // In dev mode, Vite proxies /api/live/* to CloudFront to avoid CORS issues.
 // In production, fetch directly from CloudFront (CORS allows jonathanlloyd.me).
-const BASE = import.meta.env.DEV ? '/api/live' : CLOUDFRONT_BASE;
+const BASE = import.meta.env.DEV ? '/api/live' : CLOUDFRONT_BASE
 
 export interface FetchResult {
-  health: HealthExport | null;
-  sleep: SleepExport | null;
-  workouts: WorkoutsExport | null;
-  books: BooksExport | null;
-  githubEvents: GithubEventsExport | null;
-  starredRepos: GithubStarredReposExport | null;
-  articles: ArticlesExport | null;
-  location: LocationExport | null;
-  focus: FocusExport | null;
-  theatreReviews: TheatreReviewsExport | null;
-  timestamps: Record<string, string | null>;
+  health: HealthExport | null
+  sleep: SleepExport | null
+  workouts: WorkoutsExport | null
+  books: BooksExport | null
+  githubEvents: GithubEventsExport | null
+  starredRepos: GithubStarredReposExport | null
+  articles: ArticlesExport | null
+  location: LocationExport | null
+  focus: FocusExport | null
+  theatreReviews: TheatreReviewsExport | null
+  timestamps: Record<string, string | null>
 }
 
-export async function fetchWithTimeout<T>(
-  url: string,
-  timeoutMs: number = 5000,
-): Promise<T | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+export async function fetchWithTimeout<T>(url: string, timeoutMs: number = 5000): Promise<T | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
-    const res = await fetch(url, { signal: controller.signal, cache: 'no-store' });
-    if (!res.ok) return null;
-    return (await res.json()) as T;
+    const res = await fetch(url, {signal: controller.signal, cache: 'no-store'})
+    if (!res.ok) {
+      return null
+    }
+    return (await res.json()) as T
   } catch {
-    return null;
+    return null
   } finally {
-    clearTimeout(timer);
+    clearTimeout(timer)
   }
 }
 
@@ -58,7 +57,7 @@ export async function fetchAllEndpoints(): Promise<FetchResult> {
     articles,
     location,
     focus,
-    theatreReviews,
+    theatreReviews
   ] = await Promise.all([
     fetchWithTimeout<HealthExport>(BASE + ENDPOINTS.health),
     fetchWithTimeout<SleepExport>(BASE + ENDPOINTS.sleep),
@@ -71,8 +70,8 @@ export async function fetchAllEndpoints(): Promise<FetchResult> {
       ? fetchWithTimeout<LocationExport>(BASE + ENDPOINTS.location)
       : Promise.resolve(null),
     fetchWithTimeout<FocusExport>(BASE + ENDPOINTS.focus),
-    fetchWithTimeout<TheatreReviewsExport>(BASE + ENDPOINTS.theatreReviews),
-  ]);
+    fetchWithTimeout<TheatreReviewsExport>(BASE + ENDPOINTS.theatreReviews)
+  ])
 
   return {
     health,
@@ -94,7 +93,7 @@ export async function fetchAllEndpoints(): Promise<FetchResult> {
       articles: articles?.generatedAt ?? null,
       location: location?.generatedAt ?? null,
       focus: focus?.generatedAt ?? null,
-      theatreReviews: theatreReviews?.generatedAt ?? null,
-    },
-  };
+      theatreReviews: theatreReviews?.generatedAt ?? null
+    }
+  }
 }

--- a/src/lib/runtime/live-data.ts
+++ b/src/lib/runtime/live-data.ts
@@ -1,46 +1,38 @@
-import { fetchAllEndpoints, fetchWithTimeout } from './api';
-import { updateFocusOverlay } from '@lifegames/web/runtime/updaters-focus';
-import { updateTheatreReviews } from '@lifegames/web/runtime/updaters-theatre';
-import { updatePollStatus } from './updaters-status';
-import { updateMovementRings, updateHeartRateFooter } from '@lifegames/web/runtime/updaters-movement';
+import {fetchAllEndpoints, fetchWithTimeout} from './api'
+import {updateFocusOverlay} from '@lifegames/web/runtime/updaters-focus'
+import {updateTheatreReviews} from '@lifegames/web/runtime/updaters-theatre'
+import {updatePollStatus} from './updaters-status'
+import {updateHeartRateFooter, updateMovementRings} from '@lifegames/web/runtime/updaters-movement'
 import type {
-  HealthExport,
-  SleepExport,
-  WorkoutsExport,
+  ArticlesExport,
   BooksExport,
+  FocusExport,
   GithubEventsExport,
   GithubStarredReposExport,
-  ArticlesExport,
+  HealthExport,
   LocationExport,
-  FocusExport,
+  SleepExport,
   TheatreReviewsExport,
-} from '@lifegames/web/types/exports';
-import { CLOUDFRONT_BASE, ENDPOINTS, HIDING_FOCUS_MODES, WEBSOCKET_URL } from '@lifegames/portal-contract/constants';
+  WorkoutsExport
+} from '@lifegames/web/types/exports'
+import {CLOUDFRONT_BASE, ENDPOINTS, HIDING_FOCUS_MODES, WEBSOCKET_URL} from '@lifegames/portal-contract/constants'
+import {adaptArticles, adaptBooks, adaptGithubEvents, adaptHealth, adaptSleep, adaptStarredRepos, adaptWorkouts} from '@lifegames/web/runtime/adapters'
+import {WSClient} from './ws-client'
 import {
-  adaptHealth,
-  adaptSleep,
-  adaptWorkouts,
-  adaptBooks,
-  adaptGithubEvents,
-  adaptStarredRepos,
-  adaptArticles,
-} from '@lifegames/web/runtime/adapters';
-import { WSClient } from './ws-client';
-import {
-  updateHeartRate,
-  updateWorkouts,
-  updateNightSummary,
-  updateHydration,
   updateBookshelf,
   updateDevActivityLog,
+  updateHeartRate,
+  updateHydration,
+  updateNightSummary,
   updateReadingFeed,
   updateStarredRepos,
   updateSystemStatus,
-} from '@lifegames/web/runtime/updaters';
-import { updatePlaceLeaderboardV3 } from '@lifegames/web/runtime/updaters-leaderboard-variations';
-import { updateExplorationOdometerV3 } from '@lifegames/web/runtime/updaters-odometer-variations';
-import { PollEngine } from './poll-engine';
-import type { ResourceKey } from '@lifegames/portal-contract/constants';
+  updateWorkouts
+} from '@lifegames/web/runtime/updaters'
+import {updatePlaceLeaderboardV3} from '@lifegames/web/runtime/updaters-leaderboard-variations'
+import {updateExplorationOdometerV3} from '@lifegames/web/runtime/updaters-odometer-variations'
+import {PollEngine} from './poll-engine'
+import type {ResourceKey} from '@lifegames/portal-contract/constants'
 
 const LIVE_CARDS = [
   'cardHR',
@@ -52,17 +44,17 @@ const LIVE_CARDS = [
   'cardReading',
   'cardStarredRepos',
   'cardTheatreReviews',
-  ...(import.meta.env.DEV ? ['cardPlaceLeaderboardV3', 'cardExplorationOdometerV3'] : []),
-];
+  ...(import.meta.env.DEV ? ['cardPlaceLeaderboardV3', 'cardExplorationOdometerV3'] : [])
+]
 
 // ── Module-scoped state for cross-resource dependencies ──────────────
-let lastHealth: HealthExport | undefined;
-let lastSleep: SleepExport | undefined;
-const timestamps: Record<string, string | null> = {};
-let engine: PollEngine | null = null;
+let lastHealth: HealthExport | undefined
+let lastSleep: SleepExport | undefined
+const timestamps: Record<string, string | null> = {}
+let engine: PollEngine | null = null
 // ws is hoisted to module scope so pagehide/pageshow lifecycle handlers can
 // reach it. It is null until startFetch() completes (null-guard before use).
-let ws: WSClient | null = null;
+let ws: WSClient | null = null
 
 // ── Focus-mode suppression (companion to the backend CloudFront edge gate) ──
 // While focus is a hiding mode the gate denies every suppressible artifact (403). The
@@ -72,20 +64,20 @@ let ws: WSClient | null = null;
 // shared with the backend gate + the DS overlay so the three layers can never drift — the web
 // layer is cosmetic + efficiency only; the edge gate is the real privacy boundary, so a
 // mismatch degrades to redundant 403 polls, never a data leak.
-const HIDING_FOCUS_MODE_SET = new Set<string>(HIDING_FOCUS_MODES);
-let suppressed = false;
+const HIDING_FOCUS_MODE_SET = new Set<string>(HIDING_FOCUS_MODES)
+let suppressed = false
 
 // The WS push is the authoritative focus source. A focus poll (the fallback for when the WS is
 // down) refetches the ~30s edge-cached focus.json, which lags a just-changed state. For a short
 // window after each push we ignore focus polls (they're reading the lagging cached value); after
 // the window the poll is trusted again, so a genuinely-dropped push self-heals (bounded lag)
 // rather than leaving the overlay permanently stuck on a stale value.
-const STALE_FOCUS_POLL_WINDOW_MS = 45_000;
-let wsConnected = false;
-let lastFocusPushAtMs = 0;
+const STALE_FOCUS_POLL_WINDOW_MS = 45_000
+let wsConnected = false
+let lastFocusPushAtMs = 0
 
 function isHiding(currentFocus: string | null): boolean {
-  return currentFocus !== null && HIDING_FOCUS_MODE_SET.has(currentFocus);
+  return currentFocus !== null && HIDING_FOCUS_MODE_SET.has(currentFocus)
 }
 
 /**
@@ -96,11 +88,13 @@ function isHiding(currentFocus: string | null): boolean {
 function applyFocus(currentFocus: string | null): void {
   // The overlay reflects the exact value every time (Work and Do Not Disturb are distinct
   // overlays), so this runs even when the hiding class is unchanged.
-  updateFocusOverlay(currentFocus ? { generatedAt: new Date().toISOString(), currentFocus } : null);
+  updateFocusOverlay(currentFocus ? {generatedAt: new Date().toISOString(), currentFocus} : null)
 
-  const hiding = isHiding(currentFocus);
-  if (hiding === suppressed) return;
-  suppressed = hiding;
+  const hiding = isHiding(currentFocus)
+  if (hiding === suppressed) {
+    return
+  }
+  suppressed = hiding
 
   // The overlay is opaque and full-screen, so it is the sole visual treatment — deliberately
   // DON'T re-skeleton the cards. `is-loading` only adds an opaque overlay (Card.astro) without
@@ -108,23 +102,25 @@ function applyFocus(currentFocus: string | null): void {
   // unchanged during hiding would be skipped by pollNow()'s fingerprint check on restore and
   // stay stuck showing a skeleton. On restore the overlay simply lifts to reveal the retained
   // (still-current) data; pollNow refreshes whatever actually changed.
-  engine?.setSuppressed(hiding);
-  if (!hiding) engine?.pollNow();
+  engine?.setSuppressed(hiding)
+  if (!hiding) {
+    void engine?.pollNow()
+  }
 }
 
 // ── Resource type map for discriminated validation ───────────────────
 type ResourceTypeMap = {
-  health: HealthExport;
-  sleep: SleepExport;
-  workouts: WorkoutsExport;
-  books: BooksExport;
-  githubEvents: GithubEventsExport;
-  articles: ArticlesExport;
-  location: LocationExport;
-  focus: FocusExport;
-  theatreReviews: TheatreReviewsExport;
-  starredRepos: GithubStarredReposExport;
-};
+  health: HealthExport
+  sleep: SleepExport
+  workouts: WorkoutsExport
+  books: BooksExport
+  githubEvents: GithubEventsExport
+  articles: ArticlesExport
+  location: LocationExport
+  focus: FocusExport
+  theatreReviews: TheatreReviewsExport
+  starredRepos: GithubStarredReposExport
+}
 
 const RESOURCE_DISCRIMINANTS: Record<ResourceKey, string> = {
   health: 'quantities',
@@ -136,70 +132,73 @@ const RESOURCE_DISCRIMINANTS: Record<ResourceKey, string> = {
   location: 'topPlaces',
   focus: 'currentFocus',
   theatreReviews: 'reviews',
-  starredRepos: 'repos',
-};
+  starredRepos: 'repos'
+}
 
-function validateResource<K extends ResourceKey>(
-  key: K,
-  rawData: unknown,
-): ResourceTypeMap[K] | null {
-  if (typeof rawData !== 'object' || rawData === null) return null;
-  const obj = rawData as Record<string, unknown>;
-  if (typeof obj.generatedAt !== 'string') return null;
-  if (!(RESOURCE_DISCRIMINANTS[key] in obj)) return null;
-  return rawData as ResourceTypeMap[K];
+function validateResource<K extends ResourceKey>(key: K, rawData: unknown): ResourceTypeMap[K] | null {
+  if (typeof rawData !== 'object' || rawData === null) {
+    return null
+  }
+  const obj = rawData as Record<string, unknown>
+  if (typeof obj.generatedAt !== 'string') {
+    return null
+  }
+  if (!(RESOURCE_DISCRIMINANTS[key] in obj)) {
+    return null
+  }
+  return rawData as ResourceTypeMap[K]
 }
 
 // ── Per-resource incremental update dispatch ─────────────────────────
 function handleResourceUpdate(key: ResourceKey, rawData: unknown): void {
-  const validated = validateResource(key, rawData);
+  const validated = validateResource(key, rawData)
   if (!validated) {
-    console.warn(`[live-data] ${key}: payload failed structural validation, preserving stale data`);
-    return;
+    console.warn(`[live-data] ${key}: payload failed structural validation, preserving stale data`)
+    return
   }
 
-  timestamps[key] = validated.generatedAt;
+  timestamps[key] = validated.generatedAt
 
   try {
     switch (key) {
       case 'health': {
-        const data = validated as ResourceTypeMap['health'];
-        lastHealth = data;
-        const health = adaptHealth(data, lastSleep ?? null);
-        updateHeartRate(health);
-        updateHeartRateFooter(health);
-        updateMovementRings(health);
-        updateHydration(health);
-        break;
+        const data = validated as ResourceTypeMap['health']
+        lastHealth = data
+        const health = adaptHealth(data, lastSleep ?? null)
+        updateHeartRate(health)
+        updateHeartRateFooter(health)
+        updateMovementRings(health)
+        updateHydration(health)
+        break
       }
       case 'sleep': {
-        const data = validated as ResourceTypeMap['sleep'];
-        lastSleep = data;
-        updateNightSummary(adaptSleep(data, lastHealth ?? null));
+        const data = validated as ResourceTypeMap['sleep']
+        lastSleep = data
+        updateNightSummary(adaptSleep(data, lastHealth ?? null))
         if (lastHealth) {
-          const health = adaptHealth(lastHealth, data);
-          updateHeartRate(health);
-          updateHeartRateFooter(health);
+          const health = adaptHealth(lastHealth, data)
+          updateHeartRate(health)
+          updateHeartRateFooter(health)
         }
-        break;
+        break
       }
       case 'workouts':
-        updateWorkouts(adaptWorkouts(validated as ResourceTypeMap['workouts']));
-        break;
+        updateWorkouts(adaptWorkouts(validated as ResourceTypeMap['workouts']))
+        break
       case 'books':
-        updateBookshelf(adaptBooks(validated as ResourceTypeMap['books']));
-        break;
+        updateBookshelf(adaptBooks(validated as ResourceTypeMap['books']))
+        break
       case 'githubEvents':
-        updateDevActivityLog(adaptGithubEvents(validated as ResourceTypeMap['githubEvents']));
-        break;
+        updateDevActivityLog(adaptGithubEvents(validated as ResourceTypeMap['githubEvents']))
+        break
       case 'articles':
-        updateReadingFeed(adaptArticles(validated as ResourceTypeMap['articles']));
-        break;
+        updateReadingFeed(adaptArticles(validated as ResourceTypeMap['articles']))
+        break
       case 'location': {
-        const data = validated as ResourceTypeMap['location'];
-        updatePlaceLeaderboardV3(data);
-        updateExplorationOdometerV3(data);
-        break;
+        const data = validated as ResourceTypeMap['location']
+        updatePlaceLeaderboardV3(data)
+        updateExplorationOdometerV3(data)
+        break
       }
       case 'focus': {
         // Route through applyFocus so a focus change detected by polling (e.g. the WS is down)
@@ -208,188 +207,200 @@ function handleResourceUpdate(key: ResourceKey, rawData: unknown): void {
         // focus.json — ignore it so a stale value can't re-apply over the fresh push (the
         // restore-linger bug). After the window the poll is trusted again, so a dropped push
         // self-heals (bounded lag) instead of leaving the overlay permanently stuck.
-        if (wsConnected && lastFocusPushAtMs > 0 && Date.now() - lastFocusPushAtMs < STALE_FOCUS_POLL_WINDOW_MS) break;
-        applyFocus((validated as ResourceTypeMap['focus']).currentFocus);
-        break;
+        if (wsConnected && lastFocusPushAtMs > 0 && Date.now() - lastFocusPushAtMs < STALE_FOCUS_POLL_WINDOW_MS) {
+          break
+        }
+        applyFocus((validated as ResourceTypeMap['focus']).currentFocus)
+        break
       }
       case 'theatreReviews':
-        updateTheatreReviews(validated as ResourceTypeMap['theatreReviews']);
-        break;
+        updateTheatreReviews(validated as ResourceTypeMap['theatreReviews'])
+        break
       case 'starredRepos':
-        updateStarredRepos(adaptStarredRepos(validated as ResourceTypeMap['starredRepos']));
-        break;
+        updateStarredRepos(adaptStarredRepos(validated as ResourceTypeMap['starredRepos']))
+        break
     }
 
-    updateSystemStatus(timestamps);
+    updateSystemStatus(timestamps)
   } catch (e) {
-    console.warn(`[live-data] ${key} incremental update failed, preserving stale data:`, e);
+    console.warn(`[live-data] ${key} incremental update failed, preserving stale data:`, e)
   }
 }
 
 // ── Skeleton loading ─────────────────────────────────────────────────
-LIVE_CARDS.forEach((id) => document.getElementById(id)?.classList.add('is-loading'));
+LIVE_CARDS.forEach((id) => document.getElementById(id)?.classList.add('is-loading'))
 
 // Fallback: remove skeletons after 8s if data never arrives
-let fallbackTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
-  LIVE_CARDS.forEach((id) => document.getElementById(id)?.classList.remove('is-loading'));
-}, 8000);
+const fallbackTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+  LIVE_CARDS.forEach((id) => document.getElementById(id)?.classList.remove('is-loading'))
+}, 8000)
 
 // ── Initial fetch + start continuous polling ─────────────────────────
 const startFetch = async () => {
   // Focus overlay (page-level concern). applyFocus drives the overlay immediately and, if
   // focus is already a hiding mode at load, sets suppression intent (engine is still null;
   // it is propagated via engine.setSuppressed(suppressed) below once created).
-  const focusBase = import.meta.env.DEV ? '/api/live' : CLOUDFRONT_BASE;
-  const focusData = await fetchWithTimeout<FocusExport>(focusBase + ENDPOINTS.focus);
-  applyFocus(focusData?.currentFocus ?? null);
+  const focusBase = import.meta.env.DEV ? '/api/live' : CLOUDFRONT_BASE
+  const focusData = await fetchWithTimeout<FocusExport>(focusBase + ENDPOINTS.focus)
+  applyFocus(focusData?.currentFocus ?? null)
 
-  const data = await fetchAllEndpoints();
+  const data = await fetchAllEndpoints()
 
   // Cache raw data for cross-resource dependencies
-  if (data.health) lastHealth = data.health;
-  if (data.sleep) lastSleep = data.sleep;
-  Object.assign(timestamps, data.timestamps);
+  if (data.health) {
+    lastHealth = data.health
+  }
+  if (data.sleep) {
+    lastSleep = data.sleep
+  }
+  Object.assign(timestamps, data.timestamps)
 
   // ── Initial DOM updates (identical to previous one-shot behavior) ──
   if (data.health) {
     try {
-      const health = adaptHealth(data.health, data.sleep);
-      updateHeartRate(health);
-      updateHeartRateFooter(health);
-      updateMovementRings(health);
-      updateHydration(health);
+      const health = adaptHealth(data.health, data.sleep)
+      updateHeartRate(health)
+      updateHeartRateFooter(health)
+      updateMovementRings(health)
+      updateHydration(health)
     } catch (e) {
-      console.warn('[live-data] Health update failed:', e);
+      console.warn('[live-data] Health update failed:', e)
     }
   }
 
   if (data.sleep) {
     try {
-      updateNightSummary(adaptSleep(data.sleep, data.health));
+      updateNightSummary(adaptSleep(data.sleep, data.health))
     } catch (e) {
-      console.warn('[live-data] Sleep update failed:', e);
+      console.warn('[live-data] Sleep update failed:', e)
     }
   }
 
   if (data.workouts !== undefined) {
     try {
-      updateWorkouts(adaptWorkouts(data.workouts));
+      updateWorkouts(adaptWorkouts(data.workouts))
     } catch (e) {
-      console.warn('[live-data] Workouts update failed:', e);
+      console.warn('[live-data] Workouts update failed:', e)
     }
   }
 
   if (data.books) {
     try {
-      updateBookshelf(adaptBooks(data.books));
+      updateBookshelf(adaptBooks(data.books))
     } catch (e) {
-      console.warn('[live-data] Books update failed:', e);
+      console.warn('[live-data] Books update failed:', e)
     }
   }
 
   if (data.githubEvents) {
     try {
-      updateDevActivityLog(adaptGithubEvents(data.githubEvents));
+      updateDevActivityLog(adaptGithubEvents(data.githubEvents))
     } catch (e) {
-      console.warn('[live-data] GitHub events update failed:', e);
+      console.warn('[live-data] GitHub events update failed:', e)
     }
   }
 
   if (data.articles) {
     try {
-      updateReadingFeed(adaptArticles(data.articles));
+      updateReadingFeed(adaptArticles(data.articles))
     } catch (e) {
-      console.warn('[live-data] Articles update failed:', e);
+      console.warn('[live-data] Articles update failed:', e)
     }
   }
 
   if (data.location) {
     try {
-      updatePlaceLeaderboardV3(data.location);
-      updateExplorationOdometerV3(data.location);
+      updatePlaceLeaderboardV3(data.location)
+      updateExplorationOdometerV3(data.location)
     } catch (e) {
-      console.warn('[live-data] Location update failed:', e);
+      console.warn('[live-data] Location update failed:', e)
     }
   }
 
   if (data.starredRepos) {
     try {
-      updateStarredRepos(adaptStarredRepos(data.starredRepos));
+      updateStarredRepos(adaptStarredRepos(data.starredRepos))
     } catch (e) {
-      console.warn('[live-data] Starred repos update failed:', e);
+      console.warn('[live-data] Starred repos update failed:', e)
     }
   }
 
   if (data.theatreReviews) {
     try {
-      updateTheatreReviews(data.theatreReviews);
+      updateTheatreReviews(data.theatreReviews)
     } catch (e) {
-      console.warn('[live-data] Theatre reviews update failed:', e);
+      console.warn('[live-data] Theatre reviews update failed:', e)
     }
   }
 
-  updateSystemStatus(data.timestamps);
+  updateSystemStatus(data.timestamps)
 
   // Clean up any remaining skeletons (handles partial endpoint failures) — but while
   // suppressed (loaded during a hiding mode), keep the cards skeletonised: the endpoints
   // 403 so there is no real data to show, and skeletons are the suppressed presentation.
   if (!suppressed) {
-    LIVE_CARDS.forEach((id) => document.getElementById(id)?.classList.remove('is-loading'));
+    LIVE_CARDS.forEach((id) => document.getElementById(id)?.classList.remove('is-loading'))
   }
-  if (fallbackTimer) clearTimeout(fallbackTimer);
+  if (fallbackTimer) {
+    clearTimeout(fallbackTimer)
+  }
 
   // ── Start continuous polling ───────────────────────────────────────
   engine = new PollEngine({
     onUpdate: handleResourceUpdate,
     onError: (key, err) => console.warn(`[poll] ${key} error:`, err.message),
-    onStatusChange: updatePollStatus,
-  });
-  engine.seed(data.timestamps);
+    onStatusChange: updatePollStatus
+  })
+  engine.seed(data.timestamps)
   // Propagate the load-time suppression intent set by applyFocus() (engine was null then).
-  engine.setSuppressed(suppressed);
-  engine.start();
+  engine.setSuppressed(suppressed)
+  engine.start()
 
   // Nudge the service worker to check for a new build now. The graceful,
   // state-preserving reload is owned entirely by the web app's sw-register.js
   // (window.__checkForSwUpdate); this runtime never reloads the page itself.
   // No-op if the global is absent (e.g. SW unsupported or registration failed).
   const nudgeServiceWorkerUpdate = (): void => {
-    const w = window as Window & { __checkForSwUpdate?: () => void; };
-    if (typeof w.__checkForSwUpdate === 'function') w.__checkForSwUpdate();
-  };
+    const w = window as Window & {__checkForSwUpdate?: () => void}
+    if (typeof w.__checkForSwUpdate === 'function') {
+      w.__checkForSwUpdate()
+    }
+  }
 
   // ── WebSocket push notifications (additive — polling continues if WS fails) ──
   ws = new WSClient({
     url: WEBSOCKET_URL,
     onUpdate: (resource) => {
-      const key = resource as ResourceKey;
+      const key = resource as ResourceKey
       if (key in ENDPOINTS) {
-        engine!.pollResource(key).catch(() => {});
+        engine!.pollResource(key).catch(() => {})
       }
     },
     // Focus push carries the new value → drive the overlay + suppression immediately,
     // without waiting on a refetch of the ~30s-edge-cached focus signal.
     onFocusChange: (currentFocus) => {
-      lastFocusPushAtMs = Date.now();
-      applyFocus(currentFocus);
+      lastFocusPushAtMs = Date.now()
+      applyFocus(currentFocus)
     },
     // A new web build is live (deploy push): nudge the SW to fetch the new sw.js.
     onAppUpdate: () => nudgeServiceWorkerUpdate(),
     onStateChange: (connected) => {
-      wsConnected = connected;
-      engine!.setMode(connected ? 'passive' : 'active');
+      wsConnected = connected
+      engine!.setMode(connected ? 'passive' : 'active')
       // On (re)connect — e.g. tab refocus after the WS dropped while hidden —
       // also re-check, in case an app-update push was missed while disconnected.
-      if (connected) nudgeServiceWorkerUpdate();
-    },
-  });
-  ws.connect();
-};
+      if (connected) {
+        nudgeServiceWorkerUpdate()
+      }
+    }
+  })
+  ws.connect()
+}
 
 if ('requestIdleCallback' in window) {
-  requestIdleCallback(() => startFetch(), { timeout: 500 });
+  requestIdleCallback(() => void startFetch(), {timeout: 500})
 } else {
-  setTimeout(startFetch, 200);
+  setTimeout(() => void startFetch(), 200)
 }
 
 // ── BFCache lifecycle handlers ────────────────────────────────────────
@@ -398,10 +409,14 @@ if ('requestIdleCallback' in window) {
 // (an open WebSocket is a hard Chromium BFCache blocker).
 window.addEventListener('pagehide', (event) => {
   if ((event as PageTransitionEvent).persisted) {
-    if (engine) engine.stop();
-    if (ws) ws.disconnect();
+    if (engine) {
+      engine.stop()
+    }
+    if (ws) {
+      ws.disconnect()
+    }
   }
-});
+})
 
 // pageshow(persisted=true): browser is restoring the page from BFCache.
 // Restart poll timers + reconnect the WebSocket, then trigger an immediate
@@ -412,9 +427,11 @@ window.addEventListener('pagehide', (event) => {
 window.addEventListener('pageshow', (event) => {
   if ((event as PageTransitionEvent).persisted) {
     if (engine) {
-      engine.start();
-      engine.pollNow();
+      engine.start()
+      void engine.pollNow()
     }
-    if (ws) ws.connect();
+    if (ws) {
+      ws.connect()
+    }
   }
-});
+})

--- a/src/lib/runtime/poll-engine.ts
+++ b/src/lib/runtime/poll-engine.ts
@@ -1,64 +1,66 @@
-import { CLOUDFRONT_BASE, ENDPOINTS, type ResourceKey } from '@lifegames/portal-contract/constants';
+import {CLOUDFRONT_BASE, ENDPOINTS, type ResourceKey} from '@lifegames/portal-contract/constants'
 
 /** Connection/poll status the engine emits via `onStatusChange`; rendered by `updaters-status`. */
 export interface PollStatus {
-  connected: boolean;
-  lastPollAt: string | null;
-  errorCounts: Partial<Record<ResourceKey, number>>;
-  wsConnected?: boolean;
+  connected: boolean
+  lastPollAt: string | null
+  errorCounts: Partial<Record<ResourceKey, number>>
+  wsConnected?: boolean
 }
 
-type ResourceCallback = (key: ResourceKey, data: unknown) => void;
-type ErrorCallback = (key: ResourceKey, error: Error) => void;
-type StatusCallback = (status: PollStatus) => void;
+type ResourceCallback = (key: ResourceKey, data: unknown) => void
+type ErrorCallback = (key: ResourceKey, error: Error) => void
+type StatusCallback = (status: PollStatus) => void
 
 interface PollEngineOptions {
-  onUpdate: ResourceCallback;
-  onError?: ErrorCallback;
-  onStatusChange?: StatusCallback;
+  onUpdate: ResourceCallback
+  onError?: ErrorCallback
+  onStatusChange?: StatusCallback
 }
 
 // Fast tier: resources that change frequently (iOS syncs multiple times per hour)
-const FAST_KEYS: ResourceKey[] = ['health', 'sleep', 'workouts', 'focus'];
+const FAST_KEYS: ResourceKey[] = ['health', 'sleep', 'workouts', 'focus']
 // Slow tier: resources that change infrequently
 const SLOW_KEYS: ResourceKey[] = [
   'books',
   'articles',
   'githubEvents',
   'starredRepos',
-  'theatreReviews',
-];
+  'theatreReviews'
+]
 // DEV-only: location polling (tree-shaken in production)
-const DEV_KEYS: ResourceKey[] = import.meta.env.DEV ? ['location'] : [];
+const DEV_KEYS: ResourceKey[] = import.meta.env.DEV ? ['location'] : []
 
-const FAST_INTERVAL_MS = 30_000;
-const SLOW_INTERVAL_MS = 120_000;
-const PASSIVE_FAST_INTERVAL_MS = 120_000;
-const PASSIVE_SLOW_INTERVAL_MS = 300_000;
+const FAST_INTERVAL_MS = 30_000
+const SLOW_INTERVAL_MS = 120_000
+const PASSIVE_FAST_INTERVAL_MS = 120_000
+const PASSIVE_SLOW_INTERVAL_MS = 300_000
 
-const BASE = import.meta.env.DEV ? '/api/live' : CLOUDFRONT_BASE;
+const BASE = import.meta.env.DEV ? '/api/live' : CLOUDFRONT_BASE
 
 export class PollEngine {
-  private fingerprints = new Map<ResourceKey, string>();
-  private errorCounts = new Map<ResourceKey, number>();
-  private fastTimer: ReturnType<typeof setInterval> | null = null;
-  private slowTimer: ReturnType<typeof setInterval> | null = null;
-  private running = false;
-  private lastPollAt: string | null = null;
-  private opts: PollEngineOptions;
-  private visibilityHandler: (() => void) | null = null;
-  private wsConnected = false;
-  private mode: 'active' | 'passive' = 'active';
-  private suppressed = false;
+  private fingerprints = new Map<ResourceKey, string>()
+  private errorCounts = new Map<ResourceKey, number>()
+  private fastTimer: ReturnType<typeof setInterval> | null = null
+  private slowTimer: ReturnType<typeof setInterval> | null = null
+  private running = false
+  private lastPollAt: string | null = null
+  private opts: PollEngineOptions
+  private visibilityHandler: (() => void) | null = null
+  private wsConnected = false
+  private mode: 'active' | 'passive' = 'active'
+  private suppressed = false
 
   constructor(opts: PollEngineOptions) {
-    this.opts = opts;
+    this.opts = opts
   }
 
   /** Seed with initial generatedAt fingerprints from fetchAllEndpoints */
   seed(timestamps: Record<string, string | null>): void {
     for (const [key, val] of Object.entries(timestamps)) {
-      if (val) this.fingerprints.set(key as ResourceKey, val);
+      if (val) {
+        this.fingerprints.set(key as ResourceKey, val)
+      }
     }
   }
 
@@ -70,59 +72,63 @@ export class PollEngine {
    * `pollNow()` refetches everything fresh.
    */
   setSuppressed(suppressed: boolean): void {
-    this.suppressed = suppressed;
+    this.suppressed = suppressed
   }
 
   /** Switch between active (no WS) and passive (WS connected) polling intervals */
   setMode(mode: 'active' | 'passive'): void {
-    if (this.mode === mode) return;
-    this.mode = mode;
-    this.wsConnected = mode === 'passive';
-    if (this.running) {
-      this.clearTimers();
-      this.startTimers();
+    if (this.mode === mode) {
+      return
     }
-    this.emitStatus();
+    this.mode = mode
+    this.wsConnected = mode === 'passive'
+    if (this.running) {
+      this.clearTimers()
+      this.startTimers()
+    }
+    this.emitStatus()
   }
 
   start(): void {
-    if (this.running) return;
-    this.running = true;
+    if (this.running) {
+      return
+    }
+    this.running = true
 
-    this.startTimers();
+    this.startTimers()
 
     this.visibilityHandler = () => {
       if (document.hidden) {
-        this.pause();
+        this.pause()
       } else {
-        this.resume();
+        this.resume()
       }
-    };
-    document.addEventListener('visibilitychange', this.visibilityHandler);
+    }
+    document.addEventListener('visibilitychange', this.visibilityHandler)
 
-    this.emitStatus();
+    this.emitStatus()
   }
 
   stop(): void {
-    this.running = false;
-    this.clearTimers();
+    this.running = false
+    this.clearTimers()
     if (this.visibilityHandler) {
-      document.removeEventListener('visibilitychange', this.visibilityHandler);
-      this.visibilityHandler = null;
+      document.removeEventListener('visibilitychange', this.visibilityHandler)
+      this.visibilityHandler = null
     }
-    this.emitStatus();
+    this.emitStatus()
   }
 
   /** Immediately poll a specific resource */
   async pollResource(key: ResourceKey): Promise<void> {
-    await this.fetchResource(key);
-    this.lastPollAt = new Date().toISOString();
-    this.emitStatus();
+    await this.fetchResource(key)
+    this.lastPollAt = new Date().toISOString()
+    this.emitStatus()
   }
 
   /** Immediately poll all resources */
   async pollNow(): Promise<void> {
-    await this.pollTier([...FAST_KEYS, ...DEV_KEYS, ...SLOW_KEYS]);
+    await this.pollTier([...FAST_KEYS, ...DEV_KEYS, ...SLOW_KEYS])
   }
 
   getStatus(): PollStatus {
@@ -130,91 +136,97 @@ export class PollEngine {
       connected: this.running && navigator.onLine,
       lastPollAt: this.lastPollAt,
       errorCounts: Object.fromEntries(this.errorCounts),
-      wsConnected: this.wsConnected,
-    };
+      wsConnected: this.wsConnected
+    }
   }
 
   private pause(): void {
-    this.clearTimers();
+    this.clearTimers()
   }
 
   private resume(): void {
-    if (!this.running) return;
+    if (!this.running) {
+      return
+    }
     // Immediate poll on tab return, then restart timers
-    this.pollNow();
-    this.startTimers();
+    void this.pollNow()
+    this.startTimers()
   }
 
   private startTimers(): void {
-    const fastMs = this.mode === 'passive' ? PASSIVE_FAST_INTERVAL_MS : FAST_INTERVAL_MS;
-    const slowMs = this.mode === 'passive' ? PASSIVE_SLOW_INTERVAL_MS : SLOW_INTERVAL_MS;
-    this.fastTimer = setInterval(() => this.pollTier([...FAST_KEYS, ...DEV_KEYS]), fastMs);
-    this.slowTimer = setInterval(() => this.pollTier(SLOW_KEYS), slowMs);
+    const fastMs = this.mode === 'passive' ? PASSIVE_FAST_INTERVAL_MS : FAST_INTERVAL_MS
+    const slowMs = this.mode === 'passive' ? PASSIVE_SLOW_INTERVAL_MS : SLOW_INTERVAL_MS
+    this.fastTimer = setInterval(() => void this.pollTier([...FAST_KEYS, ...DEV_KEYS]), fastMs)
+    this.slowTimer = setInterval(() => void this.pollTier(SLOW_KEYS), slowMs)
   }
 
   private clearTimers(): void {
     if (this.fastTimer) {
-      clearInterval(this.fastTimer);
-      this.fastTimer = null;
+      clearInterval(this.fastTimer)
+      this.fastTimer = null
     }
     if (this.slowTimer) {
-      clearInterval(this.slowTimer);
-      this.slowTimer = null;
+      clearInterval(this.slowTimer)
+      this.slowTimer = null
     }
   }
 
   private async pollTier(keys: ResourceKey[]): Promise<void> {
-    await Promise.all(keys.map((k) => this.fetchResource(k)));
-    this.lastPollAt = new Date().toISOString();
-    this.emitStatus();
+    await Promise.all(keys.map((k) => this.fetchResource(k)))
+    this.lastPollAt = new Date().toISOString()
+    this.emitStatus()
   }
 
   private async fetchResource(key: ResourceKey): Promise<void> {
     // While suppressed, every gated resource returns 403 — don't hammer the edge gate.
     // `focus` is exempt from the gate and stays polled (overlay fallback).
-    if (this.suppressed && key !== 'focus') return;
+    if (this.suppressed && key !== 'focus') {
+      return
+    }
 
     // Append ?_poll=1 to bypass Workbox service worker
-    const url = BASE + ENDPOINTS[key] + '?_poll=1';
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 5000);
+    const url = BASE + ENDPOINTS[key] + '?_poll=1'
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 5000)
 
     try {
-      const res = await fetch(url, { signal: controller.signal, cache: 'no-store' });
-      clearTimeout(timer);
+      const res = await fetch(url, {signal: controller.signal, cache: 'no-store'})
+      clearTimeout(timer)
 
       if (!res.ok) {
-        this.recordError(key, new Error(`HTTP ${res.status}`));
-        return;
+        this.recordError(key, new Error(`HTTP ${res.status}`))
+        return
       }
 
-      const data = await res.json();
+      const data = await res.json()
 
       // Compare generatedAt fingerprint — skip update if unchanged
-      const generatedAt = (data as { generatedAt?: string; }).generatedAt;
-      const prev = this.fingerprints.get(key);
+      const generatedAt = (data as {generatedAt?: string}).generatedAt
+      const prev = this.fingerprints.get(key)
 
       if (generatedAt && generatedAt === prev) {
-        this.errorCounts.delete(key);
-        return;
+        this.errorCounts.delete(key)
+        return
       }
 
-      if (generatedAt) this.fingerprints.set(key, generatedAt);
-      this.errorCounts.delete(key);
-      this.opts.onUpdate(key, data);
+      if (generatedAt) {
+        this.fingerprints.set(key, generatedAt)
+      }
+      this.errorCounts.delete(key)
+      this.opts.onUpdate(key, data)
     } catch (err) {
-      clearTimeout(timer);
-      this.recordError(key, err instanceof Error ? err : new Error(String(err)));
+      clearTimeout(timer)
+      this.recordError(key, err instanceof Error ? err : new Error(String(err)))
     }
   }
 
   private recordError(key: ResourceKey, error: Error): void {
-    const count = (this.errorCounts.get(key) ?? 0) + 1;
-    this.errorCounts.set(key, count);
-    this.opts.onError?.(key, error);
+    const count = (this.errorCounts.get(key) ?? 0) + 1
+    this.errorCounts.set(key, count)
+    this.opts.onError?.(key, error)
   }
 
   private emitStatus(): void {
-    this.opts.onStatusChange?.(this.getStatus());
+    this.opts.onStatusChange?.(this.getStatus())
   }
 }

--- a/src/lib/runtime/updaters-status.ts
+++ b/src/lib/runtime/updaters-status.ts
@@ -1,27 +1,29 @@
-import type { PollStatus } from './poll-engine';
+import type {PollStatus} from './poll-engine'
 
 /** Update the connection status indicator in the top bar */
 export function updatePollStatus(status: PollStatus): void {
-  const dot = document.querySelector<HTMLElement>('.poll-dot');
-  const label = document.querySelector<HTMLElement>('.poll-label');
-  if (!dot || !label) return;
+  const dot = document.querySelector<HTMLElement>('.poll-dot')
+  const label = document.querySelector<HTMLElement>('.poll-label')
+  if (!dot || !label) {
+    return
+  }
 
-  const online = navigator.onLine;
-  const errorEntries = Object.values(status.errorCounts).filter((c): c is number => c != null);
-  const hasErrors = errorEntries.some((c) => c >= 3);
-  const allFailing = !online || (errorEntries.length > 0 && errorEntries.every((c) => c >= 3));
+  const online = navigator.onLine
+  const errorEntries = Object.values(status.errorCounts).filter((c): c is number => c != null)
+  const hasErrors = errorEntries.some((c) => c >= 3)
+  const allFailing = !online || (errorEntries.length > 0 && errorEntries.every((c) => c >= 3))
 
   if (allFailing) {
-    dot.className = 'poll-dot poll-dot--error';
-    label.textContent = online ? 'Degraded' : 'Offline';
+    dot.className = 'poll-dot poll-dot--error'
+    label.textContent = online ? 'Degraded' : 'Offline'
   } else if (hasErrors) {
-    dot.className = 'poll-dot poll-dot--warn';
-    label.textContent = 'Partial';
+    dot.className = 'poll-dot poll-dot--warn'
+    label.textContent = 'Partial'
   } else if (status.connected) {
-    dot.className = 'poll-dot poll-dot--ok';
-    label.textContent = status.wsConnected ? 'Live' : 'Polling';
+    dot.className = 'poll-dot poll-dot--ok'
+    label.textContent = status.wsConnected ? 'Live' : 'Polling'
   } else {
-    dot.className = 'poll-dot poll-dot--off';
-    label.textContent = '';
+    dot.className = 'poll-dot poll-dot--off'
+    label.textContent = ''
   }
 }

--- a/src/lib/runtime/ws-client.ts
+++ b/src/lib/runtime/ws-client.ts
@@ -1,39 +1,39 @@
-export type WSMessageHandler = (resource: string) => void;
+export type WSMessageHandler = (resource: string) => void
 
 export interface WSClientOptions {
-  url: string;
-  onUpdate: WSMessageHandler;
+  url: string
+  onUpdate: WSMessageHandler
   /**
    * Fired on a focus {type:'update', resource:'focus'} push that carries the new focus
    * value, so the client can drive the overlay immediately without refetching the
    * (edge-cached) focus signal. A focus push lacking currentFocus falls through to onUpdate.
    */
-  onFocusChange?: (currentFocus: string) => void;
+  onFocusChange?: (currentFocus: string) => void
   /** Fired on a {type:'app-update'} push (a new web build is live). Optional build id. */
-  onAppUpdate?: (build?: string) => void;
-  onStateChange?: (connected: boolean) => void;
-  heartbeatIntervalMs?: number;
-  reconnectBaseMs?: number;
-  reconnectMaxMs?: number;
+  onAppUpdate?: (build?: string) => void
+  onStateChange?: (connected: boolean) => void
+  heartbeatIntervalMs?: number
+  reconnectBaseMs?: number
+  reconnectMaxMs?: number
 }
 
-export type WSState = 'connecting' | 'connected' | 'disconnected';
+export type WSState = 'connecting' | 'connected' | 'disconnected'
 
-const DEFAULT_HEARTBEAT_MS = 5 * 60 * 1000;
-const DEFAULT_RECONNECT_BASE_MS = 1000;
-const DEFAULT_RECONNECT_MAX_MS = 30_000;
-const MAX_CONNECTION_MS = 115 * 60 * 1000;
+const DEFAULT_HEARTBEAT_MS = 5 * 60 * 1000
+const DEFAULT_RECONNECT_BASE_MS = 1000
+const DEFAULT_RECONNECT_MAX_MS = 30_000
+const MAX_CONNECTION_MS = 115 * 60 * 1000
 
 export class WSClient {
-  private ws: WebSocket | null = null;
-  private state: WSState = 'disconnected';
-  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private maxConnectionTimer: ReturnType<typeof setTimeout> | null = null;
-  private reconnectAttempt = 0;
-  private intentionalClose = false;
-  private visibilityHandler: (() => void) | null = null;
-  private opts: Required<WSClientOptions>;
+  private ws: WebSocket | null = null
+  private state: WSState = 'disconnected'
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private maxConnectionTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempt = 0
+  private intentionalClose = false
+  private visibilityHandler: (() => void) | null = null
+  private opts: Required<WSClientOptions>
 
   constructor(opts: WSClientOptions) {
     this.opts = {
@@ -43,180 +43,174 @@ export class WSClient {
       heartbeatIntervalMs: DEFAULT_HEARTBEAT_MS,
       reconnectBaseMs: DEFAULT_RECONNECT_BASE_MS,
       reconnectMaxMs: DEFAULT_RECONNECT_MAX_MS,
-      ...opts,
-    };
+      ...opts
+    }
   }
 
   connect(): void {
-    this.intentionalClose = false;
-    this.openSocket();
+    this.intentionalClose = false
+    this.openSocket()
 
     this.visibilityHandler = () => {
       if (document.hidden) {
-        this.intentionalClose = true;
-        this.closeSocket();
+        this.intentionalClose = true
+        this.closeSocket()
       } else {
-        this.intentionalClose = false;
-        this.scheduleReconnect(0);
+        this.intentionalClose = false
+        this.scheduleReconnect(0)
       }
-    };
-    document.addEventListener('visibilitychange', this.visibilityHandler);
+    }
+    document.addEventListener('visibilitychange', this.visibilityHandler)
   }
 
   disconnect(): void {
-    this.intentionalClose = true;
-    this.clearAllTimers();
+    this.intentionalClose = true
+    this.clearAllTimers()
     if (this.visibilityHandler) {
-      document.removeEventListener('visibilitychange', this.visibilityHandler);
-      this.visibilityHandler = null;
+      document.removeEventListener('visibilitychange', this.visibilityHandler)
+      this.visibilityHandler = null
     }
-    this.closeSocket();
+    this.closeSocket()
   }
 
   getState(): WSState {
-    return this.state;
+    return this.state
   }
 
   private openSocket(): void {
-    this.setState('connecting');
-    const ws = new WebSocket(this.opts.url);
-    this.ws = ws;
+    this.setState('connecting')
+    const ws = new WebSocket(this.opts.url)
+    this.ws = ws
 
     ws.onopen = () => {
-      this.reconnectAttempt = 0;
-      this.setState('connected');
-      this.startHeartbeat();
-      this.startMaxConnectionTimer();
-    };
+      this.reconnectAttempt = 0
+      this.setState('connected')
+      this.startHeartbeat()
+      this.startMaxConnectionTimer()
+    }
 
     ws.onmessage = (event: MessageEvent) => {
       try {
-        const msg = JSON.parse(event.data as string) as {
-          type?: string;
-          resource?: string;
-          build?: string;
-          currentFocus?: string;
-        };
+        const msg = JSON.parse(event.data as string) as {type?: string; resource?: string; build?: string; currentFocus?: string}
         if (msg.type === 'update' && msg.resource) {
           // A focus push carries the new focus value → drive the overlay immediately, no
           // refetch (the focus signal is edge-cached ~30s). Older backends that omit
           // currentFocus fall through to the generic resource refetch.
           if (msg.resource === 'focus' && typeof msg.currentFocus === 'string') {
-            this.opts.onFocusChange(msg.currentFocus);
+            this.opts.onFocusChange(msg.currentFocus)
           } else {
-            this.opts.onUpdate(msg.resource);
+            this.opts.onUpdate(msg.resource)
           }
         } else if (msg.type === 'app-update') {
-          this.opts.onAppUpdate(msg.build);
+          this.opts.onAppUpdate(msg.build)
         }
         // Ignore 'pong' and unknown types
       } catch {
         // Ignore malformed messages
       }
-    };
+    }
 
     ws.onclose = () => {
-      this.clearHeartbeat();
-      this.clearMaxConnectionTimer();
-      this.setState('disconnected');
+      this.clearHeartbeat()
+      this.clearMaxConnectionTimer()
+      this.setState('disconnected')
       if (!this.intentionalClose) {
-        this.scheduleReconnect(this.currentDelay());
-        this.advanceBackoff();
+        this.scheduleReconnect(this.currentDelay())
+        this.advanceBackoff()
       }
-    };
+    }
 
     ws.onerror = () => {
       // onclose fires after onerror; reconnection handled there
-    };
+    }
   }
 
   private closeSocket(): void {
     if (this.ws) {
-      this.ws.onopen = null;
-      this.ws.onmessage = null;
-      this.ws.onclose = null;
-      this.ws.onerror = null;
-      this.ws.close();
-      this.ws = null;
+      this.ws.onopen = null
+      this.ws.onmessage = null
+      this.ws.onclose = null
+      this.ws.onerror = null
+      this.ws.close()
+      this.ws = null
     }
-    this.clearHeartbeat();
-    this.clearMaxConnectionTimer();
-    this.setState('disconnected');
+    this.clearHeartbeat()
+    this.clearMaxConnectionTimer()
+    this.setState('disconnected')
   }
 
   private startHeartbeat(): void {
-    this.clearHeartbeat();
+    this.clearHeartbeat()
     this.heartbeatTimer = setInterval(() => {
       if (this.ws?.readyState === WebSocket.OPEN) {
-        this.ws.send(JSON.stringify({ action: 'ping' }));
+        this.ws.send(JSON.stringify({action: 'ping'}))
       }
-    }, this.opts.heartbeatIntervalMs);
+    }, this.opts.heartbeatIntervalMs)
   }
 
   private clearHeartbeat(): void {
     if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
-      this.heartbeatTimer = null;
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
     }
   }
 
   private startMaxConnectionTimer(): void {
-    this.clearMaxConnectionTimer();
+    this.clearMaxConnectionTimer()
     this.maxConnectionTimer = setTimeout(() => {
       // Force close and reconnect after 1h55m
-      this.intentionalClose = false;
-      this.closeSocket();
-      this.scheduleReconnect(0);
-    }, MAX_CONNECTION_MS);
+      this.intentionalClose = false
+      this.closeSocket()
+      this.scheduleReconnect(0)
+    }, MAX_CONNECTION_MS)
   }
 
   private clearMaxConnectionTimer(): void {
     if (this.maxConnectionTimer) {
-      clearTimeout(this.maxConnectionTimer);
-      this.maxConnectionTimer = null;
+      clearTimeout(this.maxConnectionTimer)
+      this.maxConnectionTimer = null
     }
   }
 
   private scheduleReconnect(delayMs: number): void {
     if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
     }
     this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = null;
+      this.reconnectTimer = null
       if (!this.intentionalClose) {
-        this.openSocket();
+        this.openSocket()
       }
-    }, delayMs);
+    }, delayMs)
   }
 
   private currentDelay(): number {
-    const base = Math.min(
-      this.opts.reconnectBaseMs * Math.pow(2, this.reconnectAttempt),
-      this.opts.reconnectMaxMs,
-    );
-    return base * (0.5 + Math.random() * 0.5);
+    const base = Math.min(this.opts.reconnectBaseMs * Math.pow(2, this.reconnectAttempt), this.opts.reconnectMaxMs)
+    return base * (0.5 + Math.random() * 0.5)
   }
 
   private advanceBackoff(): void {
-    const maxAttempts = Math.ceil(Math.log2(this.opts.reconnectMaxMs / this.opts.reconnectBaseMs));
+    const maxAttempts = Math.ceil(Math.log2(this.opts.reconnectMaxMs / this.opts.reconnectBaseMs))
     if (this.reconnectAttempt < maxAttempts) {
-      this.reconnectAttempt++;
+      this.reconnectAttempt++
     }
   }
 
   private clearAllTimers(): void {
-    this.clearHeartbeat();
-    this.clearMaxConnectionTimer();
+    this.clearHeartbeat()
+    this.clearMaxConnectionTimer()
     if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
     }
   }
 
   private setState(next: WSState): void {
-    if (this.state === next) return;
-    this.state = next;
-    this.opts.onStateChange?.(next === 'connected');
+    if (this.state === next) {
+      return
+    }
+    this.state = next
+    this.opts.onStateChange?.(next === 'connected')
   }
 }

--- a/src/pages/humans.txt.ts
+++ b/src/pages/humans.txt.ts
@@ -2,12 +2,12 @@
 // humanstxt.org format — they live here, not in the copy package. All
 // customer-facing string values (name, title, location, URLs, stack, etc.)
 // are sourced from @lifegames/copy to honour the zero-duplication invariant.
-import identity from '@lifegames/copy/identity.flat.json';
+import identity from '@lifegames/copy/identity.flat.json'
 
-export const prerender = true;
+export const prerender = true
 
 export function GET(): Response {
-  const lastUpdate = new Date().toISOString().slice(0, 10);
+  const lastUpdate = new Date().toISOString().slice(0, 10)
 
   const body = `/* TEAM */
 Name: ${identity.person.name}
@@ -23,9 +23,7 @@ Last update: ${lastUpdate}
 Software: ${identity.humansTxt.stack.join(', ')}
 Hosting: ${identity.humansTxt.hosting}
 Standards: ${identity.humansTxt.standards}
-`.trimStart();
+`.trimStart()
 
-  return new Response(body, {
-    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-  });
+  return new Response(body, {headers: {'Content-Type': 'text/plain; charset=utf-8'}})
 }

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,14 +1,14 @@
-import { SITE_URL } from '@lifegames/portal-contract/constants';
+import {SITE_URL} from '@lifegames/portal-contract/constants'
 
 // /llms.txt has no dedicated LLM_CONTENT_PATHS constant — it is a Cloudflare Pages
 // Function proxy (functions/llms.txt.ts) that does not map to a CloudFront path.
 // The path is kept as a literal here intentionally; if it ever moves, update both files.
-const LLMS_TXT_PATH = '/llms.txt';
+const LLMS_TXT_PATH = '/llms.txt'
 
-export const prerender = true;
+export const prerender = true
 
 export function GET(): Response {
-  const sitemap = `${SITE_URL}/sitemap-index.xml`;
+  const sitemap = `${SITE_URL}/sitemap-index.xml`
 
   const body = `# Crawlers
 User-agent: *
@@ -88,9 +88,7 @@ Allow: /
 
 # LLM context: ${SITE_URL}${LLMS_TXT_PATH}
 Sitemap: ${sitemap}
-`.trimStart();
+`.trimStart()
 
-  return new Response(body, {
-    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-  });
+  return new Response(body, {headers: {'Content-Type': 'text/plain; charset=utf-8'}})
 }

--- a/tests/audit/check-analytics.test.ts
+++ b/tests/audit/check-analytics.test.ts
@@ -1,41 +1,41 @@
-import { describe, it, expect } from 'vitest';
-import { evaluateBeacons } from '../../scripts/audit/check-analytics.mjs';
+import {describe, expect, it} from 'vitest'
+import {evaluateBeacons} from '../../scripts/audit/check-analytics.mjs'
 
-function fullSeen(
-  overrides: Record<string, { status: number; url: string; }> = {},
-): Map<string, { status: number; url: string; }> {
+function fullSeen(overrides: Record<string, {status: number; url: string}> = {}): Map<string, {status: number; url: string}> {
   const base = new Map([
-    ['cf-insights-js', { status: 200, url: 'https://jonathanlloyd.me/cf-insights.js' }],
-    ['cf-rum', { status: 204, url: 'https://jonathanlloyd.me/cf-rum' }],
-    ['sa-script', { status: 200, url: 'https://jonathanlloyd.me/sa' }],
-    ['sa-pageview-pixel', { status: 202, url: 'https://jonathanlloyd.me/simple/simple.gif' }],
-  ]);
-  for (const [k, v] of Object.entries(overrides)) base.set(k, v);
-  return base;
+    ['cf-insights-js', {status: 200, url: 'https://jonathanlloyd.me/cf-insights.js'}],
+    ['cf-rum', {status: 204, url: 'https://jonathanlloyd.me/cf-rum'}],
+    ['sa-script', {status: 200, url: 'https://jonathanlloyd.me/sa'}],
+    ['sa-pageview-pixel', {status: 202, url: 'https://jonathanlloyd.me/simple/simple.gif'}]
+  ])
+  for (const [k, v] of Object.entries(overrides)) {
+    base.set(k, v)
+  }
+  return base
 }
 
 describe('evaluateBeacons', () => {
   it('all four beacons present with their real observed status codes produce zero findings', () => {
-    expect(evaluateBeacons(fullSeen())).toEqual([]);
-  });
+    expect(evaluateBeacons(fullSeen())).toEqual([])
+  })
 
   it('a beacon that never fired within the wait window fails as missing', () => {
-    const seen = fullSeen();
-    seen.delete('sa-script');
-    const findings = evaluateBeacons(seen);
-    expect(findings).toEqual([expect.objectContaining({ severity: 'fail', id: 'analytics-sa-script-missing' })]);
-  });
+    const seen = fullSeen()
+    seen.delete('sa-script')
+    const findings = evaluateBeacons(seen)
+    expect(findings).toEqual([expect.objectContaining({severity: 'fail', id: 'analytics-sa-script-missing'})])
+  })
 
   it('known-answer: the SA pageview pixel returning 200 instead of the real 202 contract fails with a specific message', () => {
-    const seen = fullSeen({ 'sa-pageview-pixel': { status: 200, url: 'https://jonathanlloyd.me/simple/simple.gif' } });
-    const findings = evaluateBeacons(seen);
-    expect(findings).toEqual([expect.objectContaining({ severity: 'fail', id: 'analytics-sa-pageview-pixel-status' })]);
-    expect(findings[0].message).toContain('202');
-  });
+    const seen = fullSeen({'sa-pageview-pixel': {status: 200, url: 'https://jonathanlloyd.me/simple/simple.gif'}})
+    const findings = evaluateBeacons(seen)
+    expect(findings).toEqual([expect.objectContaining({severity: 'fail', id: 'analytics-sa-pageview-pixel-status'})])
+    expect(findings[0].message).toContain('202')
+  })
 
   it('cf-rum returning a non-2xx status fails', () => {
-    const seen = fullSeen({ 'cf-rum': { status: 500, url: 'https://jonathanlloyd.me/cf-rum' } });
-    const findings = evaluateBeacons(seen);
-    expect(findings).toEqual([expect.objectContaining({ severity: 'fail', id: 'analytics-cf-rum-status' })]);
-  });
-});
+    const seen = fullSeen({'cf-rum': {status: 500, url: 'https://jonathanlloyd.me/cf-rum'}})
+    const findings = evaluateBeacons(seen)
+    expect(findings).toEqual([expect.objectContaining({severity: 'fail', id: 'analytics-cf-rum-status'})])
+  })
+})

--- a/tests/audit/check-feeds.test.ts
+++ b/tests/audit/check-feeds.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { validateFeedXml, validateFeedJson } from '../../scripts/audit/check-feeds.mjs';
+import {describe, expect, it} from 'vitest'
+import {validateFeedJson, validateFeedXml} from '../../scripts/audit/check-feeds.mjs'
 
-const NOW = new Date('2026-07-16T00:00:00.000Z');
+const NOW = new Date('2026-07-16T00:00:00.000Z')
 
 function rss(pubDate: string, extraItems = ''): string {
   return `<?xml version="1.0" encoding="utf-8"?>
@@ -11,100 +11,96 @@ function rss(pubDate: string, extraItems = ''): string {
 <description>An example feed</description>
 <item><title>First</title><link>https://example.com/1</link><guid>1</guid><pubDate>${pubDate}</pubDate></item>
 ${extraItems}
-</channel></rss>`;
+</channel></rss>`
 }
 
 describe('validateFeedXml', () => {
   it('a conformant, fresh RSS 2.0 feed produces zero findings', () => {
-    const findings = validateFeedXml(rss('Thu, 16 Jul 2026 00:00:00 GMT'), NOW);
-    expect(findings).toEqual([]);
-  });
+    const findings = validateFeedXml(rss('Thu, 16 Jul 2026 00:00:00 GMT'), NOW)
+    expect(findings).toEqual([])
+  })
 
   it('not-well-formed XML fails to parse', () => {
-    const findings = validateFeedXml('<rss><channel><title>unclosed', NOW);
-    expect(findings.map((f) => f.id)).toContain('feed-xml-parse');
-  });
+    const findings = validateFeedXml('<rss><channel><title>unclosed', NOW)
+    expect(findings.map((f) => f.id)).toContain('feed-xml-parse')
+  })
 
   it('missing the <rss><channel> root fails', () => {
-    const findings = validateFeedXml('<foo></foo>', NOW);
-    expect(findings).toEqual([expect.objectContaining({ severity: 'fail', id: 'feed-xml-shape' })]);
-  });
+    const findings = validateFeedXml('<foo></foo>', NOW)
+    expect(findings).toEqual([expect.objectContaining({severity: 'fail', id: 'feed-xml-shape'})])
+  })
 
   it('a channel missing required fields (link, description) fails', () => {
-    const xml = '<rss><channel><title>Only Title</title></channel></rss>';
-    const findings = validateFeedXml(xml, NOW);
-    const ids = findings.map((f) => f.id);
-    expect(ids.filter((id) => id === 'feed-xml-channel-field')).toHaveLength(2);
-  });
+    const xml = '<rss><channel><title>Only Title</title></channel></rss>'
+    const findings = validateFeedXml(xml, NOW)
+    const ids = findings.map((f) => f.id)
+    expect(ids.filter((id) => id === 'feed-xml-channel-field')).toHaveLength(2)
+  })
 
   it('a channel with no items is a warn', () => {
-    const xml =
-      '<rss><channel><title>T</title><link>https://example.com</link><description>D</description></channel></rss>';
-    const findings = validateFeedXml(xml, NOW);
-    expect(findings).toEqual([expect.objectContaining({ severity: 'warn', id: 'feed-xml-no-items' })]);
-  });
+    const xml = '<rss><channel><title>T</title><link>https://example.com</link><description>D</description></channel></rss>'
+    const findings = validateFeedXml(xml, NOW)
+    expect(findings).toEqual([expect.objectContaining({severity: 'warn', id: 'feed-xml-no-items'})])
+  })
 
   it('an item missing guid fails', () => {
     const xml = `<rss><channel><title>T</title><link>https://example.com</link><description>D</description>
       <item><title>X</title><link>https://example.com/x</link><pubDate>Thu, 16 Jul 2026 00:00:00 GMT</pubDate></item>
-    </channel></rss>`;
-    const findings = validateFeedXml(xml, NOW);
-    expect(findings.map((f) => f.id)).toContain('feed-xml-item-field');
-  });
+    </channel></rss>`
+    const findings = validateFeedXml(xml, NOW)
+    expect(findings.map((f) => f.id)).toContain('feed-xml-item-field')
+  })
 
   it('known-answer: a newest item older than the 7-day soft window fails freshness', () => {
-    const findings = validateFeedXml(rss('Thu, 01 Jan 2026 00:00:00 GMT'), NOW);
-    expect(findings).toEqual([expect.objectContaining({ severity: 'fail', id: 'feed-xml-stale' })]);
-  });
+    const findings = validateFeedXml(rss('Thu, 01 Jan 2026 00:00:00 GMT'), NOW)
+    expect(findings).toEqual([expect.objectContaining({severity: 'fail', id: 'feed-xml-stale'})])
+  })
 
   it('an item just inside the 7-day window passes', () => {
-    const sixDaysAgo = new Date(NOW.getTime() - 6 * 86_400_000).toUTCString();
-    const findings = validateFeedXml(rss(sixDaysAgo), NOW);
-    expect(findings).toEqual([]);
-  });
-});
+    const sixDaysAgo = new Date(NOW.getTime() - 6 * 86_400_000).toUTCString()
+    const findings = validateFeedXml(rss(sixDaysAgo), NOW)
+    expect(findings).toEqual([])
+  })
+})
 
 const validJsonFeed = {
   version: 'https://jsonfeed.org/version/1.1',
   title: 'Example Feed',
-  items: [{ id: '1', content_text: 'hello', date_published: '2026-07-16T00:00:00.000Z' }],
-};
+  items: [{id: '1', content_text: 'hello', date_published: '2026-07-16T00:00:00.000Z'}]
+}
 
 describe('validateFeedJson', () => {
   it('a conformant, fresh JSON Feed 1.1 produces zero findings', () => {
-    expect(validateFeedJson(validJsonFeed, NOW)).toEqual([]);
-  });
+    expect(validateFeedJson(validJsonFeed, NOW)).toEqual([])
+  })
 
   it('missing required top-level fields fails', () => {
-    const findings = validateFeedJson({}, NOW);
-    expect(findings.map((f) => f.id)).toEqual(['feed-json-field', 'feed-json-field', 'feed-json-field']);
-  });
+    const findings = validateFeedJson({}, NOW)
+    expect(findings.map((f) => f.id)).toEqual(['feed-json-field', 'feed-json-field', 'feed-json-field'])
+  })
 
   it('a non-JSON-Feed version URI fails', () => {
-    const findings = validateFeedJson({ ...validJsonFeed, version: 'https://example.com/notjsonfeed' }, NOW);
-    expect(findings.map((f) => f.id)).toContain('feed-json-version');
-  });
+    const findings = validateFeedJson({...validJsonFeed, version: 'https://example.com/notjsonfeed'}, NOW)
+    expect(findings.map((f) => f.id)).toContain('feed-json-version')
+  })
 
   it('an empty items array is a warn', () => {
-    const findings = validateFeedJson({ ...validJsonFeed, items: [] }, NOW);
-    expect(findings).toEqual([expect.objectContaining({ severity: 'warn', id: 'feed-json-no-items' })]);
-  });
+    const findings = validateFeedJson({...validJsonFeed, items: []}, NOW)
+    expect(findings).toEqual([expect.objectContaining({severity: 'warn', id: 'feed-json-no-items'})])
+  })
 
   it('an item missing id fails', () => {
-    const findings = validateFeedJson({ ...validJsonFeed, items: [{ content_text: 'x' }] }, NOW);
-    expect(findings.map((f) => f.id)).toContain('feed-json-item-field');
-  });
+    const findings = validateFeedJson({...validJsonFeed, items: [{content_text: 'x'}]}, NOW)
+    expect(findings.map((f) => f.id)).toContain('feed-json-item-field')
+  })
 
   it('an item with neither content_html nor content_text fails', () => {
-    const findings = validateFeedJson({ ...validJsonFeed, items: [{ id: '1' }] }, NOW);
-    expect(findings.map((f) => f.id)).toContain('feed-json-item-field');
-  });
+    const findings = validateFeedJson({...validJsonFeed, items: [{id: '1'}]}, NOW)
+    expect(findings.map((f) => f.id)).toContain('feed-json-item-field')
+  })
 
   it('known-answer: a newest item older than the 7-day soft window fails freshness', () => {
-    const findings = validateFeedJson({
-      ...validJsonFeed,
-      items: [{ id: '1', content_text: 'x', date_published: '2026-01-01T00:00:00.000Z' }],
-    }, NOW);
-    expect(findings).toEqual([expect.objectContaining({ severity: 'fail', id: 'feed-json-stale' })]);
-  });
-});
+    const findings = validateFeedJson({...validJsonFeed, items: [{id: '1', content_text: 'x', date_published: '2026-01-01T00:00:00.000Z'}]}, NOW)
+    expect(findings).toEqual([expect.objectContaining({severity: 'fail', id: 'feed-json-stale'})])
+  })
+})

--- a/tests/audit/check-headers.test.ts
+++ b/tests/audit/check-headers.test.ts
@@ -1,38 +1,34 @@
-import { describe, it, expect } from 'vitest';
-import { validateHeaders } from '../../scripts/audit/check-headers.mjs';
+import {describe, expect, it} from 'vitest'
+import {validateHeaders} from '../../scripts/audit/check-headers.mjs'
 
-const GOLDEN_CSP = "default-src 'self'; script-src 'self';";
-const TRUSTED_TYPES = "require-trusted-types-for 'script'; report-uri /api/csp-report; report-to csp-endpoint";
+const GOLDEN_CSP = "default-src 'self'; script-src 'self';"
+const TRUSTED_TYPES = "require-trusted-types-for 'script'; report-uri /api/csp-report; report-to csp-endpoint"
 
 function headers(overrides: Record<string, string> = {}): Headers {
-  return new Headers({
-    'content-security-policy': GOLDEN_CSP,
-    'content-security-policy-report-only': TRUSTED_TYPES,
-    ...overrides,
-  });
+  return new Headers({'content-security-policy': GOLDEN_CSP, 'content-security-policy-report-only': TRUSTED_TYPES, ...overrides})
 }
 
 describe('validateHeaders', () => {
   it('a live CSP matching the golden, with Trusted Types present, produces zero findings', () => {
-    expect(validateHeaders(headers(), GOLDEN_CSP)).toEqual([]);
-  });
+    expect(validateHeaders(headers(), GOLDEN_CSP)).toEqual([])
+  })
 
   it('a missing CSP header fails', () => {
-    const h = new Headers({ 'content-security-policy-report-only': TRUSTED_TYPES });
-    const findings = validateHeaders(h, GOLDEN_CSP);
-    expect(findings.map((f) => f.id)).toContain('headers-csp-missing');
-  });
+    const h = new Headers({'content-security-policy-report-only': TRUSTED_TYPES})
+    const findings = validateHeaders(h, GOLDEN_CSP)
+    expect(findings.map((f) => f.id)).toContain('headers-csp-missing')
+  })
 
   it('known-answer: a CSP that drifted from the golden fails, quoting both values', () => {
-    const findings = validateHeaders(headers({ 'content-security-policy': "default-src 'none';" }), GOLDEN_CSP);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].id).toBe('headers-csp-drift');
-    expect(findings[0].message).toContain("default-src 'none'");
-    expect(findings[0].message).toContain(GOLDEN_CSP);
-  });
+    const findings = validateHeaders(headers({'content-security-policy': "default-src 'none';"}), GOLDEN_CSP)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].id).toBe('headers-csp-drift')
+    expect(findings[0].message).toContain("default-src 'none'")
+    expect(findings[0].message).toContain(GOLDEN_CSP)
+  })
 
   it('a missing Trusted Types report-only directive fails', () => {
-    const findings = validateHeaders(headers({ 'content-security-policy-report-only': '' }), GOLDEN_CSP);
-    expect(findings.map((f) => f.id)).toContain('headers-trusted-types-missing');
-  });
-});
+    const findings = validateHeaders(headers({'content-security-policy-report-only': ''}), GOLDEN_CSP)
+    expect(findings.map((f) => f.id)).toContain('headers-trusted-types-missing')
+  })
+})

--- a/tests/audit/check-security-txt.test.ts
+++ b/tests/audit/check-security-txt.test.ts
@@ -1,54 +1,54 @@
-import { describe, it, expect } from 'vitest';
-import { validateSecurityTxt } from '../../scripts/audit/check-security-txt.mjs';
+import {describe, expect, it} from 'vitest'
+import {validateSecurityTxt} from '../../scripts/audit/check-security-txt.mjs'
 
-const NOW = new Date('2026-07-16T00:00:00.000Z');
+const NOW = new Date('2026-07-16T00:00:00.000Z')
 
 function daysFromNow(days: number): string {
-  return new Date(NOW.getTime() + days * 86_400_000).toISOString();
+  return new Date(NOW.getTime() + days * 86_400_000).toISOString()
 }
 
 describe('validateSecurityTxt', () => {
   it('known-answer: Expires 20 days out fails the 30-day threshold', () => {
-    const body = `Contact: mailto:security@example.com\nExpires: ${daysFromNow(20)}\n`;
-    const findings = validateSecurityTxt(body, NOW);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].id).toBe('security-txt-expiring-soon');
-  });
+    const body = `Contact: mailto:security@example.com\nExpires: ${daysFromNow(20)}\n`
+    const findings = validateSecurityTxt(body, NOW)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].id).toBe('security-txt-expiring-soon')
+  })
 
   it('Expires comfortably in the future (matching the live 2027-06-18 value) passes clean', () => {
-    const body = `Contact: mailto:security@example.com\nExpires: ${daysFromNow(400)}\n`;
-    expect(validateSecurityTxt(body, NOW)).toEqual([]);
-  });
+    const body = `Contact: mailto:security@example.com\nExpires: ${daysFromNow(400)}\n`
+    expect(validateSecurityTxt(body, NOW)).toEqual([])
+  })
 
   it('Expires in the past fails as expired, not merely "expiring soon"', () => {
-    const body = `Contact: mailto:security@example.com\nExpires: ${daysFromNow(-5)}\n`;
-    const findings = validateSecurityTxt(body, NOW);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].id).toBe('security-txt-expired');
-  });
+    const body = `Contact: mailto:security@example.com\nExpires: ${daysFromNow(-5)}\n`
+    const findings = validateSecurityTxt(body, NOW)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].id).toBe('security-txt-expired')
+  })
 
   it('a missing Expires field fails distinctly from an expiring one', () => {
-    const findings = validateSecurityTxt('Contact: mailto:security@example.com\n', NOW);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].id).toBe('security-txt-expires-missing');
-  });
+    const findings = validateSecurityTxt('Contact: mailto:security@example.com\n', NOW)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].id).toBe('security-txt-expires-missing')
+  })
 
   it('an unparseable Expires value fails distinctly', () => {
-    const findings = validateSecurityTxt('Expires: not-a-date\n', NOW);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].id).toBe('security-txt-expires-unparseable');
-  });
+    const findings = validateSecurityTxt('Expires: not-a-date\n', NOW)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].id).toBe('security-txt-expires-unparseable')
+  })
 
   it('a missing Contact field is a warn, not a fail', () => {
-    const findings = validateSecurityTxt(`Expires: ${daysFromNow(400)}\n`, NOW);
+    const findings = validateSecurityTxt(`Expires: ${daysFromNow(400)}\n`, NOW)
     expect(findings).toEqual([
-      expect.objectContaining({ severity: 'warn', id: 'security-txt-contact-missing' }),
-    ]);
-  });
+      expect.objectContaining({severity: 'warn', id: 'security-txt-contact-missing'})
+    ])
+  })
 
   it('exactly at the 30-day boundary still fails (threshold is inclusive of "below")', () => {
-    const body = `Contact: mailto:security@example.com\nExpires: ${daysFromNow(29)}\n`;
-    const findings = validateSecurityTxt(body, NOW);
-    expect(findings.map((f) => f.id)).toContain('security-txt-expiring-soon');
-  });
-});
+    const body = `Contact: mailto:security@example.com\nExpires: ${daysFromNow(29)}\n`
+    const findings = validateSecurityTxt(body, NOW)
+    expect(findings.map((f) => f.id)).toContain('security-txt-expiring-soon')
+  })
+})

--- a/tests/audit/check-wellknown.test.ts
+++ b/tests/audit/check-wellknown.test.ts
@@ -1,47 +1,44 @@
-import { describe, it, expect } from 'vitest';
+import {describe, expect, it} from 'vitest'
 import {
-  validateWebfingerShape,
-  validateAgentCardShape,
-  validateAiCatalogShape,
-  validateMcpServerCardShape,
-  validateApiCatalogShape,
   PINNED_A2A_SPEC_VERSION,
   PINNED_ARD_SPEC_VERSION,
-} from '../../scripts/audit/check-wellknown.mjs';
+  validateAgentCardShape,
+  validateAiCatalogShape,
+  validateApiCatalogShape,
+  validateMcpServerCardShape,
+  validateWebfingerShape
+} from '../../scripts/audit/check-wellknown.mjs'
 
 describe('validateWebfingerShape', () => {
-  const valid = {
-    subject: 'acct:jonathan@jonathanlloyd.me',
-    links: [{ rel: 'self', href: 'https://mastodon.social/ap/users/1' }],
-  };
+  const valid = {subject: 'acct:jonathan@jonathanlloyd.me', links: [{rel: 'self', href: 'https://mastodon.social/ap/users/1'}]}
 
   it('a conformant JRD produces zero findings', () => {
-    expect(validateWebfingerShape(valid, 'application/jrd+json')).toEqual([]);
-  });
+    expect(validateWebfingerShape(valid, 'application/jrd+json')).toEqual([])
+  })
 
   it('wrong content-type fails', () => {
-    const findings = validateWebfingerShape(valid, 'application/json');
-    expect(findings.map((f) => f.id)).toContain('wellknown-webfinger-content-type');
-  });
+    const findings = validateWebfingerShape(valid, 'application/json')
+    expect(findings.map((f) => f.id)).toContain('wellknown-webfinger-content-type')
+  })
 
   it('a non-acct subject fails', () => {
-    const findings = validateWebfingerShape({ ...valid, subject: 'https://example.com/x' }, 'application/jrd+json');
-    expect(findings.map((f) => f.id)).toContain('wellknown-webfinger-subject');
-  });
+    const findings = validateWebfingerShape({...valid, subject: 'https://example.com/x'}, 'application/jrd+json')
+    expect(findings.map((f) => f.id)).toContain('wellknown-webfinger-subject')
+  })
 
   it('missing a rel="self" link is a warn', () => {
-    const findings = validateWebfingerShape({ ...valid, links: [] }, 'application/jrd+json');
-    expect(findings).toEqual([expect.objectContaining({ severity: 'warn', id: 'wellknown-webfinger-no-self-link' })]);
-  });
+    const findings = validateWebfingerShape({...valid, links: []}, 'application/jrd+json')
+    expect(findings).toEqual([expect.objectContaining({severity: 'warn', id: 'wellknown-webfinger-no-self-link'})])
+  })
 
   it('missing both required fields produces two distinct findings, one per field', () => {
-    const findings = validateWebfingerShape({}, 'application/jrd+json');
-    const shapeFindings = findings.filter((f) => f.id === 'wellknown-webfinger-shape');
-    expect(shapeFindings).toHaveLength(2);
-    expect(shapeFindings.some((f) => f.message.includes('"subject"'))).toBe(true);
-    expect(shapeFindings.some((f) => f.message.includes('"links"'))).toBe(true);
-  });
-});
+    const findings = validateWebfingerShape({}, 'application/jrd+json')
+    const shapeFindings = findings.filter((f) => f.id === 'wellknown-webfinger-shape')
+    expect(shapeFindings).toHaveLength(2)
+    expect(shapeFindings.some((f) => f.message.includes('"subject"'))).toBe(true)
+    expect(shapeFindings.some((f) => f.message.includes('"links"'))).toBe(true)
+  })
+})
 
 describe('validateAgentCardShape', () => {
   const valid = {
@@ -51,111 +48,97 @@ describe('validateAgentCardShape', () => {
     capabilities: {},
     defaultInputModes: ['text/plain'],
     defaultOutputModes: ['application/json'],
-    supportedInterfaces: [{ url: 'https://example.com', protocolBinding: 'HTTP+JSON', protocolVersion: '1.0' }],
-    skills: [{ id: 'x' }],
-  };
+    supportedInterfaces: [{url: 'https://example.com', protocolBinding: 'HTTP+JSON', protocolVersion: '1.0'}],
+    skills: [{id: 'x'}]
+  }
 
   it(`a conformant A2A v${PINNED_A2A_SPEC_VERSION} card produces zero findings`, () => {
-    expect(validateAgentCardShape(valid)).toEqual([]);
-  });
+    expect(validateAgentCardShape(valid)).toEqual([])
+  })
 
   it('an empty supportedInterfaces array fails -- A2A requires at least one', () => {
-    const findings = validateAgentCardShape({ ...valid, supportedInterfaces: [] });
-    expect(findings.map((f) => f.id)).toContain('wellknown-agent-card-no-interfaces');
-  });
+    const findings = validateAgentCardShape({...valid, supportedInterfaces: []})
+    expect(findings.map((f) => f.id)).toContain('wellknown-agent-card-no-interfaces')
+  })
 
   it('a supportedInterfaces entry missing protocolBinding fails', () => {
-    const findings = validateAgentCardShape({ ...valid, supportedInterfaces: [{ url: 'https://example.com' }] });
-    expect(findings.map((f) => f.id)).toContain('wellknown-agent-card-interface-shape');
-  });
+    const findings = validateAgentCardShape({...valid, supportedInterfaces: [{url: 'https://example.com'}]})
+    expect(findings.map((f) => f.id)).toContain('wellknown-agent-card-interface-shape')
+  })
 
   it('an empty skills array is a warn', () => {
-    const findings = validateAgentCardShape({ ...valid, skills: [] });
-    expect(findings).toEqual([expect.objectContaining({ severity: 'warn', id: 'wellknown-agent-card-no-skills' })]);
-  });
-});
+    const findings = validateAgentCardShape({...valid, skills: []})
+    expect(findings).toEqual([expect.objectContaining({severity: 'warn', id: 'wellknown-agent-card-no-skills'})])
+  })
+})
 
 describe('validateAiCatalogShape', () => {
   const valid = {
     specVersion: PINNED_ARD_SPEC_VERSION,
-    entries: [{
-      identifier: 'urn:air:example.com:server:x',
-      displayName: 'X',
-      type: 'application/json',
-      url: 'https://example.com',
-    }],
-  };
+    entries: [{identifier: 'urn:air:example.com:server:x', displayName: 'X', type: 'application/json', url: 'https://example.com'}]
+  }
 
   it(`a conformant ARD specVersion ${PINNED_ARD_SPEC_VERSION} catalog produces zero findings`, () => {
-    expect(validateAiCatalogShape(valid)).toEqual([]);
-  });
+    expect(validateAiCatalogShape(valid)).toEqual([])
+  })
 
   it('a specVersion drifted from the pinned constant is a warn, not a fail', () => {
-    const findings = validateAiCatalogShape({ ...valid, specVersion: '2.0' });
+    const findings = validateAiCatalogShape({...valid, specVersion: '2.0'})
     expect(findings).toEqual([
-      expect.objectContaining({ severity: 'warn', id: 'wellknown-ai-catalog-spec-version-drift' }),
-    ]);
-  });
+      expect.objectContaining({severity: 'warn', id: 'wellknown-ai-catalog-spec-version-drift'})
+    ])
+  })
 
   it('an empty entries array fails', () => {
-    const findings = validateAiCatalogShape({ ...valid, entries: [] });
-    expect(findings.map((f) => f.id)).toContain('wellknown-ai-catalog-no-entries');
-  });
+    const findings = validateAiCatalogShape({...valid, entries: []})
+    expect(findings.map((f) => f.id)).toContain('wellknown-ai-catalog-no-entries')
+  })
 
   it('an entry identifier that is not a urn:air: URN fails', () => {
-    const findings = validateAiCatalogShape({ ...valid, entries: [{ ...valid.entries[0], identifier: 'not-a-urn' }] });
-    expect(findings.map((f) => f.id)).toContain('wellknown-ai-catalog-entry-identifier');
-  });
+    const findings = validateAiCatalogShape({...valid, entries: [{...valid.entries[0], identifier: 'not-a-urn'}]})
+    expect(findings.map((f) => f.id)).toContain('wellknown-ai-catalog-entry-identifier')
+  })
 
   it('an entry with neither url nor data fails', () => {
-    const { url: _url, ...entryWithoutLocator } = valid.entries[0];
-    const findings = validateAiCatalogShape({ ...valid, entries: [entryWithoutLocator] });
-    expect(findings.map((f) => f.id)).toContain('wellknown-ai-catalog-entry-no-locator');
-  });
-});
+    const {url: _url, ...entryWithoutLocator} = valid.entries[0]
+    const findings = validateAiCatalogShape({...valid, entries: [entryWithoutLocator]})
+    expect(findings.map((f) => f.id)).toContain('wellknown-ai-catalog-entry-no-locator')
+  })
+})
 
 describe('validateMcpServerCardShape', () => {
-  const valid = {
-    name: 'x',
-    serverInfo: {},
-    capabilities: {},
-    transport: { url: 'https://example.com' },
-    resources: [{ uri: 'https://example.com/health.json' }],
-  };
+  const valid = {name: 'x', serverInfo: {}, capabilities: {}, transport: {url: 'https://example.com'}, resources: [{uri: 'https://example.com/health.json'}]}
 
   it('a conformant server card produces zero findings', () => {
-    expect(validateMcpServerCardShape(valid)).toEqual([]);
-  });
+    expect(validateMcpServerCardShape(valid)).toEqual([])
+  })
 
   it('a transport missing a url fails', () => {
-    const findings = validateMcpServerCardShape({ ...valid, transport: {} });
-    expect(findings.map((f) => f.id)).toContain('wellknown-mcp-server-card-transport-url');
-  });
+    const findings = validateMcpServerCardShape({...valid, transport: {}})
+    expect(findings.map((f) => f.id)).toContain('wellknown-mcp-server-card-transport-url')
+  })
 
   it('an empty resources array is a warn', () => {
-    const findings = validateMcpServerCardShape({ ...valid, resources: [] });
+    const findings = validateMcpServerCardShape({...valid, resources: []})
     expect(findings).toEqual([
-      expect.objectContaining({ severity: 'warn', id: 'wellknown-mcp-server-card-no-resources' }),
-    ]);
-  });
-});
+      expect.objectContaining({severity: 'warn', id: 'wellknown-mcp-server-card-no-resources'})
+    ])
+  })
+})
 
 describe('validateApiCatalogShape', () => {
   it('a conformant linkset produces zero findings', () => {
-    const findings = validateApiCatalogShape(
-      { linkset: [{ anchor: 'https://example.com' }] },
-      'application/linkset+json',
-    );
-    expect(findings).toEqual([]);
-  });
+    const findings = validateApiCatalogShape({linkset: [{anchor: 'https://example.com'}]}, 'application/linkset+json')
+    expect(findings).toEqual([])
+  })
 
   it('wrong content-type fails (RFC 9727)', () => {
-    const findings = validateApiCatalogShape({ linkset: [{ anchor: 'https://example.com' }] }, 'application/json');
-    expect(findings.map((f) => f.id)).toContain('wellknown-api-catalog-content-type');
-  });
+    const findings = validateApiCatalogShape({linkset: [{anchor: 'https://example.com'}]}, 'application/json')
+    expect(findings.map((f) => f.id)).toContain('wellknown-api-catalog-content-type')
+  })
 
   it('an empty linkset fails', () => {
-    const findings = validateApiCatalogShape({ linkset: [] }, 'application/linkset+json');
-    expect(findings.map((f) => f.id)).toContain('wellknown-api-catalog-linkset');
-  });
-});
+    const findings = validateApiCatalogShape({linkset: []}, 'application/linkset+json')
+    expect(findings.map((f) => f.id)).toContain('wellknown-api-catalog-linkset')
+  })
+})

--- a/tests/audit/validate-llms-txt.test.ts
+++ b/tests/audit/validate-llms-txt.test.ts
@@ -1,57 +1,56 @@
-import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
-import { validateLlmsTxt } from '../../scripts/audit/validate-llms-txt.mjs';
+import {describe, expect, it} from 'vitest'
+import {readFileSync} from 'node:fs'
+import {fileURLToPath} from 'node:url'
+import path from 'node:path'
+import {validateLlmsTxt} from '../../scripts/audit/validate-llms-txt.mjs'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const fixture = (name: string) => readFileSync(path.join(__dirname, 'fixtures', name), 'utf-8');
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const fixture = (name: string) => readFileSync(path.join(__dirname, 'fixtures', name), 'utf-8')
 
 describe('validateLlmsTxt', () => {
   it('a fully spec-conformant file produces zero findings', () => {
-    const findings = validateLlmsTxt(fixture('llms-valid.txt'));
-    expect(findings).toEqual([]);
-  });
+    const findings = validateLlmsTxt(fixture('llms-valid.txt'))
+    expect(findings).toEqual([])
+  })
 
   it('known-answer fixture: bare bullets, an empty section, and no blockquote all flag', () => {
-    const findings = validateLlmsTxt(fixture('llms-invalid.txt'));
-    const ids = findings.map((f) => f.id);
-    expect(ids).toContain('llms-txt-blockquote');
-    expect(ids).toContain('llms-txt-non-link-list-item');
-    expect(ids).toContain('llms-txt-h2-no-file-list');
-  });
+    const findings = validateLlmsTxt(fixture('llms-invalid.txt'))
+    const ids = findings.map((f) => f.id)
+    expect(ids).toContain('llms-txt-blockquote')
+    expect(ids).toContain('llms-txt-non-link-list-item')
+    expect(ids).toContain('llms-txt-h2-no-file-list')
+  })
 
   it('missing H1 fails immediately and stops further parsing', () => {
-    const findings = validateLlmsTxt('Not a heading at all\n\n> some quote\n');
-    expect(findings).toHaveLength(1);
-    expect(findings[0].id).toBe('llms-txt-h1');
-  });
+    const findings = validateLlmsTxt('Not a heading at all\n\n> some quote\n')
+    expect(findings).toHaveLength(1)
+    expect(findings[0].id).toBe('llms-txt-h1')
+  })
 
   it('strips an optional BOM before validating', () => {
-    const withBom = '﻿' + fixture('llms-valid.txt');
-    const findings = validateLlmsTxt(withBom);
-    expect(findings).toEqual([]);
-  });
+    const withBom = '﻿' + fixture('llms-valid.txt')
+    const findings = validateLlmsTxt(withBom)
+    expect(findings).toEqual([])
+  })
 
   it('a bare-URL list item (not a markdown link) is flagged', () => {
-    const text = '# Site\n\n> Summary\n\n## Links\n\n- https://example.com/bare\n';
-    const findings = validateLlmsTxt(text);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].id).toBe('llms-txt-non-link-list-item');
-  });
+    const text = '# Site\n\n> Summary\n\n## Links\n\n- https://example.com/bare\n'
+    const findings = validateLlmsTxt(text)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].id).toBe('llms-txt-non-link-list-item')
+  })
 
   it('an H2 section named "Optional" is validated the same as any other section', () => {
-    const validOptional = '# Site\n\n> Summary\n\n## Optional\n\n- [Extra](https://example.com/extra)\n';
-    expect(validateLlmsTxt(validOptional)).toEqual([]);
+    const validOptional = '# Site\n\n> Summary\n\n## Optional\n\n- [Extra](https://example.com/extra)\n'
+    expect(validateLlmsTxt(validOptional)).toEqual([])
 
-    const invalidOptional = '# Site\n\n> Summary\n\n## Optional\n\n- bare bullet, no link\n';
-    const findings = validateLlmsTxt(invalidOptional);
-    expect(findings.map((f) => f.id)).toContain('llms-txt-non-link-list-item');
-  });
+    const invalidOptional = '# Site\n\n> Summary\n\n## Optional\n\n- bare bullet, no link\n'
+    const findings = validateLlmsTxt(invalidOptional)
+    expect(findings.map((f) => f.id)).toContain('llms-txt-non-link-list-item')
+  })
 
   it('free-form prose before the first H2 is not flagged', () => {
-    const text =
-      '# Site\n\n> Summary\n\nSome paragraph.\n\n- a plain list item, not yet in an H2 section\n\n## Docs\n\n- [Doc](https://example.com/doc)\n';
-    expect(validateLlmsTxt(text)).toEqual([]);
-  });
-});
+    const text = '# Site\n\n> Summary\n\nSome paragraph.\n\n- a plain list item, not yet in an H2 section\n\n## Docs\n\n- [Doc](https://example.com/doc)\n'
+    expect(validateLlmsTxt(text)).toEqual([])
+  })
+})

--- a/tests/audit/validate-robots.test.ts
+++ b/tests/audit/validate-robots.test.ts
@@ -1,55 +1,43 @@
-import { describe, it, expect } from 'vitest';
-import { validateRobots } from '../../scripts/audit/validate-robots.mjs';
+import {describe, expect, it} from 'vitest'
+import {validateRobots} from '../../scripts/audit/validate-robots.mjs'
 
-const GOLDEN = {
-  aiTrainingBotsBlockedExceptLlmsTxt: ['GPTBot', 'ClaudeBot'],
-  aiSearchAgentsAllowedFullSite: ['OAI-SearchBot'],
-};
+const GOLDEN = {aiTrainingBotsBlockedExceptLlmsTxt: ['GPTBot', 'ClaudeBot'], aiSearchAgentsAllowedFullSite: ['OAI-SearchBot']}
 
-const SITEMAP_URL = 'https://jonathanlloyd.me/sitemap-index.xml';
+const SITEMAP_URL = 'https://jonathanlloyd.me/sitemap-index.xml'
 
-function robotsBody(overrides: { sitemap?: string; contentSignal?: string; agents?: string[]; } = {}) {
-  const sitemap = overrides.sitemap ?? `Sitemap: ${SITEMAP_URL}`;
-  const contentSignal = overrides.contentSignal ?? 'Content-Signal: search=yes, ai-train=no, ai-input=yes';
-  const agents = overrides.agents ?? ['GPTBot', 'ClaudeBot', 'OAI-SearchBot'];
-  const agentBlocks = agents.map((a) => `User-agent: ${a}\nDisallow: /\n`).join('\n');
-  return `User-agent: *\nAllow: /\n\n${contentSignal}\n\n${agentBlocks}\n${sitemap}\n`;
+function robotsBody(overrides: {sitemap?: string; contentSignal?: string; agents?: string[]} = {}) {
+  const sitemap = overrides.sitemap ?? `Sitemap: ${SITEMAP_URL}`
+  const contentSignal = overrides.contentSignal ?? 'Content-Signal: search=yes, ai-train=no, ai-input=yes'
+  const agents = overrides.agents ?? ['GPTBot', 'ClaudeBot', 'OAI-SearchBot']
+  const agentBlocks = agents.map((a) => `User-agent: ${a}\nDisallow: /\n`).join('\n')
+  return `User-agent: *\nAllow: /\n\n${contentSignal}\n\n${agentBlocks}\n${sitemap}\n`
 }
 
 describe('validateRobots', () => {
   it('a fully-conformant robots.txt (matching the golden AI-crawler list) produces zero findings', () => {
-    expect(validateRobots(robotsBody(), GOLDEN)).toEqual([]);
-  });
+    expect(validateRobots(robotsBody(), GOLDEN)).toEqual([])
+  })
 
   it('a Sitemap: directive pointing elsewhere fails', () => {
-    const findings = validateRobots(robotsBody({ sitemap: 'Sitemap: https://elsewhere.example/sitemap.xml' }), GOLDEN);
-    expect(findings.map((f) => f.id)).toContain('robots-sitemap-directive');
-  });
+    const findings = validateRobots(robotsBody({sitemap: 'Sitemap: https://elsewhere.example/sitemap.xml'}), GOLDEN)
+    expect(findings.map((f) => f.id)).toContain('robots-sitemap-directive')
+  })
 
   it('a missing Content-Signal line fails', () => {
-    const body = robotsBody().replace(/Content-Signal:.*\n/, '');
-    const findings = validateRobots(body, GOLDEN);
-    expect(findings.map((f) => f.id)).toContain('robots-content-signal-missing');
-  });
+    const body = robotsBody().replace(/Content-Signal:.*\n/, '')
+    const findings = validateRobots(body, GOLDEN)
+    expect(findings.map((f) => f.id)).toContain('robots-content-signal-missing')
+  })
 
   it('known-answer: dropping a golden AI-crawler User-agent section is a drift-guard fail', () => {
-    const findings = validateRobots(robotsBody({ agents: ['ClaudeBot', 'OAI-SearchBot'] }), GOLDEN);
-    expect(findings).toContainEqual(
-      expect.objectContaining({
-        severity: 'fail',
-        id: 'robots-ai-crawler-missing',
-        message: expect.stringContaining('GPTBot'),
-      }),
-    );
-  });
+    const findings = validateRobots(robotsBody({agents: ['ClaudeBot', 'OAI-SearchBot']}), GOLDEN)
+    expect(findings).toContainEqual(expect.objectContaining({severity: 'fail', id: 'robots-ai-crawler-missing', message: expect.stringContaining('GPTBot')}))
+  })
 
   it('a new, not-yet-golden User-agent section is a warn, not a fail', () => {
-    const findings = validateRobots(
-      robotsBody({ agents: ['GPTBot', 'ClaudeBot', 'OAI-SearchBot', 'SomeNewBot'] }),
-      GOLDEN,
-    );
-    const newBotFinding = findings.find((f) => f.id === 'robots-ai-crawler-new');
-    expect(newBotFinding?.severity).toBe('warn');
-    expect(findings.some((f) => f.severity === 'fail')).toBe(false);
-  });
-});
+    const findings = validateRobots(robotsBody({agents: ['GPTBot', 'ClaudeBot', 'OAI-SearchBot', 'SomeNewBot']}), GOLDEN)
+    const newBotFinding = findings.find((f) => f.id === 'robots-ai-crawler-new')
+    expect(newBotFinding?.severity).toBe('warn')
+    expect(findings.some((f) => f.severity === 'fail')).toBe(false)
+  })
+})

--- a/tests/audit/validate-sitemap.test.ts
+++ b/tests/audit/validate-sitemap.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { execFileSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
-import { extractLocs, validateAgainstXsd } from '../../scripts/audit/validate-sitemap.mjs';
+import {describe, expect, it} from 'vitest'
+import {execFileSync} from 'node:child_process'
+import {fileURLToPath} from 'node:url'
+import path from 'node:path'
+import {extractLocs, validateAgainstXsd} from '../../scripts/audit/validate-sitemap.mjs'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const fixturePath = (name: string) => path.join(__dirname, 'fixtures', name);
-const vendorPath = (name: string) => path.join(__dirname, '..', '..', 'scripts', 'audit', 'vendor', name);
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const fixturePath = (name: string) => path.join(__dirname, 'fixtures', name)
+const vendorPath = (name: string) => path.join(__dirname, '..', '..', 'scripts', 'audit', 'vendor', name)
 
 // `npm run test:unit` is invoked from several places in this repo (its own
 // package.json script, and as a pre-check step inside visual-tests.yml) that
@@ -20,45 +20,37 @@ const vendorPath = (name: string) => path.join(__dirname, '..', '..', 'scripts',
 // shared vitest.unit.config.ts). Skip gracefully instead.
 function hasXmllint(): boolean {
   try {
-    execFileSync('xmllint', ['--version'], { stdio: 'ignore' });
-    return true;
+    execFileSync('xmllint', ['--version'], {stdio: 'ignore'})
+    return true
   } catch {
-    return false;
+    return false
   }
 }
-const xmllintAvailable = hasXmllint();
+const xmllintAvailable = hasXmllint()
 
 describe('extractLocs', () => {
   it('extracts every <loc> text content from a flat urlset', () => {
-    const xml = '<urlset><url><loc>https://a.example/</loc></url><url><loc>https://a.example/b</loc></url></urlset>';
-    expect(extractLocs(xml)).toEqual(['https://a.example/', 'https://a.example/b']);
-  });
+    const xml = '<urlset><url><loc>https://a.example/</loc></url><url><loc>https://a.example/b</loc></url></urlset>'
+    expect(extractLocs(xml)).toEqual(['https://a.example/', 'https://a.example/b'])
+  })
 
   it('returns an empty array when there are no <loc> tags', () => {
-    expect(extractLocs('<urlset></urlset>')).toEqual([]);
-  });
-});
+    expect(extractLocs('<urlset></urlset>')).toEqual([])
+  })
+})
 
 describe.skipIf(!xmllintAvailable)('validateAgainstXsd (real xmllint + vendored sitemaps.org 0.9 XSD)', () => {
   it('a schema-conformant urlset produces zero findings', () => {
-    const findings = validateAgainstXsd(
-      'sitemap-child-xsd',
-      fixturePath('sitemap-valid.xml'),
-      vendorPath('sitemap-0.9.xsd'),
-      'https://example.com/sitemap-0.xml',
-    );
-    expect(findings).toEqual([]);
-  });
+    const findings = validateAgainstXsd('sitemap-child-xsd', fixturePath('sitemap-valid.xml'), vendorPath('sitemap-0.9.xsd'),
+      'https://example.com/sitemap-0.xml')
+    expect(findings).toEqual([])
+  })
 
   it('known-answer: a <priority> outside the 0.0-1.0 range fails XSD validation', () => {
-    const findings = validateAgainstXsd(
-      'sitemap-child-xsd',
-      fixturePath('sitemap-invalid.xml'),
-      vendorPath('sitemap-0.9.xsd'),
-      'https://example.com/sitemap-0.xml',
-    );
-    expect(findings).toHaveLength(1);
-    expect(findings[0].severity).toBe('fail');
-    expect(findings[0].message).toContain('sitemap-0.xml');
-  });
-});
+    const findings = validateAgainstXsd('sitemap-child-xsd', fixturePath('sitemap-invalid.xml'), vendorPath('sitemap-0.9.xsd'),
+      'https://example.com/sitemap-0.xml')
+    expect(findings).toHaveLength(1)
+    expect(findings[0].severity).toBe('fail')
+    expect(findings[0].message).toContain('sitemap-0.xml')
+  })
+})

--- a/tests/behavioral/book-modal.spec.ts
+++ b/tests/behavioral/book-modal.spec.ts
@@ -12,28 +12,26 @@
  * Escape, backdrop-click, close-button, focus-restore, focus-containment (inert),
  * CSP onerror-fix.
  */
-import { createRequire } from 'node:module';
-import { test, expect, type Page } from '@playwright/test';
-import { CLOUDFRONT_BASE, WEBSOCKET_URL } from '@lifegames/portal-contract/constants';
+import {createRequire} from 'node:module'
+import {expect, type Page, test} from '@playwright/test'
+import {CLOUDFRONT_BASE, WEBSOCKET_URL} from '@lifegames/portal-contract/constants'
 
-const require = createRequire(import.meta.url);
+const require = createRequire(import.meta.url)
 
 // Resolve the "full" books fixture via the @lifegames/fixtures package exports
 // map. This fixture has reading+finished+upNext books with all fields populated.
-const BOOKS_FULL_FIXTURE: string = require.resolve(
-  '@lifegames/fixtures/generated/books/full.json',
-);
+const BOOKS_FULL_FIXTURE: string = require.resolve('@lifegames/fixtures/generated/books/full.json')
 
 // Other endpoints use baseline fixtures (unchanged from visual suite).
 function baselineFixture(dir: string, file: string): string {
-  const camelFile = file.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
-  return require.resolve(`@lifegames/fixtures/generated/${dir}/${camelFile}.json`);
+  const camelFile = file.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase())
+  return require.resolve(`@lifegames/fixtures/generated/${dir}/${camelFile}.json`)
 }
 
 /** Set up route interception: books→full, everything else→baseline or block */
 async function interceptRoutes(page: Page): Promise<void> {
   await page.route(`${CLOUDFRONT_BASE}/**`, async (route) => {
-    const url = new URL(route.request().url());
+    const url = new URL(route.request().url())
     const fixtureMap: Record<string, string> = {
       '/books.json': BOOKS_FULL_FIXTURE,
       '/health.json': baselineFixture('health', 'baseline'),
@@ -44,43 +42,39 @@ async function interceptRoutes(page: Page): Promise<void> {
       '/articles.json': baselineFixture('articles', 'baseline'),
       '/location.json': baselineFixture('location', 'baseline'),
       '/focus.json': baselineFixture('focus', 'empty'),
-      '/theatre-reviews.json': baselineFixture('theatre-reviews', 'baseline'),
-    };
-    const fixturePath = fixtureMap[url.pathname];
-    if (fixturePath) {
-      await route.fulfill({ path: fixturePath, contentType: 'application/json' });
-    } else {
-      await route.abort();
+      '/theatre-reviews.json': baselineFixture('theatre-reviews', 'baseline')
     }
-  });
+    const fixturePath = fixtureMap[url.pathname]
+    if (fixturePath) {
+      await route.fulfill({path: fixturePath, contentType: 'application/json'})
+    } else {
+      await route.abort()
+    }
+  })
 
   // Block WebSocket
-  await page.route(`${WEBSOCKET_URL}/**`, (route) => route.abort());
+  await page.route(`${WEBSOCKET_URL}/**`, (route) => route.abort())
 
   // Serve transparent pixel for external images; abort everything else
-  const TRANSPARENT_PIXEL = Buffer.from(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB'
-      + 'Nl7BcQAAAABJRU5ErkJggg==',
-    'base64',
-  );
+  const TRANSPARENT_PIXEL = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB' + 'Nl7BcQAAAABJRU5ErkJggg==', 'base64')
   await page.route('**/*', async (route) => {
-    const url = route.request().url();
+    const url = route.request().url()
     if (
-      url.startsWith('http://localhost')
-      || url.startsWith('data:')
-      || url.startsWith(CLOUDFRONT_BASE)
-      || url.startsWith(WEBSOCKET_URL.replace('wss://', 'https://'))
-      || url.startsWith('wss://')
+      url.startsWith('http://localhost') ||
+      url.startsWith('data:') ||
+      url.startsWith(CLOUDFRONT_BASE) ||
+      url.startsWith(WEBSOCKET_URL.replace('wss://', 'https://')) ||
+      url.startsWith('wss://')
     ) {
-      await route.fallback();
-      return;
+      await route.fallback()
+      return
     }
     if (route.request().resourceType() === 'image') {
-      await route.fulfill({ status: 200, contentType: 'image/png', body: TRANSPARENT_PIXEL });
+      await route.fulfill({status: 200, contentType: 'image/png', body: TRANSPARENT_PIXEL})
     } else {
-      await route.abort();
+      await route.abort()
     }
-  });
+  })
 }
 
 /**
@@ -91,26 +85,20 @@ async function navigateWithSaStub(page: Page): Promise<void> {
   // Inject the sa_event stub before any script runs, so both the bundled DS
   // runtime and (if present) any other script see the same stub.
   await page.addInitScript(() => {
-    (window as unknown as Record<string, unknown>)['_saEventCalls'] = [] as string[];
-    (window as unknown as Record<string, unknown>)['sa_event'] = (
-      name: string,
-      props?: Record<string, unknown>,
-    ) => {
-      ((window as unknown as Record<string, unknown>)['_saEventCalls'] as string[]).push(name);
-      console.log('[sa_stub] sa_event:', name, props);
-    };
-  });
+    ;(window as unknown as Record<string, unknown>)['_saEventCalls'] = [] as string[]
+    ;(window as unknown as Record<string, unknown>)['sa_event'] = (name: string, props?: Record<string, unknown>) => {
+      ;((window as unknown as Record<string, unknown>)['_saEventCalls'] as string[]).push(name)
+      console.log('[sa_stub] sa_event:', name, props)
+    }
+  })
 
-  await page.goto('/');
+  await page.goto('/')
 
   // Wait for skeleton states to clear — the bookshelf is populated
-  await page.waitForFunction(
-    () => document.querySelectorAll('.is-loading').length === 0,
-    { timeout: 15_000 },
-  );
+  await page.waitForFunction(() => document.querySelectorAll('.is-loading').length === 0, {timeout: 15_000})
 
   // Ensure #cardBooks has at least one clickable shelf-book
-  await page.waitForSelector('#cardBooks .shelf-book[data-book]', { timeout: 10_000 });
+  await page.waitForSelector('#cardBooks .shelf-book[data-book]', {timeout: 10_000})
 }
 
 /**
@@ -118,9 +106,9 @@ async function navigateWithSaStub(page: Page): Promise<void> {
  * Returns the trigger element locator.
  */
 async function clickBookByAsin(page: Page, asin: string): Promise<void> {
-  const trigger = page.locator(`#cardBooks .shelf-book[data-book*="${asin}"]`).first();
-  await expect(trigger).toBeVisible();
-  await trigger.click();
+  const trigger = page.locator(`#cardBooks .shelf-book[data-book*="${asin}"]`).first()
+  await expect(trigger).toBeVisible()
+  await trigger.click()
 }
 
 // ---------------------------------------------------------------------------
@@ -128,86 +116,83 @@ async function clickBookByAsin(page: Page, asin: string): Promise<void> {
 // ---------------------------------------------------------------------------
 
 test.describe('BookModal — native <dialog> behavior', () => {
-  let page: Page;
+  let page: Page
 
-  test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
-    await interceptRoutes(page);
-    await navigateWithSaStub(page);
-  });
+  test.beforeAll(async ({browser}) => {
+    page = await browser.newPage()
+    await interceptRoutes(page)
+    await navigateWithSaStub(page)
+  })
 
   test.afterAll(async () => {
-    await page.close();
-  });
+    await page.close()
+  })
 
   // Helper: close the dialog if it's open between tests
   test.afterEach(async () => {
     const isOpen = await page.evaluate(() => {
-      const d = document.getElementById('bookDialog') as HTMLDialogElement | null;
-      return d ? d.open : false;
-    });
+      const d = document.getElementById('bookDialog') as HTMLDialogElement | null
+      return d ? d.open : false
+    })
     if (isOpen) {
-      await page.keyboard.press('Escape');
-      await page.waitForFunction(
-        () => !(document.getElementById('bookDialog') as HTMLDialogElement)?.open,
-        { timeout: 3000 },
-      );
+      await page.keyboard.press('Escape')
+      await page.waitForFunction(() => !(document.getElementById('bookDialog') as HTMLDialogElement)?.open, {timeout: 3000})
     }
-  });
+  })
 
   // -----------------------------------------------------------------------
   // 1. Open: dialog gets [open] + :modal, title visible
   // -----------------------------------------------------------------------
   test('1. clicking a shelf-book opens dialog#bookDialog with [open]', async () => {
     // reading book: Shorefall (B07QVH2Q2K)
-    await clickBookByAsin(page, 'B07QVH2Q2K');
-    const dialog = page.locator('dialog#bookDialog');
-    await expect(dialog).toHaveAttribute('open');
+    await clickBookByAsin(page, 'B07QVH2Q2K')
+    const dialog = page.locator('dialog#bookDialog')
+    await expect(dialog).toHaveAttribute('open')
     // Native <dialog> showModal → matches :modal (confirmed via evaluate)
     const isModal = await page.evaluate(() => {
-      const d = document.getElementById('bookDialog') as HTMLDialogElement | null;
-      return d ? d.matches(':modal') : false;
-    });
-    expect(isModal).toBe(true);
+      const d = document.getElementById('bookDialog') as HTMLDialogElement | null
+      return d ? d.matches(':modal') : false
+    })
+    expect(isModal).toBe(true)
     // Title is visible
-    await expect(page.locator('.book-modal-title')).toContainText('Shorefall');
-  });
+    await expect(page.locator('.book-modal-title')).toContainText('Shorefall')
+  })
 
   // -----------------------------------------------------------------------
   // 1b. Status-dependent fields — reading book (progress bar)
   // -----------------------------------------------------------------------
   test('1b-reading. reading book shows .book-modal-progress-fill with a width', async () => {
-    await clickBookByAsin(page, 'B07QVH2Q2K');
-    const progressFill = page.locator('.book-modal-progress-fill');
-    await expect(progressFill).toBeVisible();
-    const width = await progressFill.evaluate((el) => (el as HTMLElement).style.width);
-    expect(width).toBeTruthy();
-    expect(width).not.toBe('0%');
-  });
+    await clickBookByAsin(page, 'B07QVH2Q2K')
+    const progressFill = page.locator('.book-modal-progress-fill')
+    await expect(progressFill).toBeVisible()
+    const width = await progressFill.evaluate((el) => (el as HTMLElement).style.width)
+    expect(width).toBeTruthy()
+    expect(width).not.toBe('0%')
+  })
 
   // -----------------------------------------------------------------------
   // 1b. Status-dependent fields — finished book (finishedAt + notes)
   // -----------------------------------------------------------------------
   test('1b-finished. finished book shows .book-modal-finished-date and .book-modal-notes', async () => {
     // The Tainted Cup — finished with finishedAt + notes
-    await clickBookByAsin(page, '1984820710');
-    await expect(page.locator('.book-modal-title')).toContainText('The Tainted Cup');
-    await expect(page.locator('.book-modal-finished-date')).toBeVisible();
-    await expect(page.locator('.book-modal-notes')).toBeVisible();
+    await clickBookByAsin(page, '1984820710')
+    await expect(page.locator('.book-modal-title')).toContainText('The Tainted Cup')
+    await expect(page.locator('.book-modal-finished-date')).toBeVisible()
+    await expect(page.locator('.book-modal-notes')).toBeVisible()
     // Progress bar must NOT appear for a finished book
-    await expect(page.locator('.book-modal-progress-fill')).toHaveCount(0);
-  });
+    await expect(page.locator('.book-modal-progress-fill')).toHaveCount(0)
+  })
 
   // -----------------------------------------------------------------------
   // 1b. Status-dependent fields — upNext book (no progress, no notes)
   // -----------------------------------------------------------------------
   test('1b-upNext. upNext book shows neither progress fill nor notes', async () => {
     // Crafting Engineering Strategy — upNext
-    await clickBookByAsin(page, 'B0FBRJY116');
-    await expect(page.locator('.book-modal-title')).toContainText('Crafting Engineering Strategy');
-    await expect(page.locator('.book-modal-progress-fill')).toHaveCount(0);
-    await expect(page.locator('.book-modal-notes')).toHaveCount(0);
-  });
+    await clickBookByAsin(page, 'B0FBRJY116')
+    await expect(page.locator('.book-modal-title')).toContainText('Crafting Engineering Strategy')
+    await expect(page.locator('.book-modal-progress-fill')).toHaveCount(0)
+    await expect(page.locator('.book-modal-notes')).toHaveCount(0)
+  })
 
   // -----------------------------------------------------------------------
   // 2. Single-fire: sa_event('book_open') fires exactly once per open
@@ -215,93 +200,89 @@ test.describe('BookModal — native <dialog> behavior', () => {
   test('2. sa_event("book_open") fires exactly once per open (no double-init)', async () => {
     // Reset the call log
     await page.evaluate(() => {
-      (window as unknown as Record<string, unknown[]>)['_saEventCalls'] = [];
-    });
+      ;(window as unknown as Record<string, unknown[]>)['_saEventCalls'] = []
+    })
 
-    await clickBookByAsin(page, 'B07QVH2Q2K');
-    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open');
+    await clickBookByAsin(page, 'B07QVH2Q2K')
+    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open')
 
-    const calls = await page.evaluate(
-      () => (window as unknown as Record<string, unknown>)['_saEventCalls'] as string[],
-    );
-    expect(calls.filter((c) => c === 'book_open')).toHaveLength(1);
-  });
+    const calls = await page.evaluate(() => (window as unknown as Record<string, unknown>)['_saEventCalls'] as string[])
+    expect(calls.filter((c) => c === 'book_open')).toHaveLength(1)
+  })
 
   // -----------------------------------------------------------------------
   // 3. Escape closes the dialog
   // -----------------------------------------------------------------------
   test('3. pressing Escape closes the dialog', async () => {
-    await clickBookByAsin(page, 'B07QVH2Q2K');
-    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open');
+    await clickBookByAsin(page, 'B07QVH2Q2K')
+    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open')
 
-    await page.keyboard.press('Escape');
+    await page.keyboard.press('Escape')
 
-    await expect(page.locator('dialog#bookDialog')).not.toHaveAttribute('open');
-  });
+    await expect(page.locator('dialog#bookDialog')).not.toHaveAttribute('open')
+  })
 
   // -----------------------------------------------------------------------
   // 4a. Backdrop click closes the dialog
   // -----------------------------------------------------------------------
   test('4a. clicking outside dialog box bounds (backdrop) closes it', async () => {
-    await clickBookByAsin(page, 'B07QVH2Q2K');
-    const dialog = page.locator('dialog#bookDialog');
-    await expect(dialog).toHaveAttribute('open');
+    await clickBookByAsin(page, 'B07QVH2Q2K')
+    const dialog = page.locator('dialog#bookDialog')
+    await expect(dialog).toHaveAttribute('open')
 
     // Get dialog bounding box and click outside (top-left corner of viewport)
-    const box = await dialog.boundingBox();
-    expect(box).not.toBeNull();
+    const box = await dialog.boundingBox()
+    expect(box).not.toBeNull()
     // Click at (1, 1) — outside the dialog box (dialog is centered)
-    await page.mouse.click(1, 1);
+    await page.mouse.click(1, 1)
 
-    await expect(dialog).not.toHaveAttribute('open');
-  });
+    await expect(dialog).not.toHaveAttribute('open')
+  })
 
   // -----------------------------------------------------------------------
   // 4b. Click inside the modal does NOT close it
   // -----------------------------------------------------------------------
   test('4b. clicking inside the dialog box does not close it', async () => {
-    await clickBookByAsin(page, 'B07QVH2Q2K');
-    const dialog = page.locator('dialog#bookDialog');
-    await expect(dialog).toHaveAttribute('open');
+    await clickBookByAsin(page, 'B07QVH2Q2K')
+    const dialog = page.locator('dialog#bookDialog')
+    await expect(dialog).toHaveAttribute('open')
 
     // Click the title (inside dialog) — should not close
-    await page.locator('.book-modal-title').click();
+    await page.locator('.book-modal-title').click()
 
-    await expect(dialog).toHaveAttribute('open');
-  });
+    await expect(dialog).toHaveAttribute('open')
+  })
 
   // -----------------------------------------------------------------------
   // 5. Close button closes the dialog
   // -----------------------------------------------------------------------
   test('5. clicking .book-modal-close closes the dialog', async () => {
-    await clickBookByAsin(page, 'B07QVH2Q2K');
-    const dialog = page.locator('dialog#bookDialog');
-    await expect(dialog).toHaveAttribute('open');
+    await clickBookByAsin(page, 'B07QVH2Q2K')
+    const dialog = page.locator('dialog#bookDialog')
+    await expect(dialog).toHaveAttribute('open')
 
-    await page.locator('.book-modal-close').click();
+    await page.locator('.book-modal-close').click()
 
-    await expect(dialog).not.toHaveAttribute('open');
-  });
+    await expect(dialog).not.toHaveAttribute('open')
+  })
 
   // -----------------------------------------------------------------------
   // 6. Focus restore: after close, focus returns to the trigger
   // -----------------------------------------------------------------------
   test('6. closing modal returns focus to the originating shelf-book trigger', async () => {
-    const trigger = page.locator('#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]').first();
-    await trigger.click();
-    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open');
+    const trigger = page.locator('#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]').first()
+    await trigger.click()
+    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open')
 
-    await page.locator('.book-modal-close').click();
-    await expect(page.locator('dialog#bookDialog')).not.toHaveAttribute('open');
+    await page.locator('.book-modal-close').click()
+    await expect(page.locator('dialog#bookDialog')).not.toHaveAttribute('open')
 
     const isFocused = await page.evaluate(() => {
-      const trigger = document.querySelector(
-        '#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]',
-      ) as HTMLElement | null;
-      return document.activeElement === trigger;
-    });
-    expect(isFocused).toBe(true);
-  });
+      const trigger = document.querySelector('#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]') as HTMLElement | null
+      return document.activeElement === trigger
+    })
+    expect(isFocused).toBe(true)
+  })
 
   // -----------------------------------------------------------------------
   // 6b. KEYBOARD dismiss (Escape) restores focus to the trigger AND shows the
@@ -310,42 +291,42 @@ test.describe('BookModal — native <dialog> behavior', () => {
   //     keeps the ring for keyboard input; pointer dismiss suppresses it (6c).
   // -----------------------------------------------------------------------
   test('6b. Escape (keyboard) dismiss returns focus to the trigger WITH a GREEN ring (DS intent)', async () => {
-    const trigger = page.locator('#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]').first();
+    const trigger = page.locator('#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]').first()
     // Open via KEYBOARD so the input-modality tracker records `keyboard`.
-    await trigger.focus();
-    await page.keyboard.press('Enter');
-    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open');
+    await trigger.focus()
+    await page.keyboard.press('Enter')
+    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open')
 
-    await page.keyboard.press('Escape');
-    await expect(page.locator('dialog#bookDialog')).not.toHaveAttribute('open');
+    await page.keyboard.press('Escape')
+    await expect(page.locator('dialog#bookDialog')).not.toHaveAttribute('open')
 
     const state = await page.evaluate(() => {
-      const t = document.querySelector(
-        '#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]',
-      ) as HTMLElement | null;
-      if (!t) return null;
+      const t = document.querySelector('#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]') as HTMLElement | null
+      if (!t) {
+        return null
+      }
       // Resolve the token to rgb via a probe so the comparison is format-agnostic.
-      const probe = document.createElement('span');
-      probe.style.color = 'var(--lg-color-accent-green)';
-      document.body.appendChild(probe);
-      const greenRgb = getComputedStyle(probe).color;
-      probe.remove();
+      const probe = document.createElement('span')
+      probe.style.color = 'var(--lg-color-accent-green)'
+      document.body.appendChild(probe)
+      const greenRgb = getComputedStyle(probe).color
+      probe.remove()
       return {
         focused: document.activeElement === t,
         modality: document.documentElement.dataset.inputModality,
         outlineStyle: getComputedStyle(t).outlineStyle,
         outlineColor: getComputedStyle(t).outlineColor,
-        greenRgb,
-      };
-    });
-    expect(state?.focused).toBe(true);
+        greenRgb
+      }
+    })
+    expect(state?.focused).toBe(true)
     // Keyboard modality → the focus ring IS visible on the returned-focus trigger.
-    expect(state?.modality).toBe('keyboard');
-    expect(state?.outlineStyle).not.toBe('none');
+    expect(state?.modality).toBe('keyboard')
+    expect(state?.outlineStyle).not.toBe('none')
     // DS intent restored: the book-tile focus ring is green
     // (base.css .shelf-book:focus-visible), not the old global pink.
-    expect(state?.outlineColor).toBe(state?.greenRgb);
-  });
+    expect(state?.outlineColor).toBe(state?.greenRgb)
+  })
 
   // -----------------------------------------------------------------------
   // 6c. POINTER dismiss (tap ×) restores focus to the trigger but SUPPRESSES the
@@ -354,66 +335,68 @@ test.describe('BookModal — native <dialog> behavior', () => {
   //     `pointer`, and a11y.css hides the ring under pointer modality).
   // -----------------------------------------------------------------------
   test('6c. pointer dismiss returns focus to the trigger with NO visible ring', async () => {
-    const trigger = page.locator('#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]').first();
-    await trigger.click(); // pointer input → modality = pointer
-    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open');
+    const trigger = page.locator('#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]').first()
+    await trigger.click() // pointer input → modality = pointer
+    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open')
 
-    await page.locator('.book-modal-close').click(); // pointer dismiss
-    await expect(page.locator('dialog#bookDialog')).not.toHaveAttribute('open');
+    await page.locator('.book-modal-close').click() // pointer dismiss
+    await expect(page.locator('dialog#bookDialog')).not.toHaveAttribute('open')
 
     const state = await page.evaluate(() => {
-      const t = document.querySelector(
-        '#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]',
-      ) as HTMLElement | null;
-      if (!t) return null;
+      const t = document.querySelector('#cardBooks .shelf-book[data-book*="B07QVH2Q2K"]') as HTMLElement | null
+      if (!t) {
+        return null
+      }
       return {
         focused: document.activeElement === t,
         modality: document.documentElement.dataset.inputModality,
-        outlineStyle: getComputedStyle(t).outlineStyle,
-      };
-    });
-    expect(state?.focused).toBe(true);
-    expect(state?.modality).toBe('pointer');
-    expect(state?.outlineStyle).toBe('none');
-  });
+        outlineStyle: getComputedStyle(t).outlineStyle
+      }
+    })
+    expect(state?.focused).toBe(true)
+    expect(state?.modality).toBe('pointer')
+    expect(state?.outlineStyle).toBe('none')
+  })
 
   // -----------------------------------------------------------------------
   // 7. Focus containment: dialog is :modal → background is inert
   // -----------------------------------------------------------------------
   test('7. while dialog is open, background #main-content is not focusable (dialog :modal)', async () => {
-    await clickBookByAsin(page, 'B07QVH2Q2K');
-    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open');
+    await clickBookByAsin(page, 'B07QVH2Q2K')
+    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open')
 
     // Confirm :modal (background inert via showModal)
     const isModal = await page.evaluate(() => {
-      const d = document.getElementById('bookDialog') as HTMLDialogElement | null;
-      return d ? d.matches(':modal') : false;
-    });
-    expect(isModal).toBe(true);
+      const d = document.getElementById('bookDialog') as HTMLDialogElement | null
+      return d ? d.matches(':modal') : false
+    })
+    expect(isModal).toBe(true)
 
     // Try to focus an element outside the dialog — should fail (inert background)
     const canFocusBehind = await page.evaluate(() => {
       // Find any focusable element in #main-content
-      const mc = document.getElementById('main-content');
-      if (!mc) return false;
-      const focusable = mc.querySelector<HTMLElement>(
-        'a[href], button, input, [tabindex]:not([tabindex="-1"])',
-      );
-      if (!focusable) return false;
-      focusable.focus();
-      return document.activeElement === focusable;
-    });
-    expect(canFocusBehind).toBe(false);
-  });
+      const mc = document.getElementById('main-content')
+      if (!mc) {
+        return false
+      }
+      const focusable = mc.querySelector<HTMLElement>('a[href], button, input, [tabindex]:not([tabindex="-1"])')
+      if (!focusable) {
+        return false
+      }
+      focusable.focus()
+      return document.activeElement === focusable
+    })
+    expect(canFocusBehind).toBe(false)
+  })
 
   // -----------------------------------------------------------------------
   // 8. CSP onerror fix: .book-modal-cover must NOT have an onerror= attribute
   // -----------------------------------------------------------------------
   test('8. .book-modal-cover outerHTML contains no onerror= attribute (D3 CSP fix)', async () => {
-    await clickBookByAsin(page, 'B07QVH2Q2K');
-    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open');
+    await clickBookByAsin(page, 'B07QVH2Q2K')
+    await expect(page.locator('dialog#bookDialog')).toHaveAttribute('open')
 
-    const outerHtml = await page.locator('.book-modal-cover').first().evaluate((el) => el.outerHTML);
-    expect(outerHtml).not.toContain('onerror=');
-  });
-});
+    const outerHtml = await page.locator('.book-modal-cover').first().evaluate((el) => el.outerHTML)
+    expect(outerHtml).not.toContain('onerror=')
+  })
+})

--- a/tests/behavioral/mobile-layout.spec.ts
+++ b/tests/behavioral/mobile-layout.spec.ts
@@ -21,31 +21,25 @@
  * Shares the route-interception pattern from book-modal.spec.ts: all CloudFront
  * endpoints use fixtures, WebSocket and external resources are blocked.
  */
-import { createRequire } from 'node:module';
-import { test, expect, type Page } from '@playwright/test';
-import { CLOUDFRONT_BASE, WEBSOCKET_URL } from '@lifegames/portal-contract/constants';
+import {createRequire} from 'node:module'
+import {expect, type Page, test} from '@playwright/test'
+import {CLOUDFRONT_BASE, WEBSOCKET_URL} from '@lifegames/portal-contract/constants'
 
-const require = createRequire(import.meta.url);
+const require = createRequire(import.meta.url)
 
 function baselineFixture(dir: string): string {
-  return require.resolve(`@lifegames/fixtures/generated/${dir}/baseline.json`);
+  return require.resolve(`@lifegames/fixtures/generated/${dir}/baseline.json`)
 }
 
 function emptyFixture(dir: string): string {
-  return require.resolve(`@lifegames/fixtures/generated/${dir}/empty.json`);
+  return require.resolve(`@lifegames/fixtures/generated/${dir}/empty.json`)
 }
 
 /** Bug-6 fixture: an article with `articleTitle: ""` + an overlong `sourceTitle`. */
-const READING_EMPTY_TITLE_FIXTURE = require.resolve(
-  '@lifegames/fixtures/generated/articles/hoodlineEmptyTitle.json',
-);
+const READING_EMPTY_TITLE_FIXTURE = require.resolve('@lifegames/fixtures/generated/articles/hoodlineEmptyTitle.json')
 
 /** 1×1 transparent PNG used as a placeholder for external images. */
-const TRANSPARENT_PIXEL = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB'
-    + 'Nl7BcQAAAABJRU5ErkJggg==',
-  'base64',
-);
+const TRANSPARENT_PIXEL = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB' + 'Nl7BcQAAAABJRU5ErkJggg==', 'base64')
 
 /**
  * Route interception: baseline fixtures for every CloudFront endpoint, with
@@ -53,7 +47,7 @@ const TRANSPARENT_PIXEL = Buffer.from(
  */
 async function interceptRoutes(page: Page, overrides: Record<string, string> = {}): Promise<void> {
   await page.route(`${CLOUDFRONT_BASE}/**`, async (route) => {
-    const url = new URL(route.request().url());
+    const url = new URL(route.request().url())
     const fixtureMap: Record<string, string> = {
       '/health.json': baselineFixture('health'),
       '/sleep.json': baselineFixture('sleep'),
@@ -65,119 +59,116 @@ async function interceptRoutes(page: Page, overrides: Record<string, string> = {
       '/location.json': baselineFixture('location'),
       '/focus.json': emptyFixture('focus'),
       '/theatre-reviews.json': baselineFixture('theatre-reviews'),
-      ...overrides,
-    };
-    const fixturePath = fixtureMap[url.pathname];
-    if (fixturePath) {
-      await route.fulfill({ path: fixturePath, contentType: 'application/json' });
-    } else {
-      await route.abort();
+      ...overrides
     }
-  });
+    const fixturePath = fixtureMap[url.pathname]
+    if (fixturePath) {
+      await route.fulfill({path: fixturePath, contentType: 'application/json'})
+    } else {
+      await route.abort()
+    }
+  })
 
-  await page.route(`${WEBSOCKET_URL}/**`, (route) => route.abort());
+  await page.route(`${WEBSOCKET_URL}/**`, (route) => route.abort())
 
   await page.route('**/*', async (route) => {
-    const url = route.request().url();
+    const url = route.request().url()
     if (
-      url.startsWith('http://localhost')
-      || url.startsWith('data:')
-      || url.startsWith(CLOUDFRONT_BASE)
-      || url.startsWith(WEBSOCKET_URL.replace('wss://', 'https://'))
-      || url.startsWith('wss://')
+      url.startsWith('http://localhost') ||
+      url.startsWith('data:') ||
+      url.startsWith(CLOUDFRONT_BASE) ||
+      url.startsWith(WEBSOCKET_URL.replace('wss://', 'https://')) ||
+      url.startsWith('wss://')
     ) {
-      await route.fallback();
-      return;
+      await route.fallback()
+      return
     }
     if (route.request().resourceType() === 'image') {
-      await route.fulfill({ status: 200, contentType: 'image/png', body: TRANSPARENT_PIXEL });
+      await route.fulfill({status: 200, contentType: 'image/png', body: TRANSPARENT_PIXEL})
     } else {
-      await route.abort();
+      await route.abort()
     }
-  });
+  })
 }
 
 /** Navigate to the dashboard and wait for live-data hydration to complete. */
 async function navigateAndWaitForHydration(page: Page): Promise<void> {
-  await page.goto('/');
-  await page.waitForFunction(() => document.querySelectorAll('.is-loading').length === 0, {
-    timeout: 15_000,
-  });
+  await page.goto('/')
+  await page.waitForFunction(() => document.querySelectorAll('.is-loading').length === 0, {timeout: 15_000})
 }
 
 test.describe('Mobile layout — system-status alignment + reading-feed truncation', () => {
-  test.describe.configure({ mode: 'serial' });
+  test.describe.configure({mode: 'serial'})
 
   // -----------------------------------------------------------------------
   // Bug 8: system-status subgrid alignment (baseline data)
   // -----------------------------------------------------------------------
-  let page: Page;
+  let page: Page
 
-  test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
-    await interceptRoutes(page);
-    await navigateAndWaitForHydration(page);
-  });
+  test.beforeAll(async ({browser}) => {
+    page = await browser.newPage()
+    await interceptRoutes(page)
+    await navigateAndWaitForHydration(page)
+  })
 
   test.afterAll(async () => {
-    await page.close();
-  });
+    await page.close()
+  })
 
   test('8a. #systemStatus and .sys-line compute as CSS grid (subgrid, not flex+min-width)', async () => {
     const displays = await page.evaluate(() => {
-      const ss = document.getElementById('systemStatus');
-      const line = document.querySelector('#systemStatus .sys-line');
-      return {
-        systemStatus: ss ? getComputedStyle(ss).display : null,
-        sysLine: line ? getComputedStyle(line).display : null,
-      };
-    });
+      const ss = document.getElementById('systemStatus')
+      const line = document.querySelector('#systemStatus .sys-line')
+      return {systemStatus: ss ? getComputedStyle(ss).display : null, sysLine: line ? getComputedStyle(line).display : null}
+    })
     // Deterministic regression guard: old code was `display:flex` on .sys-line and
     // default block on #systemStatus. The subgrid fix makes both `grid`.
-    expect(displays.systemStatus).toBe('grid');
-    expect(displays.sysLine).toBe('grid');
-  });
+    expect(displays.systemStatus).toBe('grid')
+    expect(displays.sysLine).toBe('grid')
+  })
 
   test('8b. all .sys-val cells share the same left offset (within 1px)', async () => {
     const lefts = await page.evaluate(() =>
-      Array.from(document.querySelectorAll('#systemStatus .sys-line > [class*="sys-val"]')).map(
-        (el) => el.getBoundingClientRect().left,
-      )
-    );
-    expect(lefts.length).toBeGreaterThan(1);
-    expect(Math.max(...lefts) - Math.min(...lefts)).toBeLessThanOrEqual(1);
-  });
+      Array.from(document.querySelectorAll('#systemStatus .sys-line > [class*="sys-val"]')).map((el) => el.getBoundingClientRect().left)
+    )
+    expect(lefts.length).toBeGreaterThan(1)
+    expect(Math.max(...lefts) - Math.min(...lefts)).toBeLessThanOrEqual(1)
+  })
 
   test('8c. #cardSystem does not overflow its container', async () => {
     const dims = await page.evaluate(() => {
-      const el = document.getElementById('cardSystem');
-      if (!el) return null;
-      return { scrollWidth: el.scrollWidth, offsetWidth: el.offsetWidth };
-    });
-    expect(dims).not.toBeNull();
-    expect(dims!.scrollWidth).toBeLessThanOrEqual(dims!.offsetWidth);
-  });
+      const el = document.getElementById('cardSystem')
+      if (!el) {
+        return null
+      }
+      return {scrollWidth: el.scrollWidth, offsetWidth: el.offsetWidth}
+    })
+    expect(dims).not.toBeNull()
+    expect(dims!.scrollWidth).toBeLessThanOrEqual(dims!.offsetWidth)
+  })
 
   // -----------------------------------------------------------------------
   // Bug 6: reading feed empty-title / long-source truncation
   // -----------------------------------------------------------------------
-  test('6. reading feed promotes an empty-title source into the title slot and truncates it so the date stays visible', async ({ browser }) => {
-    const readingPage = await browser.newPage();
-    await interceptRoutes(readingPage, { '/articles.json': READING_EMPTY_TITLE_FIXTURE });
-    await navigateAndWaitForHydration(readingPage);
+  test('6. reading feed promotes an empty-title source into the title slot and truncates it so the date stays visible', async ({browser}) => {
+    const readingPage = await browser.newPage()
+    await interceptRoutes(readingPage, {'/articles.json': READING_EMPTY_TITLE_FIXTURE})
+    await navigateAndWaitForHydration(readingPage)
 
     const r = await readingPage.evaluate(() => {
-      const card = document.getElementById('cardReading');
-      const rows = document.querySelectorAll('#cardReading .article-list-item');
-      const row = rows[0] ?? null;
+      const card = document.getElementById('cardReading')
+      const rows = document.querySelectorAll('#cardReading .article-list-item')
+      const row = rows[0] ?? null
       // The mixed fixture ends with a normal titled row; it must KEEP its source span,
       // proving the parenthetical is suppressed only for empty-title rows (not blanket).
-      const titledRow = rows[rows.length - 1] ?? null;
-      const title = row?.querySelector('.article-list-title') as HTMLElement | null;
-      const date = row?.querySelector('.article-list-date') as HTMLElement | null;
-      if (!card || !row || !title || !date || !titledRow || titledRow === row) return null;
-      const cardRect = card.getBoundingClientRect();
-      const dateRect = date.getBoundingClientRect();
+      const titledRow = rows[rows.length - 1] ?? null
+      const title = row?.querySelector('.article-list-title') as HTMLElement | null
+      const date = row?.querySelector('.article-list-date') as HTMLElement | null
+      if (!card || !row || !title || !date || !titledRow || titledRow === row) {
+        return null
+      }
+      const cardRect = card.getBoundingClientRect()
+      const dateRect = date.getBoundingClientRect()
       return {
         cardOverflow: card.scrollWidth - card.clientWidth,
         // Empty title is filled from the source, so the row never renders blank-left.
@@ -188,11 +179,11 @@ test.describe('Mobile layout — system-status alignment + reading-feed truncati
         titleTruncated: title.scrollWidth > title.clientWidth + 1,
         dateWithinCard: dateRect.width > 0 && dateRect.right <= cardRect.right + 1,
         // Conditional-suppression control: a titled row retains its parenthetical.
-        titledRowHasSource: titledRow.querySelector('.article-list-source') !== null,
-      };
-    });
+        titledRowHasSource: titledRow.querySelector('.article-list-source') !== null
+      }
+    })
 
-    expect(r).not.toBeNull();
+    expect(r).not.toBeNull()
     // Empty-title rows promote the source into the title slot (never blank-left); the
     // title (flex:1 1 auto; min-width:0; ellipsis) truncates so the row fits and the
     // "— Nd ago" date stays inside the card, and the source is not duplicated in a
@@ -200,13 +191,13 @@ test.describe('Mobile layout — system-status alignment + reading-feed truncati
     // parenthetical, so the suppression is conditional (not a blanket removal). Old
     // code (source flex-shrink:0, no ellipsis) overran the row and pushed the date
     // past the card edge.
-    expect(r!.titleText).toContain('Hoodline');
-    expect(r!.hasSourceSpan).toBe(false);
-    expect(r!.titledRowHasSource).toBe(true);
-    expect(r!.cardOverflow).toBeLessThanOrEqual(1);
-    expect(r!.titleTruncated).toBe(true);
-    expect(r!.dateWithinCard).toBe(true);
+    expect(r!.titleText).toContain('Hoodline')
+    expect(r!.hasSourceSpan).toBe(false)
+    expect(r!.titledRowHasSource).toBe(true)
+    expect(r!.cardOverflow).toBeLessThanOrEqual(1)
+    expect(r!.titleTruncated).toBe(true)
+    expect(r!.dateWithinCard).toBe(true)
 
-    await readingPage.close();
-  });
-});
+    await readingPage.close()
+  })
+})

--- a/tests/behavioral/system-status-popover.spec.ts
+++ b/tests/behavioral/system-status-popover.spec.ts
@@ -16,26 +16,22 @@
  *
  * Plan §4.1 acceptance criteria. Mirrors tests/behavioral/book-modal.spec.ts.
  */
-import { createRequire } from 'node:module';
-import { test, expect, type Page } from '@playwright/test';
-import { CLOUDFRONT_BASE, WEBSOCKET_URL } from '@lifegames/portal-contract/constants';
+import {createRequire} from 'node:module'
+import {expect, type Page, test} from '@playwright/test'
+import {CLOUDFRONT_BASE, WEBSOCKET_URL} from '@lifegames/portal-contract/constants'
 
-const require = createRequire(import.meta.url);
+const require = createRequire(import.meta.url)
 
 function baselineFixture(dir: string, file: string): string {
-  const camelFile = file.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
-  return require.resolve(`@lifegames/fixtures/generated/${dir}/${camelFile}.json`);
+  const camelFile = file.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase())
+  return require.resolve(`@lifegames/fixtures/generated/${dir}/${camelFile}.json`)
 }
 
-const TRANSPARENT_PIXEL = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB'
-    + 'Nl7BcQAAAABJRU5ErkJggg==',
-  'base64',
-);
+const TRANSPARENT_PIXEL = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB' + 'Nl7BcQAAAABJRU5ErkJggg==', 'base64')
 
 async function interceptRoutes(page: Page): Promise<void> {
   await page.route(`${CLOUDFRONT_BASE}/**`, async (route) => {
-    const url = new URL(route.request().url());
+    const url = new URL(route.request().url())
     const fixtureMap: Record<string, string> = {
       '/health.json': baselineFixture('health', 'baseline'),
       '/sleep.json': baselineFixture('sleep', 'baseline'),
@@ -46,43 +42,41 @@ async function interceptRoutes(page: Page): Promise<void> {
       '/articles.json': baselineFixture('articles', 'baseline'),
       '/location.json': baselineFixture('location', 'baseline'),
       '/focus.json': baselineFixture('focus', 'empty'),
-      '/theatre-reviews.json': baselineFixture('theatre-reviews', 'baseline'),
-    };
-    const fixturePath = fixtureMap[url.pathname];
-    if (fixturePath) {
-      await route.fulfill({ path: fixturePath, contentType: 'application/json' });
-    } else {
-      await route.abort();
+      '/theatre-reviews.json': baselineFixture('theatre-reviews', 'baseline')
     }
-  });
+    const fixturePath = fixtureMap[url.pathname]
+    if (fixturePath) {
+      await route.fulfill({path: fixturePath, contentType: 'application/json'})
+    } else {
+      await route.abort()
+    }
+  })
 
-  await page.route(`${WEBSOCKET_URL}/**`, (route) => route.abort());
+  await page.route(`${WEBSOCKET_URL}/**`, (route) => route.abort())
 
   await page.route('**/*', async (route) => {
-    const url = route.request().url();
+    const url = route.request().url()
     if (
-      url.startsWith('http://localhost')
-      || url.startsWith('data:')
-      || url.startsWith(CLOUDFRONT_BASE)
-      || url.startsWith(WEBSOCKET_URL.replace('wss://', 'https://'))
-      || url.startsWith('wss://')
+      url.startsWith('http://localhost') ||
+      url.startsWith('data:') ||
+      url.startsWith(CLOUDFRONT_BASE) ||
+      url.startsWith(WEBSOCKET_URL.replace('wss://', 'https://')) ||
+      url.startsWith('wss://')
     ) {
-      await route.fallback();
-      return;
+      await route.fallback()
+      return
     }
     if (route.request().resourceType() === 'image') {
-      await route.fulfill({ status: 200, contentType: 'image/png', body: TRANSPARENT_PIXEL });
+      await route.fulfill({status: 200, contentType: 'image/png', body: TRANSPARENT_PIXEL})
     } else {
-      await route.abort();
+      await route.abort()
     }
-  });
+  })
 }
 
 async function navigateAndWaitForHydration(page: Page): Promise<void> {
-  await page.goto('/');
-  await page.waitForFunction(() => document.querySelectorAll('.is-loading').length === 0, {
-    timeout: 15_000,
-  });
+  await page.goto('/')
+  await page.waitForFunction(() => document.querySelectorAll('.is-loading').length === 0, {timeout: 15_000})
 }
 
 // ---------------------------------------------------------------------------
@@ -90,73 +84,64 @@ async function navigateAndWaitForHydration(page: Page): Promise<void> {
 // ---------------------------------------------------------------------------
 
 // Health is the canonical test target: it has three links in its popover.
-const HEALTH_BUTTON = '#systemStatus .sys-line[data-source="health"] .sys-info';
-const HEALTH_POPOVER = '#tip-health';
+const HEALTH_BUTTON = '#systemStatus .sys-line[data-source="health"] .sys-info'
+const HEALTH_POPOVER = '#tip-health'
 // First link in the Health popover: Apple Watch 11 (exact URL from @lifegames/copy)
-const WATCH_LINK_HREF = 'https://www.apple.com/apple-watch-series-11/';
+const WATCH_LINK_HREF = 'https://www.apple.com/apple-watch-series-11/'
 
 // ---------------------------------------------------------------------------
 // Suite
 // ---------------------------------------------------------------------------
 
 test.describe('SystemStatus provenance disclosure — popover behavior', () => {
-  test.describe.configure({ mode: 'serial' });
+  test.describe.configure({mode: 'serial'})
 
-  let page: Page;
+  let page: Page
 
-  test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
-    await interceptRoutes(page);
-    await navigateAndWaitForHydration(page);
-  });
+  test.beforeAll(async ({browser}) => {
+    page = await browser.newPage()
+    await interceptRoutes(page)
+    await navigateAndWaitForHydration(page)
+  })
 
   test.afterAll(async () => {
-    await page.close();
-  });
+    await page.close()
+  })
 
   // Close the Health popover between tests so each test starts from a clean state.
   test.afterEach(async () => {
-    const isOpen = await page.evaluate(
-      () => document.getElementById('tip-health')?.matches(':popover-open') ?? false,
-    );
+    const isOpen = await page.evaluate(() => document.getElementById('tip-health')?.matches(':popover-open') ?? false)
     if (isOpen) {
-      await page.keyboard.press('Escape');
-      await page.waitForFunction(
-        () => !(document.getElementById('tip-health')?.matches(':popover-open') ?? false),
-        { timeout: 3000 },
-      );
+      await page.keyboard.press('Escape')
+      await page.waitForFunction(() => !(document.getElementById('tip-health')?.matches(':popover-open') ?? false), {timeout: 3000})
     }
-  });
+  })
 
   // -----------------------------------------------------------------------
   // 1. SSR structure — 7 buttons present; Location row has none
   // -----------------------------------------------------------------------
   test('1. seven .sys-info buttons rendered; Location row gets none', async () => {
-    const buttons = page.locator('#systemStatus .sys-info');
+    const buttons = page.locator('#systemStatus .sys-info')
     // Health, Sleep, Books, Articles, GithubEvents, StarredRepos, TheatreReviews
-    await expect(buttons).toHaveCount(7);
+    await expect(buttons).toHaveCount(7)
 
     // Location is filtered in production (SystemStatus.astro compact branch line 48)
-    await expect(
-      page.locator('#systemStatus .sys-line[data-source="location"] .sys-info'),
-    ).toHaveCount(0);
-  });
+    await expect(page.locator('#systemStatus .sys-line[data-source="location"] .sys-info')).toHaveCount(0)
+  })
 
   // -----------------------------------------------------------------------
   // 2. Click opens the popover (:popover-open / visible)
   // -----------------------------------------------------------------------
   test('2. clicking the Health .sys-info opens #tip-health', async () => {
-    await page.locator(HEALTH_BUTTON).click();
+    await page.locator(HEALTH_BUTTON).click()
 
-    const popover = page.locator(HEALTH_POPOVER);
-    await expect(popover).toBeVisible();
+    const popover = page.locator(HEALTH_POPOVER)
+    await expect(popover).toBeVisible()
 
     // UA :popover-open pseudo-class
-    const isOpen = await page.evaluate(
-      () => document.getElementById('tip-health')?.matches(':popover-open') ?? false,
-    );
-    expect(isOpen).toBe(true);
-  });
+    const isOpen = await page.evaluate(() => document.getElementById('tip-health')?.matches(':popover-open') ?? false)
+    expect(isOpen).toBe(true)
+  })
 
   // -----------------------------------------------------------------------
   // 2b. Positioning regression guard (the bug the shipped feature slipped past)
@@ -174,54 +159,53 @@ test.describe('SystemStatus provenance disclosure — popover behavior', () => {
   // asserting.
   // -----------------------------------------------------------------------
   test('2b. opened popover anchors adjacent to its trigger (no top-left jump, no centered fallback)', async () => {
-    await page.locator(HEALTH_BUTTON).click();
-    await expect(page.locator(HEALTH_POPOVER)).toBeVisible();
+    await page.locator(HEALTH_BUTTON).click()
+    await expect(page.locator(HEALTH_POPOVER)).toBeVisible()
 
-    const popover = page.locator(HEALTH_POPOVER);
+    const popover = page.locator(HEALTH_POPOVER)
 
     // Settle: poll until the popover's top is stable across two consecutive
     // reads (absorbs the scale entry animation), then read the final rect.
-    let prevTop: number | null = null;
-    await expect
-      .poll(
-        async () => {
-          const box = await popover.boundingBox();
-          if (!box) return false;
-          const stable = prevTop !== null && Math.abs(box.y - prevTop) < 0.5;
-          prevTop = box.y;
-          return stable;
-        },
-        { timeout: 3000, intervals: [100, 100, 100, 100] },
-      )
-      .toBe(true);
+    let prevTop: number | null = null
+    await expect.poll(async () => {
+      const box = await popover.boundingBox()
+      if (!box) {
+        return false
+      }
+      const stable = prevTop !== null && Math.abs(box.y - prevTop) < 0.5
+      prevTop = box.y
+      return stable
+    }, {timeout: 3000, intervals: [100, 100, 100, 100]}).toBe(true)
 
-    const pop = await popover.boundingBox();
-    const trig = await page.locator(HEALTH_BUTTON).boundingBox();
-    if (!pop || !trig) throw new Error('missing bounding box');
+    const pop = await popover.boundingBox()
+    const trig = await page.locator(HEALTH_BUTTON).boundingBox()
+    if (!pop || !trig) {
+      throw new Error('missing bounding box')
+    }
 
-    const popTop = pop.y;
-    const popBottom = pop.y + pop.height;
-    const popLeft = pop.x;
-    const popRight = pop.x + pop.width;
-    const trigTop = trig.y;
-    const trigBottom = trig.y + trig.height;
-    const trigCenterX = trig.x + trig.width / 2;
+    const popTop = pop.y
+    const popBottom = pop.y + pop.height
+    const popLeft = pop.x
+    const popRight = pop.x + pop.width
+    const trigTop = trig.y
+    const trigBottom = trig.y + trig.height
+    const trigCenterX = trig.x + trig.width / 2
 
     // (a) Block adjacency (primary discriminator): the popover's near block edge
     // hugs the trigger. Separates the ANCHORED state from BOTH failure modes —
     // the top-left bug (top ≈ 0) and the centered fallback (bottom: 1rem, pinned
     // near the viewport bottom, far from the trigger).
-    const blockGap = Math.min(Math.abs(popTop - trigBottom), Math.abs(popBottom - trigTop));
-    expect(blockGap).toBeLessThan(16);
+    const blockGap = Math.min(Math.abs(popTop - trigBottom), Math.abs(popBottom - trigTop))
+    expect(blockGap).toBeLessThan(16)
 
     // (b) Inline proximity: the nearest horizontal edge of the popover is close
     // to the trigger's center-x (accounts for `flip-inline`). NOT `left ≈ trigger.left`.
-    const inlineGap = Math.min(Math.abs(popRight - trigCenterX), Math.abs(popLeft - trigCenterX));
-    expect(inlineGap).toBeLessThan(48);
+    const inlineGap = Math.min(Math.abs(popRight - trigCenterX), Math.abs(popLeft - trigCenterX))
+    expect(inlineGap).toBeLessThan(48)
 
     // Explicitly kill the exact shipped bug: the popover must not sit at the
     // viewport top. (Implied by (a), asserted for clarity.)
-    expect(popTop).toBeGreaterThan(16);
+    expect(popTop).toBeGreaterThan(16)
 
     // Caret presence: with anchoring active the clip-path + at least one caret
     // pseudo-element must be live. clip-path on the popover is non-none, and the
@@ -229,120 +213,115 @@ test.describe('SystemStatus provenance disclosure — popover behavior', () => {
     const caret = await popover.evaluate((el) => ({
       clipPath: getComputedStyle(el).clipPath,
       beforeContent: getComputedStyle(el, '::before').content,
-      afterContent: getComputedStyle(el, '::after').content,
-    }));
-    expect(caret.clipPath).not.toBe('none');
+      afterContent: getComputedStyle(el, '::after').content
+    }))
+    expect(caret.clipPath).not.toBe('none')
     // One of the two carets is revealed depending on block flip; both have
     // generated content (the clip-path hides the wrong one visually).
-    expect(caret.beforeContent === 'none' && caret.afterContent === 'none').toBe(false);
-  });
+    expect(caret.beforeContent === 'none' && caret.afterContent === 'none').toBe(false)
+  })
 
   // -----------------------------------------------------------------------
   // 3. Escape closes the popover + focus returns to the invoking button
   // -----------------------------------------------------------------------
   test('3. Escape closes the popover and returns focus to the button', async () => {
-    await page.locator(HEALTH_BUTTON).click();
-    await expect(page.locator(HEALTH_POPOVER)).toBeVisible();
+    await page.locator(HEALTH_BUTTON).click()
+    await expect(page.locator(HEALTH_POPOVER)).toBeVisible()
 
-    await page.keyboard.press('Escape');
+    await page.keyboard.press('Escape')
 
-    await expect(page.locator(HEALTH_POPOVER)).toBeHidden();
+    await expect(page.locator(HEALTH_POPOVER)).toBeHidden()
 
     // Popover API guarantees focus returns to the invoker on close.
     const isFocused = await page.evaluate(() => {
-      const btn = document.querySelector(
-        '#systemStatus .sys-line[data-source="health"] .sys-info',
-      ) as HTMLElement | null;
-      return document.activeElement === btn;
-    });
-    expect(isFocused).toBe(true);
-  });
+      const btn = document.querySelector('#systemStatus .sys-line[data-source="health"] .sys-info') as HTMLElement | null
+      return document.activeElement === btn
+    })
+    expect(isFocused).toBe(true)
+  })
 
   // -----------------------------------------------------------------------
   // 4a. Enter keyboard activation
   // -----------------------------------------------------------------------
   test('4a. Enter on the focused button opens the popover', async () => {
-    await page.locator(HEALTH_BUTTON).focus();
-    await page.keyboard.press('Enter');
-    await expect(page.locator(HEALTH_POPOVER)).toBeVisible();
-  });
+    await page.locator(HEALTH_BUTTON).focus()
+    await page.keyboard.press('Enter')
+    await expect(page.locator(HEALTH_POPOVER)).toBeVisible()
+  })
 
   // -----------------------------------------------------------------------
   // 4b. Space keyboard activation
   // -----------------------------------------------------------------------
   test('4b. Space on the focused button opens the popover', async () => {
-    await page.locator(HEALTH_BUTTON).focus();
-    await page.keyboard.press('Space');
-    await expect(page.locator(HEALTH_POPOVER)).toBeVisible();
-  });
+    await page.locator(HEALTH_BUTTON).focus()
+    await page.keyboard.press('Space')
+    await expect(page.locator(HEALTH_POPOVER)).toBeVisible()
+  })
 
   // -----------------------------------------------------------------------
   // 5a. Link attributes — first link (Apple Watch 11)
   // -----------------------------------------------------------------------
   test('5a. Health popover Apple Watch link: correct href, rel="noopener noreferrer", target="_blank"', async () => {
-    await page.locator(HEALTH_BUTTON).click();
-    await expect(page.locator(HEALTH_POPOVER)).toBeVisible();
+    await page.locator(HEALTH_BUTTON).click()
+    await expect(page.locator(HEALTH_POPOVER)).toBeVisible()
 
-    const link = page.locator(`${HEALTH_POPOVER} a[href="${WATCH_LINK_HREF}"]`);
-    await expect(link).toHaveAttribute('href', WATCH_LINK_HREF);
-    await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-    await expect(link).toHaveAttribute('target', '_blank');
-  });
+    const link = page.locator(`${HEALTH_POPOVER} a[href="${WATCH_LINK_HREF}"]`)
+    await expect(link).toHaveAttribute('href', WATCH_LINK_HREF)
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    await expect(link).toHaveAttribute('target', '_blank')
+  })
 
   // -----------------------------------------------------------------------
   // 5b. Outside-click light-dismisses the popover (auto popover)
   // -----------------------------------------------------------------------
   test('5b. clicking outside the popover light-dismisses it', async () => {
-    await page.locator(HEALTH_BUTTON).click();
-    await expect(page.locator(HEALTH_POPOVER)).toBeVisible();
+    await page.locator(HEALTH_BUTTON).click()
+    await expect(page.locator(HEALTH_POPOVER)).toBeVisible()
 
     // Click at top-right corner — well outside the left-panel system-status widget.
-    const vp = page.viewportSize()!;
-    await page.mouse.click(vp.width - 10, 10);
+    const vp = page.viewportSize()!
+    await page.mouse.click(vp.width - 10, 10)
 
-    await expect(page.locator(HEALTH_POPOVER)).toBeHidden();
-  });
+    await expect(page.locator(HEALTH_POPOVER)).toBeHidden()
+  })
 
   // -----------------------------------------------------------------------
   // 6. ARIA: button carries aria-label + aria-details
   // -----------------------------------------------------------------------
   test('6. button has correct aria-label and aria-details', async () => {
-    const button = page.locator(HEALTH_BUTTON);
-    await expect(button).toHaveAttribute(
-      'aria-label',
-      'More information about the Health data source',
-    );
-    await expect(button).toHaveAttribute('aria-details', 'tip-health');
-  });
+    const button = page.locator(HEALTH_BUTTON)
+    await expect(button).toHaveAttribute('aria-label', 'More information about the Health data source')
+    await expect(button).toHaveAttribute('aria-details', 'tip-health')
+  })
 
   // -----------------------------------------------------------------------
   // 7. ARIA: aria-expanded must NOT be hand-set (Popover API manages via AOM)
   // -----------------------------------------------------------------------
   test('7. aria-expanded is NOT a DOM content attribute — widget lets Popover API manage it', async () => {
-    const button = page.locator(HEALTH_BUTTON);
+    const button = page.locator(HEALTH_BUTTON)
 
     // The plan (§2 ARIA decision) explicitly prohibits hand-setting aria-expanded.
     // The Popover API invoker manages expanded state via the accessibility object
     // model, not as a DOM content attribute. Verify the widget is correctly
     // absent of a hardcoded aria-expanded attribute in both open and closed states.
-    expect(await button.evaluate((el) => el.getAttribute('aria-expanded'))).toBeNull();
+    expect(await button.evaluate((el) => el.getAttribute('aria-expanded'))).toBeNull()
 
-    await button.click();
-    await expect(page.locator(HEALTH_POPOVER)).toBeVisible();
+    await button.click()
+    await expect(page.locator(HEALTH_POPOVER)).toBeVisible()
 
     // Open: still null — browser manages this internally; widget must not set it
-    expect(await button.evaluate((el) => el.getAttribute('aria-expanded'))).toBeNull();
-  });
+    expect(await button.evaluate((el) => el.getAttribute('aria-expanded'))).toBeNull()
+  })
 
   // -----------------------------------------------------------------------
   // 8. ARIA: popover role + label; no role="tooltip" anywhere
   // -----------------------------------------------------------------------
   test('8. popover has role="group" + aria-label; no role="tooltip" in #cardSystem', async () => {
-    const popover = page.locator(HEALTH_POPOVER);
-    await expect(popover).toHaveAttribute('role', 'group');
-    await expect(popover).toHaveAttribute('aria-label', 'Health data source');
+    const popover = page.locator(HEALTH_POPOVER)
+    await expect(popover).toHaveAttribute('role', 'group')
+    await expect(popover).toHaveAttribute('aria-label', 'Health data source')
 
     // Plan explicitly forbids role="tooltip" (this is a disclosure, not a tooltip)
-    await expect(page.locator('#cardSystem [role="tooltip"]')).toHaveCount(0);
-  });
-});
+    await expect(page.locator('#cardSystem [role="tooltip"]')).toHaveCount(0)
+  })
+})

--- a/tests/build/humans-txt.test.ts
+++ b/tests/build/humans-txt.test.ts
@@ -1,39 +1,39 @@
-import { describe, it, expect, beforeAll } from 'vitest';
-import { readFileSync, existsSync } from 'fs';
-import path from 'path';
+import {beforeAll, describe, expect, it} from 'vitest'
+import {existsSync, readFileSync} from 'fs'
+import path from 'path'
 
-const distDir = path.resolve(process.cwd(), 'dist');
-const humansTxtPath = path.join(distDir, 'humans.txt');
+const distDir = path.resolve(process.cwd(), 'dist')
+const humansTxtPath = path.join(distDir, 'humans.txt')
 
-let content: string;
+let content: string
 
 beforeAll(() => {
-  content = readFileSync(humansTxtPath, 'utf-8');
-});
+  content = readFileSync(humansTxtPath, 'utf-8')
+})
 
 describe('humans.txt build output', () => {
   it('dist/humans.txt exists and is non-empty', () => {
-    expect(existsSync(humansTxtPath)).toBe(true);
-    expect(content.length).toBeGreaterThan(0);
-  });
+    expect(existsSync(humansTxtPath)).toBe(true)
+    expect(content.length).toBeGreaterThan(0)
+  })
 
   it('contains /* TEAM */ section header', () => {
-    expect(content).toContain('/* TEAM */');
-  });
+    expect(content).toContain('/* TEAM */')
+  })
 
   it('contains /* SITE */ section header', () => {
-    expect(content).toContain('/* SITE */');
-  });
+    expect(content).toContain('/* SITE */')
+  })
 
   it('contains /* THANKS */ section header', () => {
-    expect(content).toContain('/* THANKS */');
-  });
+    expect(content).toContain('/* THANKS */')
+  })
 
   it('contains Name: Jonathan Lloyd', () => {
-    expect(content).toContain('Name: Jonathan Lloyd');
-  });
+    expect(content).toContain('Name: Jonathan Lloyd')
+  })
 
   it('contains no @ character (email privacy guard)', () => {
-    expect(content).not.toContain('@');
-  });
-});
+    expect(content).not.toContain('@')
+  })
+})

--- a/tests/build/image-pipeline.test.ts
+++ b/tests/build/image-pipeline.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync, statSync } from 'fs';
-import path from 'path';
+import {describe, expect, it} from 'vitest'
+import {existsSync, readFileSync, statSync} from 'fs'
+import path from 'path'
 
-const rootDir = process.cwd();
-const distDir = path.resolve(rootDir, 'dist');
+const rootDir = process.cwd()
+const distDir = path.resolve(rootDir, 'dist')
 
 // Book-image coverage (every book ASIN has a pre-fetched local webp) is no
 // longer asserted here: fixtures are DS-owned (Plan #04) and the SSR-shell
@@ -13,37 +13,37 @@ const distDir = path.resolve(rootDir, 'dist');
 describe('Image Pipeline', () => {
   describe('dist/ artifacts', () => {
     it('dist/sw.js exists', () => {
-      const swPath = path.join(distDir, 'sw.js');
-      expect(existsSync(swPath)).toBe(true);
-    });
+      const swPath = path.join(distDir, 'sw.js')
+      expect(existsSync(swPath)).toBe(true)
+    })
 
     it('dist/manifest.webmanifest exists', () => {
-      const manifestPath = path.join(distDir, 'manifest.webmanifest');
-      expect(existsSync(manifestPath)).toBe(true);
-    });
+      const manifestPath = path.join(distDir, 'manifest.webmanifest')
+      expect(existsSync(manifestPath)).toBe(true)
+    })
 
     it('dist/manifest.webmanifest is valid JSON', () => {
-      const manifestPath = path.join(distDir, 'manifest.webmanifest');
-      const content = readFileSync(manifestPath, 'utf-8');
-      expect(() => JSON.parse(content)).not.toThrow();
-    });
+      const manifestPath = path.join(distDir, 'manifest.webmanifest')
+      const content = readFileSync(manifestPath, 'utf-8')
+      expect(() => JSON.parse(content)).not.toThrow()
+    })
 
     it('dist/manifest.webmanifest has required PWA fields', () => {
-      const manifestPath = path.join(distDir, 'manifest.webmanifest');
-      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
-      expect(manifest.name).toBeTruthy();
-      expect(manifest.icons).toBeDefined();
-    });
+      const manifestPath = path.join(distDir, 'manifest.webmanifest')
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+      expect(manifest.name).toBeTruthy()
+      expect(manifest.icons).toBeDefined()
+    })
 
     it('dist/index.html exists', () => {
-      const indexPath = path.join(distDir, 'index.html');
-      expect(existsSync(indexPath)).toBe(true);
-    });
+      const indexPath = path.join(distDir, 'index.html')
+      expect(existsSync(indexPath)).toBe(true)
+    })
 
     it('dist/index.html is non-empty', () => {
-      const indexPath = path.join(distDir, 'index.html');
-      const stat = statSync(indexPath);
-      expect(stat.size).toBeGreaterThan(0);
-    });
-  });
-});
+      const indexPath = path.join(distDir, 'index.html')
+      const stat = statSync(indexPath)
+      expect(stat.size).toBeGreaterThan(0)
+    })
+  })
+})

--- a/tests/build/json-ld.test.ts
+++ b/tests/build/json-ld.test.ts
@@ -1,19 +1,19 @@
-import { describe, it, expect, beforeAll } from 'vitest';
-import { readFileSync } from 'fs';
-import { load } from 'cheerio';
-import path from 'path';
-import { SITE_URL, DATASET_VARIABLES, DATASET_DISTRIBUTIONS } from '@lifegames/portal-contract/constants';
+import {beforeAll, describe, expect, it} from 'vitest'
+import {readFileSync} from 'fs'
+import {load} from 'cheerio'
+import path from 'path'
+import {DATASET_DISTRIBUTIONS, DATASET_VARIABLES, SITE_URL} from '@lifegames/portal-contract/constants'
 
-const distDir = path.resolve(process.cwd(), 'dist');
+const distDir = path.resolve(process.cwd(), 'dist')
 
 /** Parse the single JSON-LD @graph emitted by a built HTML page. */
 function loadGraph(relPath: string): any[] {
-  const html = readFileSync(path.join(distDir, relPath), 'utf-8');
-  const $ = load(html);
-  const scriptContent = $('script[type="application/ld+json"]').html();
-  expect(scriptContent, `${relPath} must emit a JSON-LD block`).toBeTruthy();
-  const parsed = JSON.parse(scriptContent!);
-  return parsed['@graph'];
+  const html = readFileSync(path.join(distDir, relPath), 'utf-8')
+  const $ = load(html)
+  const scriptContent = $('script[type="application/ld+json"]').html()
+  expect(scriptContent, `${relPath} must emit a JSON-LD block`).toBeTruthy()
+  const parsed = JSON.parse(scriptContent!)
+  return parsed['@graph']
 }
 
 /**
@@ -23,148 +23,147 @@ function loadGraph(relPath: string): any[] {
  * `isPartOf`, `creator`). A reference is dangling if it names an `@id` no node
  * defines on the same page.
  */
-function collectIds(graph: any[]): { defined: Set<string>; referenced: Set<string>; } {
-  const defined = new Set<string>();
-  const referenced = new Set<string>();
+function collectIds(graph: any[]): {defined: Set<string>; referenced: Set<string>} {
+  const defined = new Set<string>()
+  const referenced = new Set<string>()
   const walk = (value: any, isTopLevelNode: boolean) => {
     if (Array.isArray(value)) {
-      value.forEach((v) => walk(v, false));
-      return;
+      value.forEach((v) => walk(v, false))
+      return
     }
-    if (!value || typeof value !== 'object') return;
+    if (!value || typeof value !== 'object') {
+      return
+    }
     if (typeof value['@id'] === 'string') {
       if (isTopLevelNode && value['@type']) {
-        defined.add(value['@id']);
+        defined.add(value['@id'])
       } else {
         // A bare `{ "@id": ... }` (no `@type`) is a cross-reference to another node.
-        referenced.add(value['@id']);
+        referenced.add(value['@id'])
       }
     }
     for (const [key, v] of Object.entries(value)) {
-      if (key === '@id' || key === '@type') continue;
-      walk(v, false);
+      if (key === '@id' || key === '@type') {
+        continue
+      }
+      walk(v, false)
     }
-  };
-  graph.forEach((node) => walk(node, true));
-  return { defined, referenced };
+  }
+  graph.forEach((node) => walk(node, true))
+  return {defined, referenced}
 }
 
-let graph: any[];
+let graph: any[]
 
 beforeAll(() => {
-  graph = loadGraph('index.html');
-});
+  graph = loadGraph('index.html')
+})
 
 describe('JSON-LD Structured Data', () => {
   it('parses as valid JSON', () => {
-    expect(graph).toBeDefined();
-    expect(Array.isArray(graph)).toBe(true);
-  });
+    expect(graph).toBeDefined()
+    expect(Array.isArray(graph)).toBe(true)
+  })
 
   it('contains a WebSite node', () => {
-    const website = graph.find((n: any) => n['@type'] === 'WebSite');
-    expect(website).toBeDefined();
-  });
+    const website = graph.find((n: any) => n['@type'] === 'WebSite')
+    expect(website).toBeDefined()
+  })
 
   it('WebSite has correct url', () => {
-    const website = graph.find((n: any) => n['@type'] === 'WebSite');
-    expect(website.url).toBe(SITE_URL);
-  });
+    const website = graph.find((n: any) => n['@type'] === 'WebSite')
+    expect(website.url).toBe(SITE_URL)
+  })
 
   it('WebSite has name', () => {
-    const website = graph.find((n: any) => n['@type'] === 'WebSite');
-    expect(website.name).toBeTruthy();
-    expect(website.name).toContain('Jonathan Lloyd');
-  });
+    const website = graph.find((n: any) => n['@type'] === 'WebSite')
+    expect(website.name).toBeTruthy()
+    expect(website.name).toContain('Jonathan Lloyd')
+  })
 
   it('contains a Person node', () => {
-    const person = graph.find((n: any) => n['@type'] === 'Person');
-    expect(person).toBeDefined();
-  });
+    const person = graph.find((n: any) => n['@type'] === 'Person')
+    expect(person).toBeDefined()
+  })
 
   it('Person has name "Jonathan Lloyd"', () => {
-    const person = graph.find((n: any) => n['@type'] === 'Person');
-    expect(person.name).toBe('Jonathan Lloyd');
-  });
+    const person = graph.find((n: any) => n['@type'] === 'Person')
+    expect(person.name).toBe('Jonathan Lloyd')
+  })
 
   it('Person has jobTitle', () => {
-    const person = graph.find((n: any) => n['@type'] === 'Person');
-    expect(person.jobTitle).toBeTruthy();
-  });
+    const person = graph.find((n: any) => n['@type'] === 'Person')
+    expect(person.jobTitle).toBeTruthy()
+  })
 
   it('Person has description', () => {
-    const person = graph.find((n: any) => n['@type'] === 'Person');
-    expect(person.description).toBeTruthy();
-    expect(person.description.length).toBeGreaterThan(0);
-  });
+    const person = graph.find((n: any) => n['@type'] === 'Person')
+    expect(person.description).toBeTruthy()
+    expect(person.description.length).toBeGreaterThan(0)
+  })
 
   it('Person has knowsAbout array', () => {
-    const person = graph.find((n: any) => n['@type'] === 'Person');
-    expect(Array.isArray(person.knowsAbout)).toBe(true);
-    expect(person.knowsAbout.length).toBeGreaterThan(0);
-  });
+    const person = graph.find((n: any) => n['@type'] === 'Person')
+    expect(Array.isArray(person.knowsAbout)).toBe(true)
+    expect(person.knowsAbout.length).toBeGreaterThan(0)
+  })
 
   it('Person has sameAs array with social links', () => {
-    const person = graph.find((n: any) => n['@type'] === 'Person');
-    expect(Array.isArray(person.sameAs)).toBe(true);
-    expect(person.sameAs.length).toBeGreaterThan(0);
-  });
+    const person = graph.find((n: any) => n['@type'] === 'Person')
+    expect(Array.isArray(person.sameAs)).toBe(true)
+    expect(person.sameAs.length).toBeGreaterThan(0)
+  })
 
   // Guards against a silently-dropped @lifegames/copy field: worksFor/alumniOf are
   // assembled from identity.person.employer* / alumniOf*, and JSON.stringify omits
   // undefined, so a missing copy field would vanish with no other test noticing.
   // Structural (not value-pinned) so it survives an employer/school change.
   it('Person has worksFor (Organization) with a name and url', () => {
-    const person = graph.find((n: any) => n['@type'] === 'Person');
-    expect(person.worksFor, 'Person.worksFor missing (copy field dropped?)').toBeDefined();
-    expect(person.worksFor['@type']).toBe('Organization');
-    expect(person.worksFor.name).toBeTruthy();
-    expect(person.worksFor.url).toMatch(/^https?:\/\//);
-  });
+    const person = graph.find((n: any) => n['@type'] === 'Person')
+    expect(person.worksFor, 'Person.worksFor missing (copy field dropped?)').toBeDefined()
+    expect(person.worksFor['@type']).toBe('Organization')
+    expect(person.worksFor.name).toBeTruthy()
+    expect(person.worksFor.url).toMatch(/^https?:\/\//)
+  })
 
   it('Person has alumniOf (EducationalOrganization) with a name and url', () => {
-    const person = graph.find((n: any) => n['@type'] === 'Person');
-    expect(person.alumniOf, 'Person.alumniOf missing (copy field dropped?)').toBeDefined();
-    expect(person.alumniOf['@type']).toBe('EducationalOrganization');
-    expect(person.alumniOf.name).toBeTruthy();
-    expect(person.alumniOf.url).toMatch(/^https?:\/\//);
-  });
+    const person = graph.find((n: any) => n['@type'] === 'Person')
+    expect(person.alumniOf, 'Person.alumniOf missing (copy field dropped?)').toBeDefined()
+    expect(person.alumniOf['@type']).toBe('EducationalOrganization')
+    expect(person.alumniOf.name).toBeTruthy()
+    expect(person.alumniOf.url).toMatch(/^https?:\/\//)
+  })
 
   it('all urls use the canonical site URL', () => {
-    const website = graph.find((n: any) => n['@type'] === 'WebSite');
-    const person = graph.find((n: any) => n['@type'] === 'Person');
-    expect(website.url).toMatch(SITE_URL);
-    expect(person.url).toMatch(SITE_URL);
-  });
-});
+    const website = graph.find((n: any) => n['@type'] === 'WebSite')
+    const person = graph.find((n: any) => n['@type'] === 'Person')
+    expect(website.url).toMatch(SITE_URL)
+    expect(person.url).toMatch(SITE_URL)
+  })
+})
 
 describe('JSON-LD Dataset (sourced from @lifegames/portal-contract)', () => {
   it('contains a Dataset node', () => {
-    const dataset = graph.find((n: any) => n['@type'] === 'Dataset');
-    expect(dataset).toBeDefined();
-  });
+    const dataset = graph.find((n: any) => n['@type'] === 'Dataset')
+    expect(dataset).toBeDefined()
+  })
 
   it('variableMeasured equals DATASET_VARIABLES exactly (ordered)', () => {
-    const dataset = graph.find((n: any) => n['@type'] === 'Dataset');
-    expect(dataset.variableMeasured).toEqual([...DATASET_VARIABLES]);
-  });
+    const dataset = graph.find((n: any) => n['@type'] === 'Dataset')
+    expect(dataset.variableMeasured).toEqual([...DATASET_VARIABLES])
+  })
 
   it('distribution equals DATASET_DISTRIBUTIONS exactly (ordered, DataDownload shape)', () => {
-    const dataset = graph.find((n: any) => n['@type'] === 'Dataset');
-    const expected = DATASET_DISTRIBUTIONS.map((d) => ({
-      '@type': 'DataDownload',
-      name: d.name,
-      encodingFormat: d.encodingFormat,
-      contentUrl: d.contentUrl,
-    }));
-    expect(dataset.distribution).toEqual(expected);
-  });
+    const dataset = graph.find((n: any) => n['@type'] === 'Dataset')
+    const expected = DATASET_DISTRIBUTIONS.map((d) => ({'@type': 'DataDownload', name: d.name, encodingFormat: d.encodingFormat, contentUrl: d.contentUrl}))
+    expect(dataset.distribution).toEqual(expected)
+  })
 
   it('license points at the privacy page, not the bare site root', () => {
-    const dataset = graph.find((n: any) => n['@type'] === 'Dataset');
-    expect(dataset.license).toBe(SITE_URL + '/privacy');
-  });
-});
+    const dataset = graph.find((n: any) => n['@type'] === 'Dataset')
+    expect(dataset.license).toBe(SITE_URL + '/privacy')
+  })
+})
 
 // Regression guard for the /privacy + /404 bug: Dashboard.astro is the shared
 // layout for every page, and it once emitted ProfilePage + Dataset on all of
@@ -173,56 +172,56 @@ describe('JSON-LD Dataset (sourced from @lifegames/portal-contract)', () => {
 // gated to the home page.
 describe('JSON-LD @graph per-page shape and @id resolution', () => {
   const pages = [
-    { label: 'home', file: 'index.html', isHome: true },
-    { label: 'privacy', file: 'privacy/index.html', isHome: false },
-    { label: '404', file: '404.html', isHome: false },
-  ];
+    {label: 'home', file: 'index.html', isHome: true},
+    {label: 'privacy', file: 'privacy/index.html', isHome: false},
+    {label: '404', file: '404.html', isHome: false}
+  ]
 
   for (const page of pages) {
     describe(`${page.label} (${page.file})`, () => {
-      let pageGraph: any[];
+      let pageGraph: any[]
       beforeAll(() => {
-        pageGraph = loadGraph(page.file);
-      });
+        pageGraph = loadGraph(page.file)
+      })
 
       it('parses as a non-empty JSON @graph array', () => {
-        expect(Array.isArray(pageGraph)).toBe(true);
-        expect(pageGraph.length).toBeGreaterThan(0);
-      });
+        expect(Array.isArray(pageGraph)).toBe(true)
+        expect(pageGraph.length).toBeGreaterThan(0)
+      })
 
       it('has no dangling @id references (every reference resolves to a defined node)', () => {
-        const { defined, referenced } = collectIds(pageGraph);
-        const dangling = [...referenced].filter((id) => !defined.has(id));
-        expect(dangling, `dangling @id references on ${page.file}`).toEqual([]);
-      });
+        const {defined, referenced} = collectIds(pageGraph)
+        const dangling = [...referenced].filter((id) => !defined.has(id))
+        expect(dangling, `dangling @id references on ${page.file}`).toEqual([])
+      })
 
       it('always carries a WebSite and a Person node', () => {
-        expect(pageGraph.some((n) => n['@type'] === 'WebSite')).toBe(true);
-        expect(pageGraph.some((n) => n['@type'] === 'Person')).toBe(true);
-      });
+        expect(pageGraph.some((n) => n['@type'] === 'WebSite')).toBe(true)
+        expect(pageGraph.some((n) => n['@type'] === 'Person')).toBe(true)
+      })
 
       if (page.isHome) {
         it('home page defines ProfilePage and Dataset', () => {
-          expect(pageGraph.some((n) => n['@type'] === 'ProfilePage')).toBe(true);
-          expect(pageGraph.some((n) => n['@type'] === 'Dataset')).toBe(true);
-        });
+          expect(pageGraph.some((n) => n['@type'] === 'ProfilePage')).toBe(true)
+          expect(pageGraph.some((n) => n['@type'] === 'Dataset')).toBe(true)
+        })
 
         it('home page does NOT emit a WebPage node', () => {
-          expect(pageGraph.some((n) => n['@type'] === 'WebPage')).toBe(false);
-        });
+          expect(pageGraph.some((n) => n['@type'] === 'WebPage')).toBe(false)
+        })
       } else {
         it('non-home page does NOT emit ProfilePage or Dataset', () => {
-          expect(pageGraph.some((n) => n['@type'] === 'ProfilePage')).toBe(false);
-          expect(pageGraph.some((n) => n['@type'] === 'Dataset')).toBe(false);
-        });
+          expect(pageGraph.some((n) => n['@type'] === 'ProfilePage')).toBe(false)
+          expect(pageGraph.some((n) => n['@type'] === 'Dataset')).toBe(false)
+        })
 
         it('non-home page emits a WebPage node that isPartOf the WebSite', () => {
-          const webpage = pageGraph.find((n) => n['@type'] === 'WebPage');
-          expect(webpage).toBeDefined();
-          expect(webpage.isPartOf['@id']).toBe(SITE_URL + '#website');
-          expect(webpage.name).toBeTruthy();
-        });
+          const webpage = pageGraph.find((n) => n['@type'] === 'WebPage')
+          expect(webpage).toBeDefined()
+          expect(webpage.isPartOf['@id']).toBe(SITE_URL + '#website')
+          expect(webpage.name).toBeTruthy()
+        })
       }
-    });
+    })
   }
-});
+})

--- a/tests/build/png-iend-truncate.test.ts
+++ b/tests/build/png-iend-truncate.test.ts
@@ -1,63 +1,63 @@
-import { describe, it, expect } from 'vitest';
-import { truncateAtIEND } from '../visual/png-iend-truncate';
+import {describe, expect, it} from 'vitest'
+import {truncateAtIEND} from '../visual/png-iend-truncate'
 
-const IEND_SIG = Buffer.from([0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82]);
-const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const IEND_SIG = Buffer.from([0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82])
+const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
 
 describe('truncateAtIEND', () => {
   it('returns empty buffer unchanged', () => {
-    const buf = Buffer.alloc(0);
-    expect(truncateAtIEND(buf)).toBe(buf);
-  });
+    const buf = Buffer.alloc(0)
+    expect(truncateAtIEND(buf)).toBe(buf)
+  })
 
   it('returns undersized buffer unchanged (no room for header + IEND)', () => {
-    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
-    expect(truncateAtIEND(buf)).toBe(buf);
-  });
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    expect(truncateAtIEND(buf)).toBe(buf)
+  })
 
   it('returns unchanged when buffer ends exactly at IEND signature', () => {
-    const buf = Buffer.concat([PNG_HEADER, Buffer.alloc(20), IEND_SIG]);
-    expect(truncateAtIEND(buf)).toBe(buf);
-  });
+    const buf = Buffer.concat([PNG_HEADER, Buffer.alloc(20), IEND_SIG])
+    expect(truncateAtIEND(buf)).toBe(buf)
+  })
 
   it('truncates trailing garbage after IEND signature', () => {
-    const trailing = Buffer.from([0x00, 0xff, 0xab, 0xcd, 0x12]);
-    const dirty = Buffer.concat([PNG_HEADER, Buffer.alloc(20), IEND_SIG, trailing]);
-    const cleaned = truncateAtIEND(dirty);
-    expect(cleaned.length).toBe(PNG_HEADER.length + 20 + IEND_SIG.length);
-    expect(cleaned.subarray(-IEND_SIG.length)).toEqual(IEND_SIG);
-  });
+    const trailing = Buffer.from([0x00, 0xff, 0xab, 0xcd, 0x12])
+    const dirty = Buffer.concat([PNG_HEADER, Buffer.alloc(20), IEND_SIG, trailing])
+    const cleaned = truncateAtIEND(dirty)
+    expect(cleaned.length).toBe(PNG_HEADER.length + 20 + IEND_SIG.length)
+    expect(cleaned.subarray(-IEND_SIG.length)).toEqual(IEND_SIG)
+  })
 
   it('uses indexOf so multiple IEND literals cut at the FIRST (matches pngjs parser)', () => {
     // pngjs's parser stops at the first IEND it sees. If Chromium emits a buffer
     // where trailing garbage contains a duplicate IEND signature near the end,
     // we must cut at the first IEND — matching what pngjs's parser does.
-    const first = IEND_SIG;
-    const trailing = Buffer.from([0xaa, 0xbb]);
-    const secondAtEnd = IEND_SIG;
-    const dirty = Buffer.concat([PNG_HEADER, Buffer.alloc(20), first, trailing, Buffer.alloc(50), secondAtEnd]);
-    const cleaned = truncateAtIEND(dirty);
+    const first = IEND_SIG
+    const trailing = Buffer.from([0xaa, 0xbb])
+    const secondAtEnd = IEND_SIG
+    const dirty = Buffer.concat([PNG_HEADER, Buffer.alloc(20), first, trailing, Buffer.alloc(50), secondAtEnd])
+    const cleaned = truncateAtIEND(dirty)
     // Should cut right after the FIRST IEND (not the second/last)
-    expect(cleaned.length).toBe(PNG_HEADER.length + 20 + IEND_SIG.length);
-    expect(cleaned.subarray(-IEND_SIG.length)).toEqual(IEND_SIG);
-  });
+    expect(cleaned.length).toBe(PNG_HEADER.length + 20 + IEND_SIG.length)
+    expect(cleaned.subarray(-IEND_SIG.length)).toEqual(IEND_SIG)
+  })
 
   it('returns buffer unchanged when IEND signature is absent', () => {
-    const buf = Buffer.concat([PNG_HEADER, Buffer.alloc(30)]);
-    expect(truncateAtIEND(buf)).toBe(buf);
-  });
+    const buf = Buffer.concat([PNG_HEADER, Buffer.alloc(30)])
+    expect(truncateAtIEND(buf)).toBe(buf)
+  })
 
   it('passes through non-Buffer inputs unchanged (defensive)', () => {
     // @ts-expect-error — testing runtime guard
-    expect(truncateAtIEND('not a buffer')).toBe('not a buffer');
-  });
+    expect(truncateAtIEND('not a buffer')).toBe('not a buffer')
+  })
 
   it('truncated buffer can be re-truncated idempotently', () => {
-    const trailing = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
-    const dirty = Buffer.concat([PNG_HEADER, Buffer.alloc(10), IEND_SIG, trailing]);
-    const once = truncateAtIEND(dirty);
-    const twice = truncateAtIEND(once);
-    expect(twice.length).toBe(once.length);
-    expect(twice).toEqual(once);
-  });
-});
+    const trailing = Buffer.from([0xde, 0xad, 0xbe, 0xef])
+    const dirty = Buffer.concat([PNG_HEADER, Buffer.alloc(10), IEND_SIG, trailing])
+    const once = truncateAtIEND(dirty)
+    const twice = truncateAtIEND(once)
+    expect(twice.length).toBe(once.length)
+    expect(twice).toEqual(once)
+  })
+})

--- a/tests/build/predicates.test.ts
+++ b/tests/build/predicates.test.ts
@@ -1,40 +1,40 @@
-import { describe, it, expect } from 'vitest';
-import { allImagesComplete, scrollHeightStable } from '../visual/predicates';
+import {describe, expect, it} from 'vitest'
+import {allImagesComplete, scrollHeightStable} from '../visual/predicates'
 
 describe('allImagesComplete', () => {
   it('returns true for empty array', () => {
-    expect(allImagesComplete([])).toBe(true);
-  });
+    expect(allImagesComplete([])).toBe(true)
+  })
   it('returns true when all images report complete', () => {
-    expect(allImagesComplete([{ complete: true }, { complete: true }])).toBe(true);
-  });
+    expect(allImagesComplete([{complete: true}, {complete: true}])).toBe(true)
+  })
   it('returns false when any image is incomplete', () => {
-    expect(allImagesComplete([{ complete: true }, { complete: false }])).toBe(false);
-  });
+    expect(allImagesComplete([{complete: true}, {complete: false}])).toBe(false)
+  })
   it('returns false when single image is incomplete', () => {
-    expect(allImagesComplete([{ complete: false }])).toBe(false);
-  });
-});
+    expect(allImagesComplete([{complete: false}])).toBe(false)
+  })
+})
 
 describe('scrollHeightStable', () => {
   it('returns true for empty array (no reads yet)', () => {
-    expect(scrollHeightStable([])).toBe(true);
-  });
+    expect(scrollHeightStable([])).toBe(true)
+  })
   it('returns true for single read', () => {
-    expect(scrollHeightStable([100])).toBe(true);
-  });
+    expect(scrollHeightStable([100])).toBe(true)
+  })
   it('returns true for four equal reads', () => {
-    expect(scrollHeightStable([100, 100, 100, 100])).toBe(true);
-  });
+    expect(scrollHeightStable([100, 100, 100, 100])).toBe(true)
+  })
   it('returns false if any read differs', () => {
-    expect(scrollHeightStable([100, 100, 100, 101])).toBe(false);
-  });
+    expect(scrollHeightStable([100, 100, 100, 101])).toBe(false)
+  })
   it('returns false for first-read divergence', () => {
-    expect(scrollHeightStable([100, 200, 100, 100])).toBe(false);
-  });
+    expect(scrollHeightStable([100, 200, 100, 100])).toBe(false)
+  })
   // [0,0,0,0] returns true (semantically: stable at zero); real usage wraps
   // this in waitForFunction timeout to fail if page never loads.
   it('returns true for [0,0,0,0] (caller guards against zero via timeout)', () => {
-    expect(scrollHeightStable([0, 0, 0, 0])).toBe(true);
-  });
-});
+    expect(scrollHeightStable([0, 0, 0, 0])).toBe(true)
+  })
+})

--- a/tests/build/sa-proxy.test.ts
+++ b/tests/build/sa-proxy.test.ts
@@ -1,58 +1,52 @@
-import { describe, it, expect, beforeAll } from 'vitest';
-import { readFileSync } from 'fs';
-import { load } from 'cheerio';
-import path from 'path';
+import {beforeAll, describe, expect, it} from 'vitest'
+import {readFileSync} from 'fs'
+import {load} from 'cheerio'
+import path from 'path'
 
 // Build-tier test: asserts the compiled CSP + HTML artifacts satisfy the
 // Simple Analytics reverse-proxy invariants (Issue #83).
 
-const distDir = path.resolve(process.cwd(), 'dist');
+const distDir = path.resolve(process.cwd(), 'dist')
 
-let $: ReturnType<typeof load>;
-let middlewareSrc: string;
+let $: ReturnType<typeof load>
+let middlewareSrc: string
 
 beforeAll(() => {
-  const html = readFileSync(path.join(distDir, 'index.html'), 'utf-8');
-  $ = load(html);
+  const html = readFileSync(path.join(distDir, 'index.html'), 'utf-8')
+  $ = load(html)
   // Read the middleware source to inspect the CSP string
-  middlewareSrc = readFileSync(
-    path.resolve(process.cwd(), 'functions/_middleware.ts'),
-    'utf-8',
-  );
-});
+  middlewareSrc = readFileSync(path.resolve(process.cwd(), 'functions/_middleware.ts'), 'utf-8')
+})
 
 describe('Simple Analytics reverse-proxy CSP assertions', () => {
   it('CSP string contains no simpleanalyticscdn.com reference', () => {
-    expect(middlewareSrc).not.toContain('simpleanalyticscdn');
-  });
+    expect(middlewareSrc).not.toContain('simpleanalyticscdn')
+  })
 
   it('noscript pixel uses the first-party /simple/noscript.gif path', () => {
-    const noscriptImg = $('noscript img').attr('src');
+    const noscriptImg = $('noscript img').attr('src')
     // The noscript block is only rendered in PROD; in a test build it may be absent.
     // If present, assert it is first-party.
     if (noscriptImg !== undefined) {
-      expect(noscriptImg).toBe('/simple/noscript.gif');
-      expect(noscriptImg).not.toContain('simpleanalyticscdn');
+      expect(noscriptImg).toBe('/simple/noscript.gif')
+      expect(noscriptImg).not.toContain('simpleanalyticscdn')
     }
-  });
+  })
 
   it('no dns-prefetch hints to simpleanalyticscdn.com remain in the HTML', () => {
-    const prefetchLinks = $('link[rel="dns-prefetch"]');
+    const prefetchLinks = $('link[rel="dns-prefetch"]')
     prefetchLinks.each((_i, el) => {
-      const href = $(el).attr('href') ?? '';
-      expect(href).not.toContain('simpleanalyticscdn');
-    });
-  });
+      const href = $(el).attr('href') ?? ''
+      expect(href).not.toContain('simpleanalyticscdn')
+    })
+  })
 
   it('sa-loader.js loads the first-party /sa route and not simpleanalyticscdn.com', () => {
-    const loaderSrc = readFileSync(
-      path.resolve(process.cwd(), 'public/js/sa-loader.js'),
-      'utf-8',
-    );
+    const loaderSrc = readFileSync(path.resolve(process.cwd(), 'public/js/sa-loader.js'), 'utf-8')
     // Cloudflare Pages serves functions/sa.ts at the route /sa (the .ts extension
     // is stripped), so the loader must request /sa, NOT /sa.js (which 404s).
-    expect(loaderSrc).toContain("s.src = '/sa'");
-    expect(loaderSrc).not.toContain('/sa.js');
-    expect(loaderSrc).not.toContain('simpleanalyticscdn');
-  });
-});
+    expect(loaderSrc).toContain("s.src = '/sa'")
+    expect(loaderSrc).not.toContain('/sa.js')
+    expect(loaderSrc).not.toContain('simpleanalyticscdn')
+  })
+})

--- a/tests/build/seo-meta.test.ts
+++ b/tests/build/seo-meta.test.ts
@@ -1,110 +1,110 @@
-import { describe, it, expect, beforeAll } from 'vitest';
-import { readFileSync } from 'fs';
-import { load } from 'cheerio';
-import path from 'path';
-import { SITE_URL } from '@lifegames/portal-contract/constants';
+import {beforeAll, describe, expect, it} from 'vitest'
+import {readFileSync} from 'fs'
+import {load} from 'cheerio'
+import path from 'path'
+import {SITE_URL} from '@lifegames/portal-contract/constants'
 
-const distDir = path.resolve(process.cwd(), 'dist');
+const distDir = path.resolve(process.cwd(), 'dist')
 
-let $: ReturnType<typeof load>;
+let $: ReturnType<typeof load>
 
 beforeAll(() => {
-  const html = readFileSync(path.join(distDir, 'index.html'), 'utf-8');
-  $ = load(html);
-});
+  const html = readFileSync(path.join(distDir, 'index.html'), 'utf-8')
+  $ = load(html)
+})
 
 describe('SEO Meta Tags', () => {
   it('title contains "Jonathan Lloyd"', () => {
-    const title = $('title').text();
-    expect(title).toContain('Jonathan Lloyd');
-  });
+    const title = $('title').text()
+    expect(title).toContain('Jonathan Lloyd')
+  })
 
   it('meta description is non-empty', () => {
-    const desc = $('meta[name="description"]').attr('content');
-    expect(desc).toBeTruthy();
-    expect(desc!.length).toBeGreaterThan(0);
-  });
+    const desc = $('meta[name="description"]').attr('content')
+    expect(desc).toBeTruthy()
+    expect(desc!.length).toBeGreaterThan(0)
+  })
 
   it('meta description contains "data dashboard"', () => {
-    const desc = $('meta[name="description"]').attr('content');
-    expect(desc).toContain('data dashboard');
-  });
+    const desc = $('meta[name="description"]').attr('content')
+    expect(desc).toContain('data dashboard')
+  })
 
   it('og:type is "profile"', () => {
-    const ogType = $('meta[property="og:type"]').attr('content');
-    expect(ogType).toBe('profile');
-  });
+    const ogType = $('meta[property="og:type"]').attr('content')
+    expect(ogType).toBe('profile')
+  })
 
   it('og:title is present and non-empty', () => {
-    const ogTitle = $('meta[property="og:title"]').attr('content');
-    expect(ogTitle).toBeTruthy();
-    expect(ogTitle!.length).toBeGreaterThan(0);
-  });
+    const ogTitle = $('meta[property="og:title"]').attr('content')
+    expect(ogTitle).toBeTruthy()
+    expect(ogTitle!.length).toBeGreaterThan(0)
+  })
 
   it('og:description is present and non-empty', () => {
-    const ogDesc = $('meta[property="og:description"]').attr('content');
-    expect(ogDesc).toBeTruthy();
-    expect(ogDesc!.length).toBeGreaterThan(0);
-  });
+    const ogDesc = $('meta[property="og:description"]').attr('content')
+    expect(ogDesc).toBeTruthy()
+    expect(ogDesc!.length).toBeGreaterThan(0)
+  })
 
   it('og:image is present and non-empty', () => {
-    const ogImage = $('meta[property="og:image"]').attr('content');
-    expect(ogImage).toBeTruthy();
-    expect(ogImage!.length).toBeGreaterThan(0);
-  });
+    const ogImage = $('meta[property="og:image"]').attr('content')
+    expect(ogImage).toBeTruthy()
+    expect(ogImage!.length).toBeGreaterThan(0)
+  })
 
   it('profile:first_name is "Jonathan"', () => {
-    const firstName = $('meta[property="profile:first_name"]').attr('content');
-    expect(firstName).toBe('Jonathan');
-  });
+    const firstName = $('meta[property="profile:first_name"]').attr('content')
+    expect(firstName).toBe('Jonathan')
+  })
 
   it('profile:last_name is "Lloyd"', () => {
-    const lastName = $('meta[property="profile:last_name"]').attr('content');
-    expect(lastName).toBe('Lloyd');
-  });
+    const lastName = $('meta[property="profile:last_name"]').attr('content')
+    expect(lastName).toBe('Lloyd')
+  })
 
   it('twitter:card is present', () => {
-    const twitterCard = $('meta[name="twitter:card"]').attr('content');
-    expect(twitterCard).toBeTruthy();
-  });
+    const twitterCard = $('meta[name="twitter:card"]').attr('content')
+    expect(twitterCard).toBeTruthy()
+  })
 
   it('canonical link is present and uses the canonical site URL', () => {
-    const canonical = $('link[rel="canonical"]').attr('href');
-    expect(canonical).toBeTruthy();
-    expect(canonical).toContain(new URL(SITE_URL).hostname);
-  });
+    const canonical = $('link[rel="canonical"]').attr('href')
+    expect(canonical).toBeTruthy()
+    expect(canonical).toContain(new URL(SITE_URL).hostname)
+  })
 
   it('sitemap link is present', () => {
-    const sitemap = $('link[rel="sitemap"]').attr('href');
-    expect(sitemap).toBeTruthy();
-  });
+    const sitemap = $('link[rel="sitemap"]').attr('href')
+    expect(sitemap).toBeTruthy()
+  })
 
   it('no duplicate title tags', () => {
-    const titles = $('title');
-    expect(titles.length).toBe(1);
-  });
+    const titles = $('title')
+    expect(titles.length).toBe(1)
+  })
 
   it('og:url is present', () => {
-    const ogUrl = $('meta[property="og:url"]').attr('content');
-    expect(ogUrl).toBeTruthy();
-  });
+    const ogUrl = $('meta[property="og:url"]').attr('content')
+    expect(ogUrl).toBeTruthy()
+  })
 
   it('meta author is present', () => {
-    const author = $('meta[name="author"]').attr('content');
-    expect(author).toBeTruthy();
-  });
+    const author = $('meta[name="author"]').attr('content')
+    expect(author).toBeTruthy()
+  })
 
   it('RSS feed discovery link is present with correct type and href', () => {
-    const rssLink = $('link[rel="alternate"][type="application/rss+xml"]');
-    expect(rssLink.length, 'RSS <link rel="alternate"> is missing').toBeGreaterThan(0);
-    expect(rssLink.attr('href'), 'RSS feed href should be /feed.xml').toBe('/feed.xml');
-    expect(rssLink.attr('title'), 'RSS feed title should be non-empty').toBeTruthy();
-  });
+    const rssLink = $('link[rel="alternate"][type="application/rss+xml"]')
+    expect(rssLink.length, 'RSS <link rel="alternate"> is missing').toBeGreaterThan(0)
+    expect(rssLink.attr('href'), 'RSS feed href should be /feed.xml').toBe('/feed.xml')
+    expect(rssLink.attr('title'), 'RSS feed title should be non-empty').toBeTruthy()
+  })
 
   it('JSON Feed discovery link is present with correct type and href', () => {
-    const jsonLink = $('link[rel="alternate"][type="application/feed+json"]');
-    expect(jsonLink.length, 'JSON Feed <link rel="alternate"> is missing').toBeGreaterThan(0);
-    expect(jsonLink.attr('href'), 'JSON Feed href should be /feed.json').toBe('/feed.json');
-    expect(jsonLink.attr('title'), 'JSON Feed title should be non-empty').toBeTruthy();
-  });
-});
+    const jsonLink = $('link[rel="alternate"][type="application/feed+json"]')
+    expect(jsonLink.length, 'JSON Feed <link rel="alternate"> is missing').toBeGreaterThan(0)
+    expect(jsonLink.attr('href'), 'JSON Feed href should be /feed.json').toBe('/feed.json')
+    expect(jsonLink.attr('title'), 'JSON Feed title should be non-empty').toBeTruthy()
+  })
+})

--- a/tests/build/setup.ts
+++ b/tests/build/setup.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'child_process';
+import {execSync} from 'child_process'
 
 export async function setup() {
-  execSync('npm run build', { stdio: 'inherit', cwd: process.cwd() });
+  execSync('npm run build', {stdio: 'inherit', cwd: process.cwd()})
 }

--- a/tests/build/sw-update.test.ts
+++ b/tests/build/sw-update.test.ts
@@ -1,19 +1,19 @@
-import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync } from 'fs';
-import path from 'path';
+import {describe, expect, it} from 'vitest'
+import {existsSync, readFileSync} from 'fs'
+import path from 'path'
 
 // Graceful no-interaction deploy updates (Phase 1).
 // Plan: .omc/plans/graceful-deploy-auto-update-plan.md
-const distDir = path.resolve(process.cwd(), 'dist');
-const swRegisterPath = path.join(distDir, 'js', 'sw-register.js');
+const distDir = path.resolve(process.cwd(), 'dist')
+const swRegisterPath = path.join(distDir, 'js', 'sw-register.js')
 
 describe('SW update controller', () => {
   it('dist/js/sw-register.js exists', () => {
-    expect(existsSync(swRegisterPath)).toBe(true);
-  });
+    expect(existsSync(swRegisterPath)).toBe(true)
+  })
 
   it('is ES5 only (ships verbatim, no transpile)', () => {
-    const src = readFileSync(swRegisterPath, 'utf-8');
+    const src = readFileSync(swRegisterPath, 'utf-8')
     const forbidden: Array<[string, RegExp]> = [
       ['arrow function', /=>/],
       ['const', /\bconst\b/],
@@ -21,20 +21,20 @@ describe('SW update controller', () => {
       ['template literal', /`/],
       ['class', /\bclass\b/],
       ['optional chaining', /\?\./],
-      ['nullish coalescing', /\?\?/],
-    ];
-    const hits = forbidden.filter(([, re]) => re.test(src)).map(([name]) => name);
-    expect(hits).toEqual([]);
-  });
+      ['nullish coalescing', /\?\?/]
+    ]
+    const hits = forbidden.filter(([, re]) => re.test(src)).map(([name]) => name)
+    expect(hits).toEqual([])
+  })
 
   it('wires the controllerchange reload spine and the update nudge', () => {
-    const src = readFileSync(swRegisterPath, 'utf-8');
-    expect(src).toContain("addEventListener('controllerchange'");
-    expect(src).toContain('window.__checkForSwUpdate');
-    expect(src).toContain("register('/sw.js')");
-  });
+    const src = readFileSync(swRegisterPath, 'utf-8')
+    expect(src).toContain("addEventListener('controllerchange'")
+    expect(src).toContain('window.__checkForSwUpdate')
+    expect(src).toContain("register('/sw.js')")
+  })
 
   it('does not ship vite-plugin-pwa registerSW.js (injectRegister:false)', () => {
-    expect(existsSync(path.join(distDir, 'registerSW.js'))).toBe(false);
-  });
-});
+    expect(existsSync(path.join(distDir, 'registerSW.js'))).toBe(false)
+  })
+})

--- a/tests/build/webfinger.test.ts
+++ b/tests/build/webfinger.test.ts
@@ -1,49 +1,47 @@
-import { describe, it, expect, beforeAll } from 'vitest';
-import { readFileSync, existsSync } from 'fs';
-import path from 'path';
+import {beforeAll, describe, expect, it} from 'vitest'
+import {existsSync, readFileSync} from 'fs'
+import path from 'path'
 
-const distDir = path.resolve(process.cwd(), 'dist');
-const webfingerPath = path.join(distDir, '.well-known', 'webfinger');
+const distDir = path.resolve(process.cwd(), 'dist')
+const webfingerPath = path.join(distDir, '.well-known', 'webfinger')
 
 interface JrdLink {
-  rel: string;
-  type?: string;
-  href?: string;
-  template?: string;
+  rel: string
+  type?: string
+  href?: string
+  template?: string
 }
 interface Jrd {
-  subject: string;
-  aliases?: string[];
-  links: JrdLink[];
+  subject: string
+  aliases?: string[]
+  links: JrdLink[]
 }
 
-let jrd: Jrd;
+let jrd: Jrd
 
 beforeAll(() => {
-  jrd = JSON.parse(readFileSync(webfingerPath, 'utf-8')) as Jrd;
-});
+  jrd = JSON.parse(readFileSync(webfingerPath, 'utf-8')) as Jrd
+})
 
 describe('webfinger build output', () => {
   it('dist/.well-known/webfinger exists', () => {
-    expect(existsSync(webfingerPath)).toBe(true);
-  });
+    expect(existsSync(webfingerPath)).toBe(true)
+  })
 
   it('subject is the custom-domain alias handle', () => {
-    expect(jrd.subject).toBe('acct:jonathan@jonathanlloyd.me');
-  });
+    expect(jrd.subject).toBe('acct:jonathan@jonathanlloyd.me')
+  })
 
   it('exposes a self link to the ActivityPub actor', () => {
-    const self = jrd.links.find((l) => l.rel === 'self');
-    expect(self, 'missing rel=self link').toBeDefined();
-    expect(self?.type).toBe('application/activity+json');
-    expect(self?.href).toBe('https://mastodon.social/ap/users/116794886250734590');
-  });
+    const self = jrd.links.find((l) => l.rel === 'self')
+    expect(self, 'missing rel=self link').toBeDefined()
+    expect(self?.type).toBe('application/activity+json')
+    expect(self?.href).toBe('https://mastodon.social/ap/users/116794886250734590')
+  })
 
   it('exposes an html profile-page link to the real account', () => {
-    const profile = jrd.links.find(
-      (l) => l.rel === 'http://webfinger.net/rel/profile-page',
-    );
-    expect(profile?.type).toBe('text/html');
-    expect(profile?.href).toBe('https://mastodon.social/@j0nathan');
-  });
-});
+    const profile = jrd.links.find((l) => l.rel === 'http://webfinger.net/rel/profile-page')
+    expect(profile?.type).toBe('text/html')
+    expect(profile?.href).toBe('https://mastodon.social/@j0nathan')
+  })
+})

--- a/tests/shared/chromium-launch-args.ts
+++ b/tests/shared/chromium-launch-args.ts
@@ -46,5 +46,5 @@ export const CHROMIUM_DETERMINISM_ARGS: ReadonlyArray<string> = [
   // See Chromium 40827297, Chromium 460486.
   '--use-gl=swiftshader',
   '--disable-gpu',
-  '--in-process-gpu',
-];
+  '--in-process-gpu'
+]

--- a/tests/smoke/fixtures.ts
+++ b/tests/smoke/fixtures.ts
@@ -46,18 +46,18 @@
  * (bio terminal types its content; `.is-loading` skeletons clear). A hydration
  * module that fails to load is caught there regardless of CSP nuance.
  */
-import { test as base, expect, type Page } from '@playwright/test';
-import { SITE_URL } from '@lifegames/portal-contract/constants';
+import {expect, type Page, test as base} from '@playwright/test'
+import {SITE_URL} from '@lifegames/portal-contract/constants'
 
 interface CspViolation {
-  directive: string;
-  blockedURI: string;
+  directive: string
+  blockedURI: string
 }
 
 declare global {
   interface Window {
-    __cspViolations?: CspViolation[];
-    __unhandledRejections?: string[];
+    __cspViolations?: CspViolation[]
+    __unhandledRejections?: string[]
   }
 }
 
@@ -69,7 +69,7 @@ declare global {
  * The baseline is now 0: inline JS is fully externalised, so ANY blocked inline
  * <script> is a regression (a newly-inlined script).
  */
-const KNOWN_INLINE_SCRIPT_CSP_VIOLATIONS = 0;
+const KNOWN_INLINE_SCRIPT_CSP_VIOLATIONS = 0
 
 /**
  * Console/pageerror messages that are benign on this live, third-party-laden
@@ -81,8 +81,8 @@ const BENIGN_MESSAGE_PATTERNS: RegExp[] = [
   /net::ERR_BLOCKED_BY_CLIENT/i, // ad/track blockers in the runner
   /ERR_INTERNET_DISCONNECTED|ERR_NETWORK_CHANGED|net::ERR_FAILED/i, // transient blips (retried on CI)
   /WebSocket.*(closed|failed|1006|1011)/i, // live push socket may not connect from CI
-  /Content Security Policy|Refused to (execute|apply)/i, // CSP console noise — asserted structurally below, not here
-];
+  /Content Security Policy|Refused to (execute|apply)/i // CSP console noise — asserted structurally below, not here
+]
 
 /** Patterns indicating a JS chunk / dynamic import() failed to load. */
 const CHUNK_ERROR_PATTERNS: RegExp[] = [
@@ -90,14 +90,14 @@ const CHUNK_ERROR_PATTERNS: RegExp[] = [
   /error loading dynamically imported module/i,
   /ChunkLoadError/i,
   /Loading chunk \d+ failed/i,
-  /Importing a module script failed/i,
-];
+  /Importing a module script failed/i
+]
 
 /** Our own origin — a resource under this host failing to load is a real signal. */
-const FIRST_PARTY_HOST = new URL(SITE_URL).hostname;
+const FIRST_PARTY_HOST = new URL(SITE_URL).hostname
 
 function isBenign(message: string): boolean {
-  return BENIGN_MESSAGE_PATTERNS.some((re) => re.test(message));
+  return BENIGN_MESSAGE_PATTERNS.some((re) => re.test(message))
 }
 
 /**
@@ -108,129 +108,121 @@ function isBenign(message: string): boolean {
  * `_astro/*.js` chunk 404ing) is a real signal and is NOT allowlisted.
  */
 function isBenignConsole(message: string, resourceUrl: string): boolean {
-  if (isBenign(message)) return true;
-  if (/Failed to load resource/i.test(message)) {
-    const thirdParty = resourceUrl !== '' && !resourceUrl.includes(FIRST_PARTY_HOST);
-    if (thirdParty) return true;
+  if (isBenign(message)) {
+    return true
   }
-  return false;
+  if (/Failed to load resource/i.test(message)) {
+    const thirdParty = resourceUrl !== '' && !resourceUrl.includes(FIRST_PARTY_HOST)
+    if (thirdParty) {
+      return true
+    }
+  }
+  return false
 }
 
 export function isChunkError(message: string): boolean {
-  return CHUNK_ERROR_PATTERNS.some((re) => re.test(message));
+  return CHUNK_ERROR_PATTERNS.some((re) => re.test(message))
 }
 
 function isUrlBlock(blockedURI: string): boolean {
-  return /^https?:/i.test(blockedURI);
+  return /^https?:/i.test(blockedURI)
 }
 
 function isInlineScriptBlock(v: CspViolation): boolean {
   return (
-    !isUrlBlock(v.blockedURI)
-    && /script-src(-elem)?$/.test(v.directive) // script-src or script-src-elem, NOT script-src-attr
-  );
+    !isUrlBlock(v.blockedURI) && /script-src(-elem)?$/.test(v.directive) // script-src or script-src-elem, NOT script-src-attr
+  )
 }
 
 export const test = base.extend({
-  page: async ({ page }, use) => {
-    const consoleErrors: string[] = [];
-    const pageErrors: string[] = [];
+  page: async ({page}, use) => {
+    const consoleErrors: string[] = []
+    const pageErrors: string[] = []
 
     page.on('console', (msg) => {
       if (msg.type() === 'error') {
-        const text = msg.text();
-        const url = msg.location()?.url ?? '';
-        if (!isBenignConsole(text, url)) consoleErrors.push(url ? `${text} (${url})` : text);
+        const text = msg.text()
+        const url = msg.location()?.url ?? ''
+        if (!isBenignConsole(text, url)) {
+          consoleErrors.push(url ? `${text} (${url})` : text)
+        }
       }
-    });
+    })
 
     page.on('pageerror', (err) => {
-      const msg = err.message;
-      if (!isBenign(msg)) pageErrors.push(msg);
-    });
+      const msg = err.message
+      if (!isBenign(msg)) {
+        pageErrors.push(msg)
+      }
+    })
 
     await page.addInitScript(() => {
-      window.__cspViolations = [];
-      window.__unhandledRejections = [];
+      window.__cspViolations = []
+      window.__unhandledRejections = []
       document.addEventListener('securitypolicyviolation', (e) => {
-        window.__cspViolations!.push({
-          directive: e.effectiveDirective || e.violatedDirective,
-          blockedURI: e.blockedURI || '',
-        });
-      });
+        window.__cspViolations!.push({directive: e.effectiveDirective || e.violatedDirective, blockedURI: e.blockedURI || ''})
+      })
       window.addEventListener('unhandledrejection', (e) => {
-        const reason = e.reason as unknown;
+        const reason = e.reason as unknown
         const msg = reason && typeof reason === 'object' && 'message' in reason
-          ? String((reason as { message: unknown; }).message)
-          : String(reason);
-        window.__unhandledRejections!.push(msg);
-      });
-    });
+          ? String((reason as {message: unknown}).message)
+          : String(reason)
+        window.__unhandledRejections!.push(msg)
+      })
+    })
 
-    await use(page);
+    await use(page)
 
     // --- Teardown assertions ---
-    const cspViolations = await readCspViolations(page);
-    const rejections = await readWindowStringArray(page, '__unhandledRejections');
+    const cspViolations = await readCspViolations(page)
+    const rejections = await readWindowStringArray(page, '__unhandledRejections')
 
-    const urlBlocked = cspViolations.filter((v) => isUrlBlock(v.blockedURI));
-    const inlineScriptBlocked = cspViolations.filter(isInlineScriptBlock);
+    const urlBlocked = cspViolations.filter((v) => isUrlBlock(v.blockedURI))
+    const inlineScriptBlocked = cspViolations.filter(isInlineScriptBlock)
 
     // Use soft assertions so a deploy with multiple problems (e.g. a CSP
     // regression AND a chunk-load failure) reports them all in one run instead
     // of masking the later ones behind the first failure.
 
     // 1. An external script blocked by CSP is a genuine per-deploy regression.
-    expect.soft(
-      urlBlocked,
-      `CSP blocked external script(s) — a real deploy/config regression:\n${
-        urlBlocked
-          .map((v) => `${v.directive} -> ${v.blockedURI}`)
-          .join('\n')
-      }`,
-    ).toEqual([]);
+    expect.soft(urlBlocked,
+      `CSP blocked external script(s) — a real deploy/config regression:\n${urlBlocked.map((v) => `${v.directive} -> ${v.blockedURI}`).join('\n')}`).toEqual(
+        []
+      )
 
     // 2. Regression-guard the count of blocked inline <script> elements.
     if (inlineScriptBlocked.length > KNOWN_INLINE_SCRIPT_CSP_VIOLATIONS) {
       // eslint-disable-next-line no-console
-      console.warn(
-        `[smoke] inline-script CSP violations: ${inlineScriptBlocked.length} (baseline ${KNOWN_INLINE_SCRIPT_CSP_VIOLATIONS})`,
-      );
+      console.warn(`[smoke] inline-script CSP violations: ${inlineScriptBlocked.length} (baseline ${KNOWN_INLINE_SCRIPT_CSP_VIOLATIONS})`)
     }
-    expect.soft(
-      inlineScriptBlocked.length,
-      `More blocked inline <script> elements (${inlineScriptBlocked.length}) than the documented baseline (${KNOWN_INLINE_SCRIPT_CSP_VIOLATIONS}). Inline JS is fully externalised (per #07), so a new inline script was introduced — externalise it so CSP 'self' allows it (the #50 fix) rather than raising this baseline.`,
-    ).toBeLessThanOrEqual(KNOWN_INLINE_SCRIPT_CSP_VIOLATIONS);
+    expect.soft(inlineScriptBlocked.length,
+      `More blocked inline <script> elements (${inlineScriptBlocked.length}) than the documented baseline (${KNOWN_INLINE_SCRIPT_CSP_VIOLATIONS}). Inline JS is fully externalised (per #07), so a new inline script was introduced — externalise it so CSP 'self' allows it (the #50 fix) rather than raising this baseline.`)
+      .toBeLessThanOrEqual(KNOWN_INLINE_SCRIPT_CSP_VIOLATIONS)
 
     // 3. Chunk/dynamic-import load failures — a missing or renamed _astro/*.js chunk.
-    const chunkRejections = rejections.filter(isChunkError);
-    const chunkPageErrors = pageErrors.filter(isChunkError);
-    expect.soft(
-      [...chunkPageErrors, ...chunkRejections],
-      `JS chunk / dynamic import() load failures:\n${[...chunkPageErrors, ...chunkRejections].join('\n')}`,
-    ).toEqual([]);
+    const chunkRejections = rejections.filter(isChunkError)
+    const chunkPageErrors = pageErrors.filter(isChunkError)
+    expect.soft([...chunkPageErrors, ...chunkRejections],
+      `JS chunk / dynamic import() load failures:\n${[...chunkPageErrors, ...chunkRejections].join('\n')}`).toEqual([])
 
     // 4. Any other uncaught page error / console error (allowlist-filtered).
-    expect.soft(pageErrors, `Uncaught page errors:\n${pageErrors.join('\n')}`).toEqual([]);
-    expect.soft(consoleErrors, `Unexpected console.error output:\n${consoleErrors.join('\n')}`).toEqual([]);
-  },
-});
+    expect.soft(pageErrors, `Uncaught page errors:\n${pageErrors.join('\n')}`).toEqual([])
+    expect.soft(consoleErrors, `Unexpected console.error output:\n${consoleErrors.join('\n')}`).toEqual([])
+  }
+})
 
 async function readCspViolations(page: Page): Promise<CspViolation[]> {
   return page.evaluate(() => {
-    const v = window.__cspViolations;
-    return Array.isArray(v) ? v : [];
-  });
+    const v = window.__cspViolations
+    return Array.isArray(v) ? v : []
+  })
 }
 
-async function readWindowStringArray(
-  page: Page,
-  key: '__unhandledRejections',
-): Promise<string[]> {
+async function readWindowStringArray(page: Page, key: '__unhandledRejections'): Promise<string[]> {
   return page.evaluate((k) => {
-    const v = (window as unknown as Record<string, unknown>)[k];
-    return Array.isArray(v) ? (v as string[]) : [];
-  }, key);
+    const v = (window as unknown as Record<string, unknown>)[k]
+    return Array.isArray(v) ? (v as string[]) : []
+  }, key)
 }
 
-export { expect };
+export { expect }

--- a/tests/smoke/home.smoke.ts
+++ b/tests/smoke/home.smoke.ts
@@ -23,8 +23,8 @@
  *   - CSP-violation and chunk-load assertions live in the fixture teardown
  *     (tests/smoke/fixtures.ts) and run automatically for every test.
  */
-import { test, expect } from './fixtures';
-import type { APIRequestContext, APIResponse } from '@playwright/test';
+import {expect, test} from './fixtures'
+import type {APIRequestContext, APIResponse} from '@playwright/test'
 
 // All navigations use page.goto('/'), resolved against `baseURL` in
 // playwright.smoke.config.ts — keep the target URL defined in one place.
@@ -42,18 +42,14 @@ import type { APIRequestContext, APIResponse } from '@playwright/test';
  * whole-test CI retry could not because the upstream error outlived the quick
  * back-to-back retry window.
  */
-async function getStable(
-  request: APIRequestContext,
-  url: string,
-  options?: Parameters<APIRequestContext['get']>[1],
-): Promise<APIResponse> {
-  const deadline = Date.now() + 25_000;
-  let res = await request.get(url, options);
+async function getStable(request: APIRequestContext, url: string, options?: Parameters<APIRequestContext['get']>[1]): Promise<APIResponse> {
+  const deadline = Date.now() + 25_000
+  let res = await request.get(url, options)
   for (let attempt = 0; res.status() >= 500 && Date.now() < deadline; attempt++) {
-    await new Promise((resolve) => setTimeout(resolve, Math.min(2_000 * 2 ** attempt, 8_000)));
-    res = await request.get(url, options);
+    await new Promise((resolve) => setTimeout(resolve, Math.min(2_000 * 2 ** attempt, 8_000)))
+    res = await request.get(url, options)
   }
-  return res;
+  return res
 }
 
 // Statically server-rendered containers that must always be present. These are
@@ -73,78 +69,68 @@ const REQUIRED_CONTAINERS = [
   '#cardReading',
   '#cardStarredRepos',
   '#cardBooks',
-  '#cardTheatreReviews',
-];
+  '#cardTheatreReviews'
+]
 
 test.describe('production home dashboard', () => {
-  test('serves 200 and the document shell renders', async ({ page }) => {
-    const response = await page.goto('/', { waitUntil: 'domcontentloaded' });
-    expect(response, 'no response object from navigation').not.toBeNull();
-    expect(response!.status(), 'home page did not return HTTP 200').toBe(200);
+  test('serves 200 and the document shell renders', async ({page}) => {
+    const response = await page.goto('/', {waitUntil: 'domcontentloaded'})
+    expect(response, 'no response object from navigation').not.toBeNull()
+    expect(response!.status(), 'home page did not return HTTP 200').toBe(200)
 
     // The triptych grid is the structural anchor of the dashboard.
-    await expect(page.locator('#triptychGrid')).toBeVisible();
-  });
+    await expect(page.locator('#triptychGrid')).toBeVisible()
+  })
 
-  test('all widget containers are present (SSR shell intact)', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
+  test('all widget containers are present (SSR shell intact)', async ({page}) => {
+    await page.goto('/', {waitUntil: 'domcontentloaded'})
     for (const selector of REQUIRED_CONTAINERS) {
-      await expect(
-        page.locator(selector),
-        `required widget container ${selector} missing from SSR output`,
-      ).toBeAttached();
+      await expect(page.locator(selector), `required widget container ${selector} missing from SSR output`).toBeAttached()
     }
-  });
+  })
 
-  test('live-data runtime hydrates (skeletons clear, no throw)', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
+  test('live-data runtime hydrates (skeletons clear, no throw)', async ({page}) => {
+    await page.goto('/', {waitUntil: 'domcontentloaded'})
 
     // The live-data runtime marks live cards with `is-loading`, then removes it
     // when each updater completes or an 8s fallback fires. If the runtime chunk
     // failed to load, the SSR `is-loading` cards never clear and this times out.
     // This is the same readiness predicate the visual suite relies on.
-    await expect
-      .poll(
-        () => page.locator('.is-loading').count(),
-        {
-          message: 'live-data runtime never cleared skeleton states — the hydration runtime likely failed to load',
-          timeout: 20_000,
-          intervals: [500, 1000, 2000],
-        },
-      )
-      .toBe(0);
-  });
+    await expect.poll(() => page.locator('.is-loading').count(), {
+      message: 'live-data runtime never cleared skeleton states — the hydration runtime likely failed to load',
+      timeout: 20_000,
+      intervals: [500, 1000, 2000]
+    }).toBe(0)
+  })
 
-  test('bio terminal hydrates and types its content (#50 regression guard)', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
+  test('bio terminal hydrates and types its content (#50 regression guard)', async ({page}) => {
+    await page.goto('/', {waitUntil: 'domcontentloaded'})
 
     // Desktop reveals terminal lines via a typewriter animation driven by the
     // bio-terminal init script (the exact script CSP-blocked in #50). Scroll the
     // card into view so the IntersectionObserver fires, then assert the last
     // line becomes `.visible`. If the init script is blocked, no line ever gains
     // `.visible` and this fails — deterministically catching the #50 class.
-    const bio = page.locator('#cardBio');
-    await expect(bio).toBeAttached();
-    await bio.scrollIntoViewIfNeeded();
+    const bio = page.locator('#cardBio')
+    await expect(bio).toBeAttached()
+    await bio.scrollIntoViewIfNeeded()
 
-    await page
-      .waitForFunction(
-        () => {
-          const lines = document.querySelectorAll('#terminalBody .terminal-line');
-          if (lines.length === 0) return false;
-          return lines[lines.length - 1].classList.contains('visible');
-        },
-        { timeout: 20_000 },
-      );
+    await page.waitForFunction(() => {
+      const lines = document.querySelectorAll('#terminalBody .terminal-line')
+      if (lines.length === 0) {
+        return false
+      }
+      return lines[lines.length - 1].classList.contains('visible')
+    }, {timeout: 20_000})
 
     // Belt-and-suspenders: the typed output must be non-empty. In #50 the body
     // rendered blank, so this is a second, content-level proof hydration ran.
-    const typedText = (await bio.locator('#terminalBody').innerText()).trim();
-    expect(typedText.length, 'bio terminal body is empty after hydration').toBeGreaterThan(0);
-  });
+    const typedText = (await bio.locator('#terminalBody').innerText()).trim()
+    expect(typedText.length, 'bio terminal body is empty after hydration').toBeGreaterThan(0)
+  })
 
-  test('service worker registers for /sw.js', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'load' });
+  test('service worker registers for /sw.js', async ({page}) => {
+    await page.goto('/', {waitUntil: 'load'})
 
     // sw-register.js registers the SW on window `load`. The registration object
     // (with its scriptURL) appears within a few hundred ms via the `installing`
@@ -156,130 +142,123 @@ test.describe('production home dashboard', () => {
     // (returning the instant a registration appears) is more reliable than a
     // cross-process poll and is bounded well under the 45s test timeout.
     const swScriptUrl = await page.evaluate(async () => {
-      if (!('serviceWorker' in navigator)) return null;
-      const read = async (): Promise<string | null> => {
-        const reg = await navigator.serviceWorker.getRegistration();
-        return (
-          reg?.active?.scriptURL
-            ?? reg?.installing?.scriptURL
-            ?? reg?.waiting?.scriptURL
-            ?? null
-        );
-      };
-      const deadline = Date.now() + 35_000;
-      let url = await read();
-      while (!url && Date.now() < deadline) {
-        await new Promise((r) => setTimeout(r, 250));
-        url = await read();
+      if (!('serviceWorker' in navigator)) {
+        return null
       }
-      return url;
-    });
+      const read = async (): Promise<string | null> => {
+        const reg = await navigator.serviceWorker.getRegistration()
+        return (
+          reg?.active?.scriptURL ?? reg?.installing?.scriptURL ?? reg?.waiting?.scriptURL ?? null
+        )
+      }
+      const deadline = Date.now() + 35_000
+      let url = await read()
+      while (!url && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 250))
+        url = await read()
+      }
+      return url
+    })
 
-    expect(swScriptUrl, 'no service worker registered for /sw.js within 35s').not.toBeNull();
-    expect(swScriptUrl).toMatch(/\/sw\.js$/);
-  });
+    expect(swScriptUrl, 'no service worker registered for /sw.js within 35s').not.toBeNull()
+    expect(swScriptUrl).toMatch(/\/sw\.js$/)
+  })
 
-  test('humans.txt is reachable and plain text', async ({ page }) => {
-    const res = await getStable(page.request, '/humans.txt');
-    expect(res.status(), '/humans.txt did not return 200').toBe(200);
-    const contentType = res.headers()['content-type'] || '';
-    expect(contentType, '/humans.txt wrong content-type').toContain('text/plain');
-  });
+  test('humans.txt is reachable and plain text', async ({page}) => {
+    const res = await getStable(page.request, '/humans.txt')
+    expect(res.status(), '/humans.txt did not return 200').toBe(200)
+    const contentType = res.headers()['content-type'] || ''
+    expect(contentType, '/humans.txt wrong content-type').toContain('text/plain')
+  })
 
-  test('feed.xml is reachable and RSS content-type', async ({ page }) => {
-    const res = await getStable(page.request, '/feed.xml');
-    expect(res.status(), '/feed.xml did not return 200').toBe(200);
-    const contentType = res.headers()['content-type'] || '';
-    expect(contentType, '/feed.xml wrong content-type').toContain('application/rss+xml');
-  });
+  test('feed.xml is reachable and RSS content-type', async ({page}) => {
+    const res = await getStable(page.request, '/feed.xml')
+    expect(res.status(), '/feed.xml did not return 200').toBe(200)
+    const contentType = res.headers()['content-type'] || ''
+    expect(contentType, '/feed.xml wrong content-type').toContain('application/rss+xml')
+  })
 
-  test('feed.json is reachable and JSON Feed content-type', async ({ page }) => {
-    const res = await getStable(page.request, '/feed.json');
-    expect(res.status(), '/feed.json did not return 200').toBe(200);
-    const contentType = res.headers()['content-type'] || '';
-    expect(contentType, '/feed.json wrong content-type').toContain('application/feed+json');
-  });
+  test('feed.json is reachable and JSON Feed content-type', async ({page}) => {
+    const res = await getStable(page.request, '/feed.json')
+    expect(res.status(), '/feed.json did not return 200').toBe(200)
+    const contentType = res.headers()['content-type'] || ''
+    expect(contentType, '/feed.json wrong content-type').toContain('application/feed+json')
+  })
 
-  test('llms.txt is reachable and plain text', async ({ page }) => {
-    const res = await getStable(page.request, '/llms.txt');
-    expect(res.status(), '/llms.txt did not return 200').toBe(200);
-    const contentType = res.headers()['content-type'] || '';
-    expect(contentType, '/llms.txt wrong content-type').toContain('text/plain');
-  });
+  test('llms.txt is reachable and plain text', async ({page}) => {
+    const res = await getStable(page.request, '/llms.txt')
+    expect(res.status(), '/llms.txt did not return 200').toBe(200)
+    const contentType = res.headers()['content-type'] || ''
+    expect(contentType, '/llms.txt wrong content-type').toContain('text/plain')
+  })
 
-  test('llms-full.txt is reachable on the prod domain and markdown', async ({ page }) => {
+  test('llms-full.txt is reachable on the prod domain and markdown', async ({page}) => {
     // Regression guard: until 2026-07-17 only /llms.txt had a proxy route, so
     // the full dump the discovery index advertises 404'd on jonathanlloyd.me.
-    const res = await getStable(page.request, '/llms-full.txt');
-    expect(res.status(), '/llms-full.txt did not return 200').toBe(200);
-    const contentType = res.headers()['content-type'] || '';
-    expect(contentType, '/llms-full.txt wrong content-type').toContain('text/markdown');
-  });
+    const res = await getStable(page.request, '/llms-full.txt')
+    expect(res.status(), '/llms-full.txt did not return 200').toBe(200)
+    const contentType = res.headers()['content-type'] || ''
+    expect(contentType, '/llms-full.txt wrong content-type').toContain('text/markdown')
+  })
 
-  test('index.md is reachable on the prod domain and markdown', async ({ page }) => {
-    const res = await getStable(page.request, '/index.md');
-    expect(res.status(), '/index.md did not return 200').toBe(200);
-    const contentType = res.headers()['content-type'] || '';
-    expect(contentType, '/index.md wrong content-type').toContain('text/markdown');
-  });
+  test('index.md is reachable on the prod domain and markdown', async ({page}) => {
+    const res = await getStable(page.request, '/index.md')
+    expect(res.status(), '/index.md did not return 200').toBe(200)
+    const contentType = res.headers()['content-type'] || ''
+    expect(contentType, '/index.md wrong content-type').toContain('text/markdown')
+  })
 
-  test('webfinger resolves the Fediverse alias with JRD content-type', async ({ page }) => {
+  test('webfinger resolves the Fediverse alias with JRD content-type', async ({page}) => {
     // Accept: application/jrd+json avoids the text/markdown early-return in
     // functions/_middleware.ts that would otherwise short-circuit to llms-full.
-    const res = await getStable(
-      page.request,
-      '/.well-known/webfinger?resource=acct:jonathan@jonathanlloyd.me',
-      { headers: { Accept: 'application/jrd+json' } },
-    );
-    expect(res.status(), '/.well-known/webfinger did not return 200').toBe(200);
-    const contentType = res.headers()['content-type'] || '';
-    expect(contentType, 'webfinger wrong content-type').toContain('application/jrd+json');
-    const body = await res.json();
-    expect(body.subject, 'webfinger subject mismatch').toBe('acct:jonathan@jonathanlloyd.me');
+    const res = await getStable(page.request, '/.well-known/webfinger?resource=acct:jonathan@jonathanlloyd.me', {headers: {Accept: 'application/jrd+json'}})
+    expect(res.status(), '/.well-known/webfinger did not return 200').toBe(200)
+    const contentType = res.headers()['content-type'] || ''
+    expect(contentType, 'webfinger wrong content-type').toContain('application/jrd+json')
+    const body = await res.json()
+    expect(body.subject, 'webfinger subject mismatch').toBe('acct:jonathan@jonathanlloyd.me')
     // The self link is what makes aliasing work; assert it on the LIVE path too,
     // not just the build artifact, to catch a stale/edge-cached deploy.
-    const self = body.links?.find((l: { rel: string; href?: string; }) => l.rel === 'self');
-    expect(self?.href, 'webfinger self link must target the canonical Mastodon actor').toBe(
-      'https://mastodon.social/ap/users/116794886250734590',
-    );
-  });
+    const self = body.links?.find((l: {rel: string; href?: string}) => l.rel === 'self')
+    expect(self?.href, 'webfinger self link must target the canonical Mastodon actor').toBe('https://mastodon.social/ap/users/116794886250734590')
+  })
 
-  test('api-catalog is reachable and linkset content-type', async ({ page }) => {
+  test('api-catalog is reachable and linkset content-type', async ({page}) => {
     // Regression guard for the adjacent middleware override edited alongside the
     // webfinger block (currently otherwise untested).
-    const res = await getStable(page.request, '/.well-known/api-catalog');
-    expect(res.status(), '/.well-known/api-catalog did not return 200').toBe(200);
-    const contentType = res.headers()['content-type'] || '';
-    expect(contentType, 'api-catalog wrong content-type').toContain('application/linkset+json');
-  });
+    const res = await getStable(page.request, '/.well-known/api-catalog')
+    expect(res.status(), '/.well-known/api-catalog did not return 200').toBe(200)
+    const contentType = res.headers()['content-type'] || ''
+    expect(contentType, 'api-catalog wrong content-type').toContain('application/linkset+json')
+  })
 
-  test('Trusted Types telemetry ships as a report-only header', async ({ page }) => {
+  test('Trusted Types telemetry ships as a report-only header', async ({page}) => {
     // The report-only policy is non-enforcing; it only drains DOM injection-sink
     // violations to /api/csp-report. Assert it reaches the browser on the live path
     // (set unconditionally in functions/_middleware.ts alongside the enforced CSP).
-    const res = await getStable(page.request, '/');
-    expect(res.status(), 'home page did not return 200').toBe(200);
-    const reportOnly = res.headers()['content-security-policy-report-only'] || '';
-    expect(reportOnly, 'Trusted Types report-only header missing').toContain(
-      "require-trusted-types-for 'script'",
-    );
-  });
+    const res = await getStable(page.request, '/')
+    expect(res.status(), 'home page did not return 200').toBe(200)
+    const reportOnly = res.headers()['content-security-policy-report-only'] || ''
+    expect(reportOnly, 'Trusted Types report-only header missing').toContain("require-trusted-types-for 'script'")
+  })
 
-  test('version.json reports the deployed build', async ({ page }) => {
-    const res = await getStable(page.request, '/version.json');
-    expect(res.status(), '/version.json did not return HTTP 200').toBe(200);
+  test('version.json reports the deployed build', async ({page}) => {
+    const res = await getStable(page.request, '/version.json')
+    expect(res.status(), '/version.json did not return HTTP 200').toBe(200)
 
-    const body = await res.json();
-    expect(typeof body.build, 'version.json missing a build string').toBe('string');
-    expect(body.build.length, 'version.json build is empty').toBeGreaterThan(0);
+    const body = await res.json()
+    expect(typeof body.build, 'version.json missing a build string').toBe('string')
+    expect(body.build.length, 'version.json build is empty').toBeGreaterThan(0)
 
     // When the smoke workflow passes the just-deployed commit (EXPECTED_BUILD =
     // workflow_run.head_sha), assert the LIVE origin actually serves it. Catches a
     // silently-stale / failed deploy — a class the hydration checks above cannot
     // detect (the old build hydrates fine). Skipped on manual/local runs where
     // EXPECTED_BUILD is unset.
-    const expected = process.env.EXPECTED_BUILD;
-    if (!expected) return;
+    const expected = process.env.EXPECTED_BUILD
+    if (!expected) {
+      return
+    }
 
     // Rapid successive deploys: if a NEWER deploy landed between this deploy and
     // this smoke run (e.g. two PRs merged minutes apart), the origin correctly
@@ -290,8 +269,8 @@ test.describe('production home dashboard', () => {
     // this deploy (or any later one) produces has builtAt >= that instant, while a
     // stale older build's builtAt predates it. Unset (older workflow / manual
     // dispatch) => strict exact-match, preserving the original behavior.
-    const builtAfterMs = Date.parse(process.env.EXPECTED_BUILT_AFTER ?? '');
-    const acceptsNewer = !Number.isNaN(builtAfterMs);
+    const builtAfterMs = Date.parse(process.env.EXPECTED_BUILT_AFTER ?? '')
+    const acceptsNewer = !Number.isNaN(builtAfterMs)
 
     // version.json is edge-cached (`Cache-Control: max-age=600`) and the deploy
     // does NOT purge the Cloudflare cache, so the EDGE can keep serving the
@@ -305,31 +284,25 @@ test.describe('production home dashboard', () => {
     // so this asserts the ORIGIN published the new build — the real failure mode —
     // while tolerating the bounded edge-propagation lag. A deploy that never lands
     // at origin still fails once the budget is spent.
-    test.setTimeout(90_000);
-    await expect
-      .poll(
-        async () => {
-          const fresh = await page.request.get(`/version.json?cb=${Date.now()}`, {
-            headers: { 'Cache-Control': 'no-cache' },
-          });
-          if (fresh.status() !== 200) return false;
-          const live = await fresh.json();
-          if (live.build === expected) return true;
-          // Accept a NEWER superseding deploy (builtAt at/after this deploy started),
-          // never an older/stale one. See the comment above.
-          return (
-            acceptsNewer
-            && typeof live.builtAt === 'string'
-            && Date.parse(live.builtAt) >= builtAfterMs
-          );
-        },
-        {
-          message:
-            'live origin never served the just-deployed build (or a newer superseding build) within the propagation window',
-          timeout: 60_000,
-          intervals: [2_000, 3_000, 5_000],
-        },
+    test.setTimeout(90_000)
+    await expect.poll(async () => {
+      const fresh = await page.request.get(`/version.json?cb=${Date.now()}`, {headers: {'Cache-Control': 'no-cache'}})
+      if (fresh.status() !== 200) {
+        return false
+      }
+      const live = await fresh.json()
+      if (live.build === expected) {
+        return true
+      }
+      // Accept a NEWER superseding deploy (builtAt at/after this deploy started),
+      // never an older/stale one. See the comment above.
+      return (
+        acceptsNewer && typeof live.builtAt === 'string' && Date.parse(live.builtAt) >= builtAfterMs
       )
-      .toBe(true);
-  });
-});
+    }, {
+      message: 'live origin never served the just-deployed build (or a newer superseding build) within the propagation window',
+      timeout: 60_000,
+      intervals: [2_000, 3_000, 5_000]
+    }).toBe(true)
+  })
+})

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -1,128 +1,120 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fetchWithTimeout, fetchAllEndpoints } from '../../src/lib/runtime/api';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {fetchAllEndpoints, fetchWithTimeout} from '../../src/lib/runtime/api'
 
 // Mock constants module
-vi.mock('@lifegames/portal-contract/constants', () => ({
-  CLOUDFRONT_BASE: 'https://mock.cloudfront.net',
-  ENDPOINTS: {
-    health: '/health.json',
-    sleep: '/sleep.json',
-    workouts: '/workouts.json',
-    books: '/books.json',
-    starredRepos: '/github-starred-repos.json',
-    githubEvents: '/github-events.json',
-    articles: '/articles.json',
-    location: '/location.json',
-    focus: '/focus.json',
-    theatreReviews: '/theatre-reviews.json',
-  },
-}));
+vi.mock('@lifegames/portal-contract/constants',
+  () => ({
+    CLOUDFRONT_BASE: 'https://mock.cloudfront.net',
+    ENDPOINTS: {
+      health: '/health.json',
+      sleep: '/sleep.json',
+      workouts: '/workouts.json',
+      books: '/books.json',
+      starredRepos: '/github-starred-repos.json',
+      githubEvents: '/github-events.json',
+      articles: '/articles.json',
+      location: '/location.json',
+      focus: '/focus.json',
+      theatreReviews: '/theatre-reviews.json'
+    }
+  }))
 
 function makeFetchResponse(data: unknown, ok = true, status = 200) {
-  return {
-    ok,
-    status,
-    json: () => Promise.resolve(data),
-  };
+  return {ok, status, json: () => Promise.resolve(data)}
 }
 
 // Minimal fixture data with generatedAt for timestamps test
-const healthFixture = { generatedAt: '2024-01-01T00:00:00Z', heartRate: 72 };
-const sleepFixture = { generatedAt: '2024-01-01T00:00:00Z', duration: 7.5 };
-const workoutsFixture = { generatedAt: '2024-01-01T00:00:00Z', workouts: [] };
-const booksFixture = { generatedAt: '2024-01-01T00:00:00Z', books: [] };
-const githubEventsFixture = { generatedAt: '2024-01-01T00:00:00Z', events: [] };
-const starredReposFixture = { generatedAt: '2024-01-01T00:00:00Z' };
-const articlesFixture = { generatedAt: '2024-01-01T00:00:00Z', articles: [] };
-const locationFixture = { generatedAt: '2024-01-01T00:00:00Z', lat: 37.7, lng: -122.4 };
-const focusFixture = { generatedAt: '2024-01-01T00:00:00Z', sessions: [] };
-const theatreFixture = { generatedAt: '2024-01-01T00:00:00Z', reviews: [] };
+const healthFixture = {generatedAt: '2024-01-01T00:00:00Z', heartRate: 72}
+const sleepFixture = {generatedAt: '2024-01-01T00:00:00Z', duration: 7.5}
+const workoutsFixture = {generatedAt: '2024-01-01T00:00:00Z', workouts: []}
+const booksFixture = {generatedAt: '2024-01-01T00:00:00Z', books: []}
+const githubEventsFixture = {generatedAt: '2024-01-01T00:00:00Z', events: []}
+const starredReposFixture = {generatedAt: '2024-01-01T00:00:00Z'}
+const articlesFixture = {generatedAt: '2024-01-01T00:00:00Z', articles: []}
+const locationFixture = {generatedAt: '2024-01-01T00:00:00Z', lat: 37.7, lng: -122.4}
+const focusFixture = {generatedAt: '2024-01-01T00:00:00Z', sessions: []}
+const theatreFixture = {generatedAt: '2024-01-01T00:00:00Z', reviews: []}
 
 describe('fetchWithTimeout', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
-  });
+    vi.useFakeTimers()
+  })
 
   afterEach(() => {
-    vi.useRealTimers();
-    vi.unstubAllGlobals();
-  });
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
 
   it('returns parsed JSON on success', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse({ foo: 'bar' })));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse({foo: 'bar'})))
 
-    const promise = fetchWithTimeout<{ foo: string; }>('https://example.com/data.json');
-    await vi.runAllTimersAsync();
-    const result = await promise;
+    const promise = fetchWithTimeout<{foo: string}>('https://example.com/data.json')
+    await vi.runAllTimersAsync()
+    const result = await promise
 
-    expect(result).toEqual({ foo: 'bar' });
-  });
+    expect(result).toEqual({foo: 'bar'})
+  })
 
   it('returns null for 404 response', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse(null, false, 404)));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse(null, false, 404)))
 
-    const promise = fetchWithTimeout('https://example.com/missing.json');
-    await vi.runAllTimersAsync();
-    const result = await promise;
+    const promise = fetchWithTimeout('https://example.com/missing.json')
+    await vi.runAllTimersAsync()
+    const result = await promise
 
-    expect(result).toBeNull();
-  });
+    expect(result).toBeNull()
+  })
 
   it('returns null for 500 response', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse(null, false, 500)));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse(null, false, 500)))
 
-    const promise = fetchWithTimeout('https://example.com/error.json');
-    await vi.runAllTimersAsync();
-    const result = await promise;
+    const promise = fetchWithTimeout('https://example.com/error.json')
+    await vi.runAllTimersAsync()
+    const result = await promise
 
-    expect(result).toBeNull();
-  });
+    expect(result).toBeNull()
+  })
 
   it('returns null on network error', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')))
 
-    const promise = fetchWithTimeout('https://example.com/data.json');
-    await vi.runAllTimersAsync();
-    const result = await promise;
+    const promise = fetchWithTimeout('https://example.com/data.json')
+    await vi.runAllTimersAsync()
+    const result = await promise
 
-    expect(result).toBeNull();
-  });
+    expect(result).toBeNull()
+  })
 
   it('returns null on timeout (AbortError)', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockImplementation((_url: string, opts: { signal?: AbortSignal; }) => {
-        return new Promise((_resolve, reject) => {
-          if (opts?.signal) {
-            opts.signal.addEventListener('abort', () => {
-              reject(new DOMException('The operation was aborted.', 'AbortError'));
-            });
-          }
-        });
-      }),
-    );
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: {signal?: AbortSignal}) => {
+      return new Promise((_resolve, reject) => {
+        if (opts?.signal) {
+          opts.signal.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'))
+          })
+        }
+      })
+    }))
 
-    const promise = fetchWithTimeout('https://example.com/slow.json', 1000);
-    vi.advanceTimersByTime(1000);
-    await vi.runAllTimersAsync();
-    const result = await promise;
+    const promise = fetchWithTimeout('https://example.com/slow.json', 1000)
+    vi.advanceTimersByTime(1000)
+    await vi.runAllTimersAsync()
+    const result = await promise
 
-    expect(result).toBeNull();
-  });
-});
+    expect(result).toBeNull()
+  })
+})
 
 describe('fetchAllEndpoints', () => {
   afterEach(() => {
-    vi.unstubAllGlobals();
-  });
+    vi.unstubAllGlobals()
+  })
 
   it('returns all data when all endpoints succeed', async () => {
     // Order matches Promise.all in fetchAllEndpoints.
     // In the vitest environment import.meta.env.DEV=true, so location IS fetched:
     // health, sleep, workouts, books, githubEvents, starredRepos, articles, location, focus, theatreReviews
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(makeFetchResponse(healthFixture)) // health
+    const fetchMock = vi.fn().mockResolvedValueOnce(makeFetchResponse(healthFixture)) // health
       .mockResolvedValueOnce(makeFetchResponse(sleepFixture)) // sleep
       .mockResolvedValueOnce(makeFetchResponse(workoutsFixture)) // workouts
       .mockResolvedValueOnce(makeFetchResponse(booksFixture)) // books
@@ -131,84 +123,74 @@ describe('fetchAllEndpoints', () => {
       .mockResolvedValueOnce(makeFetchResponse(articlesFixture)) // articles
       .mockResolvedValueOnce(makeFetchResponse(locationFixture)) // location (DEV=true)
       .mockResolvedValueOnce(makeFetchResponse(focusFixture)) // focus
-      .mockResolvedValueOnce(makeFetchResponse(theatreFixture)); // theatreReviews
-    vi.stubGlobal('fetch', fetchMock);
+      .mockResolvedValueOnce(makeFetchResponse(theatreFixture)) // theatreReviews
+    vi.stubGlobal('fetch', fetchMock)
 
-    const result = await fetchAllEndpoints();
+    const result = await fetchAllEndpoints()
 
-    expect(result.health).toEqual(healthFixture);
-    expect(result.sleep).toEqual(sleepFixture);
-    expect(result.books).toEqual(booksFixture);
-    expect(result.githubEvents).toEqual(githubEventsFixture);
-    expect(result.articles).toEqual(articlesFixture);
-    expect(result.focus).toEqual(focusFixture);
-    expect(result.theatreReviews).toEqual(theatreFixture);
-  });
+    expect(result.health).toEqual(healthFixture)
+    expect(result.sleep).toEqual(sleepFixture)
+    expect(result.books).toEqual(booksFixture)
+    expect(result.githubEvents).toEqual(githubEventsFixture)
+    expect(result.articles).toEqual(articlesFixture)
+    expect(result.focus).toEqual(focusFixture)
+    expect(result.theatreReviews).toEqual(theatreFixture)
+  })
 
   it('returns null for failing endpoints without rejecting', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockRejectedValueOnce(new Error('fail')) // health fails
-      .mockResolvedValueOnce(makeFetchResponse(sleepFixture))
-      .mockResolvedValueOnce(makeFetchResponse(workoutsFixture))
-      .mockResolvedValueOnce(makeFetchResponse(booksFixture))
-      .mockResolvedValueOnce(makeFetchResponse(githubEventsFixture))
-      .mockResolvedValueOnce(makeFetchResponse(starredReposFixture))
-      .mockResolvedValueOnce(makeFetchResponse(articlesFixture))
-      .mockResolvedValueOnce(makeFetchResponse(locationFixture)) // location (DEV=true)
-      .mockResolvedValueOnce(makeFetchResponse(focusFixture))
-      .mockResolvedValueOnce(makeFetchResponse(theatreFixture));
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error('fail')) // health fails
+      .mockResolvedValueOnce(makeFetchResponse(sleepFixture)).mockResolvedValueOnce(makeFetchResponse(workoutsFixture)).mockResolvedValueOnce(
+        makeFetchResponse(booksFixture)
+      ).mockResolvedValueOnce(makeFetchResponse(githubEventsFixture)).mockResolvedValueOnce(makeFetchResponse(starredReposFixture)).mockResolvedValueOnce(
+        makeFetchResponse(articlesFixture)
+      ).mockResolvedValueOnce(makeFetchResponse(locationFixture)) // location (DEV=true)
+      .mockResolvedValueOnce(makeFetchResponse(focusFixture)).mockResolvedValueOnce(makeFetchResponse(theatreFixture))
+    vi.stubGlobal('fetch', fetchMock)
 
-    const result = await fetchAllEndpoints();
+    const result = await fetchAllEndpoints()
 
-    expect(result.health).toBeNull();
-    expect(result.sleep).toEqual(sleepFixture);
-  });
+    expect(result.health).toBeNull()
+    expect(result.sleep).toEqual(sleepFixture)
+  })
 
   it('returns all nulls when all endpoints fail', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('all fail')));
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('all fail')))
 
-    const result = await fetchAllEndpoints();
+    const result = await fetchAllEndpoints()
 
-    expect(result.health).toBeNull();
-    expect(result.sleep).toBeNull();
-    expect(result.workouts).toBeNull();
-    expect(result.books).toBeNull();
-    expect(result.githubEvents).toBeNull();
-    expect(result.articles).toBeNull();
-    expect(result.focus).toBeNull();
-    expect(result.theatreReviews).toBeNull();
-  });
+    expect(result.health).toBeNull()
+    expect(result.sleep).toBeNull()
+    expect(result.workouts).toBeNull()
+    expect(result.books).toBeNull()
+    expect(result.githubEvents).toBeNull()
+    expect(result.articles).toBeNull()
+    expect(result.focus).toBeNull()
+    expect(result.theatreReviews).toBeNull()
+  })
 
   it('populates timestamps from generatedAt fields', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(makeFetchResponse(healthFixture))
-      .mockResolvedValueOnce(makeFetchResponse(sleepFixture))
-      .mockResolvedValueOnce(makeFetchResponse(workoutsFixture))
-      .mockResolvedValueOnce(makeFetchResponse(booksFixture))
-      .mockResolvedValueOnce(makeFetchResponse(githubEventsFixture))
-      .mockResolvedValueOnce(makeFetchResponse(starredReposFixture))
-      .mockResolvedValueOnce(makeFetchResponse(articlesFixture))
-      .mockResolvedValueOnce(makeFetchResponse(locationFixture)) // location (DEV=true)
-      .mockResolvedValueOnce(makeFetchResponse(focusFixture))
-      .mockResolvedValueOnce(makeFetchResponse(theatreFixture));
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = vi.fn().mockResolvedValueOnce(makeFetchResponse(healthFixture)).mockResolvedValueOnce(makeFetchResponse(sleepFixture))
+      .mockResolvedValueOnce(makeFetchResponse(workoutsFixture)).mockResolvedValueOnce(makeFetchResponse(booksFixture)).mockResolvedValueOnce(
+        makeFetchResponse(githubEventsFixture)
+      ).mockResolvedValueOnce(makeFetchResponse(starredReposFixture)).mockResolvedValueOnce(makeFetchResponse(articlesFixture)).mockResolvedValueOnce(
+        makeFetchResponse(locationFixture)
+      ) // location (DEV=true)
+      .mockResolvedValueOnce(makeFetchResponse(focusFixture)).mockResolvedValueOnce(makeFetchResponse(theatreFixture))
+    vi.stubGlobal('fetch', fetchMock)
 
-    const result = await fetchAllEndpoints();
+    const result = await fetchAllEndpoints()
 
-    expect(result.timestamps.health).toBe('2024-01-01T00:00:00Z');
-    expect(result.timestamps.sleep).toBe('2024-01-01T00:00:00Z');
-    expect(result.timestamps.books).toBe('2024-01-01T00:00:00Z');
-  });
+    expect(result.timestamps.health).toBe('2024-01-01T00:00:00Z')
+    expect(result.timestamps.sleep).toBe('2024-01-01T00:00:00Z')
+    expect(result.timestamps.books).toBe('2024-01-01T00:00:00Z')
+  })
 
   it('sets timestamps to null for failed endpoints', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('fail')));
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('fail')))
 
-    const result = await fetchAllEndpoints();
+    const result = await fetchAllEndpoints()
 
-    expect(result.timestamps.health).toBeNull();
-    expect(result.timestamps.sleep).toBeNull();
-  });
-});
+    expect(result.timestamps.health).toBeNull()
+    expect(result.timestamps.sleep).toBeNull()
+  })
+})

--- a/tests/unit/cloudfront-proxy.test.ts
+++ b/tests/unit/cloudfront-proxy.test.ts
@@ -1,11 +1,11 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { CLOUDFRONT_BASE, LLM_CONTENT_PATHS } from '@lifegames/portal-contract/constants';
-import { makeCloudfrontProxy } from '../../functions/_lib/proxy';
-import { onRequest as feedJsonRoute } from '../../functions/feed.json.ts';
-import { onRequest as feedXmlRoute } from '../../functions/feed.xml.ts';
-import { onRequest as indexMdRoute } from '../../functions/index.md.ts';
-import { onRequest as llmsFullRoute } from '../../functions/llms-full.txt.ts';
-import { onRequest as llmsTxtRoute } from '../../functions/llms.txt.ts';
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import {CLOUDFRONT_BASE, LLM_CONTENT_PATHS} from '@lifegames/portal-contract/constants'
+import {makeCloudfrontProxy} from '../../functions/_lib/proxy'
+import {onRequest as feedJsonRoute} from '../../functions/feed.json.ts'
+import {onRequest as feedXmlRoute} from '../../functions/feed.xml.ts'
+import {onRequest as indexMdRoute} from '../../functions/index.md.ts'
+import {onRequest as llmsFullRoute} from '../../functions/llms-full.txt.ts'
+import {onRequest as llmsTxtRoute} from '../../functions/llms.txt.ts'
 
 // Unit tests for the shared CloudFront proxy factory and the five routes built
 // from it. The regression class under guard: an artifact advertised by the
@@ -13,45 +13,43 @@ import { onRequest as llmsTxtRoute } from '../../functions/llms.txt.ts';
 // prod domain — /llms-full.txt 404'd on jonathanlloyd.me until 2026-07-17.
 
 const stubFetch = (response: Response) => {
-  const mock = vi.fn().mockResolvedValue(response);
-  vi.stubGlobal('fetch', mock);
-  return mock;
-};
+  const mock = vi.fn().mockResolvedValue(response)
+  vi.stubGlobal('fetch', mock)
+  return mock
+}
 
 afterEach(() => {
-  vi.unstubAllGlobals();
-});
+  vi.unstubAllGlobals()
+})
 
 describe('makeCloudfrontProxy', () => {
   it('fetches the CloudFront artifact with the edge-cache options', async () => {
-    const mock = stubFetch(new Response('body'));
-    const proxy = makeCloudfrontProxy({ path: '/thing.txt', contentType: 'text/plain; charset=utf-8' });
-    await proxy();
-    expect(mock).toHaveBeenCalledWith(`${CLOUDFRONT_BASE}/thing.txt`, {
-      cf: { cacheTtl: 3600, cacheEverything: true },
-    });
-  });
+    const mock = stubFetch(new Response('body'))
+    const proxy = makeCloudfrontProxy({path: '/thing.txt', contentType: 'text/plain; charset=utf-8'})
+    await proxy()
+    expect(mock).toHaveBeenCalledWith(`${CLOUDFRONT_BASE}/thing.txt`, {cf: {cacheTtl: 3600, cacheEverything: true}})
+  })
 
   it('passes the upstream body through with proxy headers on success', async () => {
-    stubFetch(new Response('# content'));
-    const proxy = makeCloudfrontProxy({ path: '/thing.txt', contentType: 'text/markdown; charset=utf-8' });
-    const res = await proxy();
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8');
-    expect(res.headers.get('Cache-Control')).toBe('public, max-age=300, s-maxage=3600, stale-while-revalidate=86400');
-    expect(res.headers.get('X-Source')).toBe('cloudfront-proxy');
-    expect(await res.text()).toBe('# content');
-  });
+    stubFetch(new Response('# content'))
+    const proxy = makeCloudfrontProxy({path: '/thing.txt', contentType: 'text/markdown; charset=utf-8'})
+    const res = await proxy()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/markdown; charset=utf-8')
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=300, s-maxage=3600, stale-while-revalidate=86400')
+    expect(res.headers.get('X-Source')).toBe('cloudfront-proxy')
+    expect(await res.text()).toBe('# content')
+  })
 
   it('returns a 502 with a plain-text notice when upstream fails', async () => {
-    stubFetch(new Response('nope', { status: 500 }));
-    const proxy = makeCloudfrontProxy({ path: '/thing.txt', contentType: 'text/markdown; charset=utf-8' });
-    const res = await proxy();
-    expect(res.status).toBe(502);
-    expect(res.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
-    expect(await res.text()).toBe('thing.txt unavailable');
-  });
-});
+    stubFetch(new Response('nope', {status: 500}))
+    const proxy = makeCloudfrontProxy({path: '/thing.txt', contentType: 'text/markdown; charset=utf-8'})
+    const res = await proxy()
+    expect(res.status).toBe(502)
+    expect(res.headers.get('Content-Type')).toBe('text/plain; charset=utf-8')
+    expect(await res.text()).toBe('thing.txt unavailable')
+  })
+})
 
 describe('proxy routes', () => {
   // Every artifact the site serves from its own domain: upstream CloudFront
@@ -61,16 +59,14 @@ describe('proxy routes', () => {
     ['/llms-full.txt', llmsFullRoute, LLM_CONTENT_PATHS.llmsFull, 'text/markdown; charset=utf-8'],
     ['/index.md', indexMdRoute, LLM_CONTENT_PATHS.indexMarkdown, 'text/markdown; charset=utf-8'],
     ['/feed.xml', feedXmlRoute, '/feed.xml', 'application/rss+xml; charset=utf-8'],
-    ['/feed.json', feedJsonRoute, '/feed.json', 'application/feed+json; charset=utf-8'],
-  ];
+    ['/feed.json', feedJsonRoute, '/feed.json', 'application/feed+json; charset=utf-8']
+  ]
 
   it.each(routes)('%s proxies its CloudFront artifact', async (_route, onRequest, upstreamPath, contentType) => {
-    const mock = stubFetch(new Response('payload'));
-    const res = await onRequest();
-    expect(mock).toHaveBeenCalledWith(`${CLOUDFRONT_BASE}${upstreamPath}`, {
-      cf: { cacheTtl: 3600, cacheEverything: true },
-    });
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe(contentType);
-  });
-});
+    const mock = stubFetch(new Response('payload'))
+    const res = await onRequest()
+    expect(mock).toHaveBeenCalledWith(`${CLOUDFRONT_BASE}${upstreamPath}`, {cf: {cacheTtl: 3600, cacheEverything: true}})
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe(contentType)
+  })
+})

--- a/tests/unit/live-data.app-update.test.ts
+++ b/tests/unit/live-data.app-update.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 // Characterization test for the wiring this refactor relocated from the design
 // system: live-data forwards a WebSocket 'app-update' push (and a reconnect) to
@@ -9,74 +9,75 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // drive the captured WSClient callbacks.
 
 interface CapturedWsOpts {
-  onAppUpdate?: (build?: string) => void;
-  onStateChange?: (connected: boolean) => void;
-  onFocusChange?: (currentFocus: string) => void;
+  onAppUpdate?: (build?: string) => void
+  onStateChange?: (connected: boolean) => void
+  onFocusChange?: (currentFocus: string) => void
 }
-let wsOpts: CapturedWsOpts | null = null;
+let wsOpts: CapturedWsOpts | null = null
 
 vi.mock('../../src/lib/runtime/ws-client', () => ({
   WSClient: class {
     constructor(opts: CapturedWsOpts) {
-      wsOpts = opts;
+      wsOpts = opts
     }
     connect(): void {}
     disconnect(): void {}
-  },
-}));
+  }
+}))
 
 // Engine method spies, so the focus-suppression wiring (setSuppressed / pollNow) is assertable.
 const engineSpies = vi.hoisted(() => ({
   setSuppressed: vi.fn<(v: boolean) => void>(),
   pollNow: vi.fn<() => Promise<void>>(() => Promise.resolve()),
-  pollResource: vi.fn<() => Promise<void>>(() => Promise.resolve()),
-}));
+  pollResource: vi.fn<() => Promise<void>>(() => Promise.resolve())
+}))
 
 // Captures the engine's onUpdate (handleResourceUpdate) so a test can simulate a poll result.
-const engineCapture = vi.hoisted(() => ({ onUpdate: null as null | ((key: string, data: unknown) => void) }));
+const engineCapture = vi.hoisted(() => ({onUpdate: null as null | ((key: string, data: unknown) => void)}))
 
 vi.mock('../../src/lib/runtime/poll-engine', () => ({
   PollEngine: class {
-    constructor(opts: { onUpdate: (key: string, data: unknown) => void; }) {
-      engineCapture.onUpdate = opts.onUpdate;
+    constructor(opts: {onUpdate: (key: string, data: unknown) => void}) {
+      engineCapture.onUpdate = opts.onUpdate
     }
     seed(): void {}
     start(): void {}
     setMode(): void {}
-    setSuppressed = engineSpies.setSuppressed;
-    pollNow = engineSpies.pollNow;
-    pollResource = engineSpies.pollResource;
-  },
-}));
+    setSuppressed = engineSpies.setSuppressed
+    pollNow = engineSpies.pollNow
+    pollResource = engineSpies.pollResource
+  }
+}))
 
 // fetchWithTimeout is the focus-signal fetch at startup; a hoisted spy (default null)
 // lets a test resolve a hiding focus to exercise the load-during-hiding path.
-const fetchSpy = vi.hoisted(() => vi.fn<() => Promise<unknown>>(() => Promise.resolve(null)));
+const fetchSpy = vi.hoisted(() => vi.fn<() => Promise<unknown>>(() => Promise.resolve(null)))
 
-vi.mock('../../src/lib/runtime/api', () => ({
-  fetchWithTimeout: fetchSpy,
-  fetchAllEndpoints: () =>
-    Promise.resolve({
-      health: null,
-      sleep: null,
-      workouts: null,
-      books: null,
-      githubEvents: null,
-      starredRepos: null,
-      articles: null,
-      location: null,
-      focus: null,
-      theatreReviews: null,
-      timestamps: {},
-    }),
-}));
+vi.mock('../../src/lib/runtime/api',
+  () => ({
+    fetchWithTimeout: fetchSpy,
+    fetchAllEndpoints: () =>
+      Promise.resolve({
+        health: null,
+        sleep: null,
+        workouts: null,
+        books: null,
+        githubEvents: null,
+        starredRepos: null,
+        articles: null,
+        location: null,
+        focus: null,
+        theatreReviews: null,
+        timestamps: {}
+      })
+  }))
 
 vi.mock('@lifegames/portal-contract/constants', async (importActual) => {
   // Pull the REAL cross-platform constants (HIDING_FOCUS_MODES, FOCUS_MODES) from the
   // contract so this test enforces the single source of truth instead of duplicating it —
   // a hardcoded copy here would pass even if the contract's hiding modes changed. Only the
   // network URLs + endpoint paths are overridden with test doubles.
-  const actual = await importActual<typeof import('@lifegames/portal-contract/constants')>();
+  const actual = await importActual<typeof import('@lifegames/portal-contract/constants')>()
   return {
     ...actual,
     CLOUDFRONT_BASE: 'https://mock.cloudfront.net',
@@ -91,183 +92,179 @@ vi.mock('@lifegames/portal-contract/constants', async (importActual) => {
       articles: '/articles.json',
       location: '/location.json',
       focus: '/focus.json',
-      theatreReviews: '/theatre-reviews.json',
-    },
-  };
-});
+      theatreReviews: '/theatre-reviews.json'
+    }
+  }
+})
 
-type SwWindow = Window & { __checkForSwUpdate?: () => void; };
+type SwWindow = Window & {__checkForSwUpdate?: () => void}
 
 function clearSpies(): void {
-  engineSpies.setSuppressed.mockClear();
-  engineSpies.pollNow.mockClear();
-  engineSpies.pollResource.mockClear();
-  fetchSpy.mockClear();
+  engineSpies.setSuppressed.mockClear()
+  engineSpies.pollNow.mockClear()
+  engineSpies.pollResource.mockClear()
+  fetchSpy.mockClear()
 }
 
 async function bootLiveData(): Promise<void> {
-  await import('../../src/lib/runtime/live-data');
-  await vi.runAllTimersAsync(); // flush the deferred startFetch + awaited fetches
+  await import('../../src/lib/runtime/live-data')
+  await vi.runAllTimersAsync() // flush the deferred startFetch + awaited fetches
 }
 
 describe('live-data → service-worker nudge wiring', () => {
   beforeEach(() => {
-    wsOpts = null;
-    vi.resetModules();
-    vi.useFakeTimers();
-    document.body.innerHTML = '';
-    clearSpies();
-  });
+    wsOpts = null
+    vi.resetModules()
+    vi.useFakeTimers()
+    document.body.innerHTML = ''
+    clearSpies()
+  })
 
   afterEach(() => {
-    vi.useRealTimers();
-    delete (window as SwWindow).__checkForSwUpdate;
-  });
+    vi.useRealTimers()
+    delete (window as SwWindow).__checkForSwUpdate
+  })
 
   it('invokes window.__checkForSwUpdate on an app-update push', async () => {
-    const nudge = vi.fn();
-    (window as SwWindow).__checkForSwUpdate = nudge;
+    const nudge = vi.fn()
+    ;(window as SwWindow).__checkForSwUpdate = nudge
 
-    await bootLiveData();
+    await bootLiveData()
 
-    expect(wsOpts).not.toBeNull();
-    expect(typeof wsOpts?.onAppUpdate).toBe('function');
-    wsOpts?.onAppUpdate?.('deadbeef');
-    expect(nudge).toHaveBeenCalledTimes(1);
-  });
+    expect(wsOpts).not.toBeNull()
+    expect(typeof wsOpts?.onAppUpdate).toBe('function')
+    wsOpts?.onAppUpdate?.('deadbeef')
+    expect(nudge).toHaveBeenCalledTimes(1)
+  })
 
   it('re-checks on WebSocket (re)connect to catch a missed push', async () => {
-    const nudge = vi.fn();
-    (window as SwWindow).__checkForSwUpdate = nudge;
+    const nudge = vi.fn()
+    ;(window as SwWindow).__checkForSwUpdate = nudge
 
-    await bootLiveData();
+    await bootLiveData()
 
-    wsOpts?.onStateChange?.(true);
-    expect(nudge).toHaveBeenCalledTimes(1);
-  });
+    wsOpts?.onStateChange?.(true)
+    expect(nudge).toHaveBeenCalledTimes(1)
+  })
 
   it('is a no-op when the service-worker hook is absent', async () => {
-    await bootLiveData();
-    expect(() => wsOpts?.onAppUpdate?.()).not.toThrow();
-  });
-});
+    await bootLiveData()
+    expect(() => wsOpts?.onAppUpdate?.()).not.toThrow()
+  })
+})
 
 describe('live-data → focus overlay + suppression wiring', () => {
   beforeEach(() => {
-    wsOpts = null;
-    vi.resetModules();
-    vi.useFakeTimers();
-    clearSpies();
+    wsOpts = null
+    vi.resetModules()
+    vi.useFakeTimers()
+    clearSpies()
     // Overlays so the (real) updateFocusOverlay can toggle them.
-    document.body.innerHTML = '<div id="focusOverlay" style="display:none"></div>'
-      + '<div id="dndOverlay" style="display:none"></div>';
-  });
+    document.body.innerHTML = '<div id="focusOverlay" style="display:none"></div>' + '<div id="dndOverlay" style="display:none"></div>'
+  })
 
   afterEach(() => {
-    vi.useRealTimers();
-  });
+    vi.useRealTimers()
+  })
 
   it('shows the overlay immediately from a focus push (no refetch) and suppresses polling', async () => {
-    await bootLiveData();
-    engineSpies.setSuppressed.mockClear(); // discard the startup setSuppressed(false)
+    await bootLiveData()
+    engineSpies.setSuppressed.mockClear() // discard the startup setSuppressed(false)
 
-    wsOpts?.onFocusChange?.('Do Not Disturb');
+    wsOpts?.onFocusChange?.('Do Not Disturb')
 
-    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex');
-    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(true);
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex')
+    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(true)
     // Cards are deliberately NOT re-skeletoned (the overlay covers them); re-skeletoning
     // would strand any unchanged card in its skeleton after restore (pollNow fingerprint skip).
-    expect(engineSpies.pollNow).not.toHaveBeenCalled();
-  });
+    expect(engineSpies.pollNow).not.toHaveBeenCalled()
+  })
 
   it('restores on exit: hides the overlay, clears suppression, and refetches all', async () => {
-    await bootLiveData();
-    wsOpts?.onFocusChange?.('Do Not Disturb');
-    engineSpies.setSuppressed.mockClear();
-    engineSpies.pollNow.mockClear();
+    await bootLiveData()
+    wsOpts?.onFocusChange?.('Do Not Disturb')
+    engineSpies.setSuppressed.mockClear()
+    engineSpies.pollNow.mockClear()
 
-    wsOpts?.onFocusChange?.('Personal');
+    wsOpts?.onFocusChange?.('Personal')
 
-    expect(document.getElementById('dndOverlay')?.style.display).toBe('none');
-    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(false);
-    expect(engineSpies.pollNow).toHaveBeenCalledTimes(1);
-  });
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('none')
+    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(false)
+    expect(engineSpies.pollNow).toHaveBeenCalledTimes(1)
+  })
 
   it('swaps Work→DND overlays without re-toggling suppression (still hiding)', async () => {
-    await bootLiveData();
-    wsOpts?.onFocusChange?.('Work');
-    expect(document.getElementById('focusOverlay')?.style.display).toBe('flex');
-    engineSpies.setSuppressed.mockClear();
+    await bootLiveData()
+    wsOpts?.onFocusChange?.('Work')
+    expect(document.getElementById('focusOverlay')?.style.display).toBe('flex')
+    engineSpies.setSuppressed.mockClear()
 
-    wsOpts?.onFocusChange?.('Do Not Disturb');
+    wsOpts?.onFocusChange?.('Do Not Disturb')
 
-    expect(document.getElementById('focusOverlay')?.style.display).toBe('none');
-    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex');
-    expect(engineSpies.setSuppressed).not.toHaveBeenCalled();
-  });
+    expect(document.getElementById('focusOverlay')?.style.display).toBe('none')
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex')
+    expect(engineSpies.setSuppressed).not.toHaveBeenCalled()
+  })
 
   // Load-during-hiding: opening the dashboard while focus is ALREADY a hiding mode. applyFocus
   // runs before the engine exists, so suppression must be propagated via the post-seed
   // engine.setSuppressed(suppressed), and the skeletons must be retained (endpoints 403).
   it('loads directly into suppression when focus is already a hiding mode at startup', async () => {
-    document.body.innerHTML += '<div id="cardHR" class="is-loading"></div>';
-    fetchSpy.mockResolvedValueOnce({
-      generatedAt: '2026-01-01T00:00:00Z',
-      currentFocus: 'Do Not Disturb',
-    });
+    document.body.innerHTML += '<div id="cardHR" class="is-loading"></div>'
+    fetchSpy.mockResolvedValueOnce({generatedAt: '2026-01-01T00:00:00Z', currentFocus: 'Do Not Disturb'})
 
-    await bootLiveData();
+    await bootLiveData()
 
-    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(true);
-    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex');
+    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(true)
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex')
     // Skeletons stay while suppressed — the 403'd endpoints have no real data to reveal.
-    expect(document.getElementById('cardHR')?.classList.contains('is-loading')).toBe(true);
-  });
+    expect(document.getElementById('cardHR')?.classList.contains('is-loading')).toBe(true)
+  })
 
   it('ignores a stale focus poll that contradicts the latest push while the WS is connected', async () => {
-    await bootLiveData();
-    wsOpts?.onStateChange?.(true); // WS live → the focus poll is fallback-only
+    await bootLiveData()
+    wsOpts?.onStateChange?.(true) // WS live → the focus poll is fallback-only
 
-    wsOpts?.onFocusChange?.('Do Not Disturb');
-    wsOpts?.onFocusChange?.('None'); // restore via push clears the overlay
-    expect(document.getElementById('dndOverlay')?.style.display).toBe('none');
-    engineSpies.setSuppressed.mockClear();
+    wsOpts?.onFocusChange?.('Do Not Disturb')
+    wsOpts?.onFocusChange?.('None') // restore via push clears the overlay
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('none')
+    engineSpies.setSuppressed.mockClear()
 
     // The ~30s edge-cached focus.json still reports the OLD hiding value on the next poll.
-    engineCapture.onUpdate?.('focus', { generatedAt: '2026-01-01T00:00:00Z', currentFocus: 'Do Not Disturb' });
+    engineCapture.onUpdate?.('focus', {generatedAt: '2026-01-01T00:00:00Z', currentFocus: 'Do Not Disturb'})
 
     // Must NOT re-show the overlay or re-suppress — this was the restore-linger bug.
-    expect(document.getElementById('dndOverlay')?.style.display).toBe('none');
-    expect(engineSpies.setSuppressed).not.toHaveBeenCalled();
-  });
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('none')
+    expect(engineSpies.setSuppressed).not.toHaveBeenCalled()
+  })
 
   it('still applies a focus poll when the WS is down (poll is the fallback)', async () => {
-    await bootLiveData();
-    wsOpts?.onStateChange?.(false); // WS down → the poll drives focus
+    await bootLiveData()
+    wsOpts?.onStateChange?.(false) // WS down → the poll drives focus
 
-    engineCapture.onUpdate?.('focus', { generatedAt: '2026-01-01T00:00:00Z', currentFocus: 'Do Not Disturb' });
+    engineCapture.onUpdate?.('focus', {generatedAt: '2026-01-01T00:00:00Z', currentFocus: 'Do Not Disturb'})
 
-    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex');
-    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(true);
-  });
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex')
+    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(true)
+  })
 
   it('trusts the focus poll again after the propagation window (dropped-push self-heal)', async () => {
-    await bootLiveData();
-    wsOpts?.onStateChange?.(true);
-    wsOpts?.onFocusChange?.('Do Not Disturb'); // enter hiding via push; the ignore-window opens
-    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex');
-    engineSpies.setSuppressed.mockClear();
+    await bootLiveData()
+    wsOpts?.onStateChange?.(true)
+    wsOpts?.onFocusChange?.('Do Not Disturb') // enter hiding via push; the ignore-window opens
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex')
+    engineSpies.setSuppressed.mockClear()
 
     // The user exits to None but the WS push is DROPPED — only the poll sees it. Within the
     // window the poll is ignored; once the window elapses it must be trusted so the overlay
     // does not stay stuck forever on the stale hiding value.
-    engineCapture.onUpdate?.('focus', { generatedAt: '2026-01-01T00:00:01Z', currentFocus: 'None' });
-    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex'); // still ignored (in window)
+    engineCapture.onUpdate?.('focus', {generatedAt: '2026-01-01T00:00:01Z', currentFocus: 'None'})
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('flex') // still ignored (in window)
 
-    vi.advanceTimersByTime(46_000); // past STALE_FOCUS_POLL_WINDOW_MS
-    engineCapture.onUpdate?.('focus', { generatedAt: '2026-01-01T00:00:02Z', currentFocus: 'None' });
+    vi.advanceTimersByTime(46_000) // past STALE_FOCUS_POLL_WINDOW_MS
+    engineCapture.onUpdate?.('focus', {generatedAt: '2026-01-01T00:00:02Z', currentFocus: 'None'})
 
-    expect(document.getElementById('dndOverlay')?.style.display).toBe('none'); // self-healed
-    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(false);
-  });
-});
+    expect(document.getElementById('dndOverlay')?.style.display).toBe('none') // self-healed
+    expect(engineSpies.setSuppressed).toHaveBeenCalledWith(false)
+  })
+})

--- a/tests/unit/poll-engine.test.ts
+++ b/tests/unit/poll-engine.test.ts
@@ -1,376 +1,336 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { PollEngine } from '../../src/lib/runtime/poll-engine';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {PollEngine} from '../../src/lib/runtime/poll-engine'
 
 // Mock constants module
-vi.mock('@lifegames/portal-contract/constants', () => ({
-  CLOUDFRONT_BASE: 'https://mock.cloudfront.net',
-  ENDPOINTS: {
-    health: '/health.json',
-    sleep: '/sleep.json',
-    workouts: '/workouts.json',
-    books: '/books.json',
-    starredRepos: '/github-starred-repos.json',
-    githubEvents: '/github-events.json',
-    articles: '/articles.json',
-    location: '/location.json',
-    focus: '/focus.json',
-    theatreReviews: '/theatre-reviews.json',
-  },
-}));
+vi.mock('@lifegames/portal-contract/constants',
+  () => ({
+    CLOUDFRONT_BASE: 'https://mock.cloudfront.net',
+    ENDPOINTS: {
+      health: '/health.json',
+      sleep: '/sleep.json',
+      workouts: '/workouts.json',
+      books: '/books.json',
+      starredRepos: '/github-starred-repos.json',
+      githubEvents: '/github-events.json',
+      articles: '/articles.json',
+      location: '/location.json',
+      focus: '/focus.json',
+      theatreReviews: '/theatre-reviews.json'
+    }
+  }))
 
 function makeFetchResponse(data: unknown, ok = true, status = 200) {
-  return {
-    ok,
-    status,
-    json: () => Promise.resolve(data),
-  };
+  return {ok, status, json: () => Promise.resolve(data)}
 }
 
 describe('PollEngine', () => {
-  let onUpdate: ReturnType<typeof vi.fn>;
-  let onError: ReturnType<typeof vi.fn>;
-  let onStatusChange: ReturnType<typeof vi.fn>;
-  let engine: PollEngine;
+  let onUpdate: ReturnType<typeof vi.fn>
+  let onError: ReturnType<typeof vi.fn>
+  let onStatusChange: ReturnType<typeof vi.fn>
+  let engine: PollEngine
 
   beforeEach(() => {
-    vi.useFakeTimers();
-    onUpdate = vi.fn();
-    onError = vi.fn();
-    onStatusChange = vi.fn();
-    vi.stubGlobal('fetch', vi.fn());
-    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
-    engine = new PollEngine({ onUpdate, onError, onStatusChange });
-  });
+    vi.useFakeTimers()
+    onUpdate = vi.fn()
+    onError = vi.fn()
+    onStatusChange = vi.fn()
+    vi.stubGlobal('fetch', vi.fn())
+    Object.defineProperty(navigator, 'onLine', {value: true, configurable: true})
+    engine = new PollEngine({onUpdate, onError, onStatusChange})
+  })
 
   afterEach(() => {
-    engine.stop();
-    vi.useRealTimers();
-    vi.unstubAllGlobals();
-  });
+    engine.stop()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
 
   describe('constructor', () => {
     it('creates engine without throwing', () => {
-      expect(engine).toBeDefined();
-    });
+      expect(engine).toBeDefined()
+    })
 
     it('getStatus() returns disconnected initially', () => {
-      const status = engine.getStatus();
-      expect(status.connected).toBe(false);
-      expect(status.lastPollAt).toBeNull();
-      expect(status.errorCounts).toEqual({});
-      expect(status.wsConnected).toBe(false);
-    });
-  });
+      const status = engine.getStatus()
+      expect(status.connected).toBe(false)
+      expect(status.lastPollAt).toBeNull()
+      expect(status.errorCounts).toEqual({})
+      expect(status.wsConnected).toBe(false)
+    })
+  })
 
   describe('seed()', () => {
     it('seeds fingerprints so unchanged data is skipped', async () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-01T00:00:00Z', data: 'x' }));
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-01T00:00:00Z', data: 'x'}))
+      vi.stubGlobal('fetch', fetchMock)
 
-      engine.seed({ health: '2024-01-01T00:00:00Z' });
-      await engine.pollResource('health');
+      engine.seed({health: '2024-01-01T00:00:00Z'})
+      await engine.pollResource('health')
 
       // onUpdate should NOT be called because fingerprint matches
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
 
     it('ignores null values in seed timestamps', () => {
-      engine.seed({ health: null as unknown as string, sleep: '2024-01-01T00:00:00Z' });
+      engine.seed({health: null as unknown as string, sleep: '2024-01-01T00:00:00Z'})
       // No error thrown; null values are skipped
-      expect(engine.getStatus().errorCounts).toEqual({});
-    });
-  });
+      expect(engine.getStatus().errorCounts).toEqual({})
+    })
+  })
 
   describe('start()', () => {
     it('sets connected=true after start when online', () => {
-      engine.start();
-      expect(engine.getStatus().connected).toBe(true);
-    });
+      engine.start()
+      expect(engine.getStatus().connected).toBe(true)
+    })
 
     it('is idempotent — calling start() twice does not double-register timers', () => {
-      engine.start();
-      engine.start();
-      expect(onStatusChange).toHaveBeenCalledTimes(1);
-    });
+      engine.start()
+      engine.start()
+      expect(onStatusChange).toHaveBeenCalledTimes(1)
+    })
 
     it('emits status on start', () => {
-      engine.start();
-      expect(onStatusChange).toHaveBeenCalledOnce();
-    });
-  });
+      engine.start()
+      expect(onStatusChange).toHaveBeenCalledOnce()
+    })
+  })
 
   describe('stop()', () => {
     it('sets connected=false after stop', () => {
-      engine.start();
-      engine.stop();
-      expect(engine.getStatus().connected).toBe(false);
-    });
+      engine.start()
+      engine.stop()
+      expect(engine.getStatus().connected).toBe(false)
+    })
 
     it('emits status on stop', () => {
-      engine.start();
-      onStatusChange.mockClear();
-      engine.stop();
-      expect(onStatusChange).toHaveBeenCalledOnce();
-    });
+      engine.start()
+      onStatusChange.mockClear()
+      engine.stop()
+      expect(onStatusChange).toHaveBeenCalledOnce()
+    })
 
     it('cleans up visibilitychange listener on stop', () => {
-      const removeSpy = vi.spyOn(document, 'removeEventListener');
-      engine.start();
-      engine.stop();
-      expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
-    });
-  });
+      const removeSpy = vi.spyOn(document, 'removeEventListener')
+      engine.start()
+      engine.stop()
+      expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    })
+  })
 
   describe('setMode()', () => {
     it('setMode("passive") sets wsConnected=true', () => {
-      engine.setMode('passive');
-      expect(engine.getStatus().wsConnected).toBe(true);
-    });
+      engine.setMode('passive')
+      expect(engine.getStatus().wsConnected).toBe(true)
+    })
 
     it('setMode("active") sets wsConnected=false', () => {
-      engine.setMode('passive');
-      engine.setMode('active');
-      expect(engine.getStatus().wsConnected).toBe(false);
-    });
+      engine.setMode('passive')
+      engine.setMode('active')
+      expect(engine.getStatus().wsConnected).toBe(false)
+    })
 
     it('calling setMode with the same mode is a no-op', () => {
-      engine.setMode('active'); // already active by default
-      expect(onStatusChange).not.toHaveBeenCalled();
-    });
+      engine.setMode('active') // already active by default
+      expect(onStatusChange).not.toHaveBeenCalled()
+    })
 
     it('passive mode uses longer intervals (120s fast, 300s slow)', () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-01T00:00:00Z' }));
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-01T00:00:00Z'}))
+      vi.stubGlobal('fetch', fetchMock)
 
-      engine.start();
-      engine.setMode('passive');
-      fetchMock.mockClear();
+      engine.start()
+      engine.setMode('passive')
+      fetchMock.mockClear()
 
       // At 30s (active fast interval) — should NOT fire in passive mode
-      vi.advanceTimersByTime(30_000);
-      expect(fetchMock).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(30_000)
+      expect(fetchMock).not.toHaveBeenCalled()
 
       // At 120s — passive fast interval fires
-      vi.advanceTimersByTime(90_000);
-      expect(fetchMock).toHaveBeenCalled();
-    });
+      vi.advanceTimersByTime(90_000)
+      expect(fetchMock).toHaveBeenCalled()
+    })
 
     it('active mode uses shorter intervals (30s fast)', () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-01T00:00:00Z' }));
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-01T00:00:00Z'}))
+      vi.stubGlobal('fetch', fetchMock)
 
-      engine.start();
-      vi.advanceTimersByTime(30_000);
-      expect(fetchMock).toHaveBeenCalled();
-    });
-  });
+      engine.start()
+      vi.advanceTimersByTime(30_000)
+      expect(fetchMock).toHaveBeenCalled()
+    })
+  })
 
   describe('fetchResource()', () => {
     it('calls onUpdate with new data when fingerprint differs', async () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-02T00:00:00Z', value: 42 }));
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-02T00:00:00Z', value: 42}))
+      vi.stubGlobal('fetch', fetchMock)
 
-      engine.seed({ health: '2024-01-01T00:00:00Z' });
-      await engine.pollResource('health');
+      engine.seed({health: '2024-01-01T00:00:00Z'})
+      await engine.pollResource('health')
 
-      expect(onUpdate).toHaveBeenCalledWith('health', {
-        generatedAt: '2024-01-02T00:00:00Z',
-        value: 42,
-      });
-    });
+      expect(onUpdate).toHaveBeenCalledWith('health', {generatedAt: '2024-01-02T00:00:00Z', value: 42})
+    })
 
     it('skips onUpdate when fingerprint is unchanged', async () => {
-      const ts = '2024-01-01T00:00:00Z';
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse({ generatedAt: ts })));
+      const ts = '2024-01-01T00:00:00Z'
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: ts})))
 
-      engine.seed({ health: ts });
-      await engine.pollResource('health');
+      engine.seed({health: ts})
+      await engine.pollResource('health')
 
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
 
     it('calls onError on HTTP error (non-ok response)', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse(null, false, 500)));
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse(null, false, 500)))
 
-      await engine.pollResource('health');
+      await engine.pollResource('health')
 
-      expect(onError).toHaveBeenCalledWith(
-        'health',
-        expect.objectContaining({ message: 'HTTP 500' }),
-      );
-    });
+      expect(onError).toHaveBeenCalledWith('health', expect.objectContaining({message: 'HTTP 500'}))
+    })
 
     it('calls onError on network error', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network failure')));
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network failure')))
 
-      await engine.pollResource('health');
+      await engine.pollResource('health')
 
-      expect(onError).toHaveBeenCalledWith(
-        'health',
-        expect.objectContaining({ message: 'Network failure' }),
-      );
-    });
+      expect(onError).toHaveBeenCalledWith('health', expect.objectContaining({message: 'Network failure'}))
+    })
 
     it('increments errorCounts on repeated errors', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('fail')));
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('fail')))
 
-      await engine.pollResource('health');
-      await engine.pollResource('health');
+      await engine.pollResource('health')
+      await engine.pollResource('health')
 
-      expect(engine.getStatus().errorCounts.health).toBe(2);
-    });
+      expect(engine.getStatus().errorCounts.health).toBe(2)
+    })
 
     it('clears errorCounts on successful fetch', async () => {
-      vi.stubGlobal(
-        'fetch',
-        vi
-          .fn()
-          .mockRejectedValueOnce(new Error('fail'))
-          .mockResolvedValueOnce(makeFetchResponse({ generatedAt: '2024-01-02T00:00:00Z' })),
-      );
+      vi.stubGlobal('fetch',
+        vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValueOnce(makeFetchResponse({generatedAt: '2024-01-02T00:00:00Z'})))
 
-      await engine.pollResource('health');
-      expect(engine.getStatus().errorCounts.health).toBe(1);
+      await engine.pollResource('health')
+      expect(engine.getStatus().errorCounts.health).toBe(1)
 
-      await engine.pollResource('health');
-      expect(engine.getStatus().errorCounts.health).toBeUndefined();
-    });
+      await engine.pollResource('health')
+      expect(engine.getStatus().errorCounts.health).toBeUndefined()
+    })
 
     it('updates lastPollAt after a poll', async () => {
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-01T00:00:00Z' })),
-      );
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-01T00:00:00Z'})))
 
-      expect(engine.getStatus().lastPollAt).toBeNull();
-      await engine.pollResource('health');
-      expect(engine.getStatus().lastPollAt).not.toBeNull();
-    });
-  });
+      expect(engine.getStatus().lastPollAt).toBeNull()
+      await engine.pollResource('health')
+      expect(engine.getStatus().lastPollAt).not.toBeNull()
+    })
+  })
 
   describe('setSuppressed()', () => {
     it('skips a gated resource while suppressed (no fetch, no update)', async () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-02T00:00:00Z' }));
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-02T00:00:00Z'}))
+      vi.stubGlobal('fetch', fetchMock)
 
-      engine.setSuppressed(true);
-      await engine.pollResource('health');
+      engine.setSuppressed(true)
+      await engine.pollResource('health')
 
-      expect(fetchMock).not.toHaveBeenCalled();
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
 
     it('keeps polling focus while suppressed (overlay fallback is never gated)', async () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-02T00:00:00Z', currentFocus: 'Do Not Disturb' }));
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-02T00:00:00Z', currentFocus: 'Do Not Disturb'}))
+      vi.stubGlobal('fetch', fetchMock)
 
-      engine.setSuppressed(true);
-      await engine.pollResource('focus');
+      engine.setSuppressed(true)
+      await engine.pollResource('focus')
 
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      expect(onUpdate).toHaveBeenCalledWith('focus', expect.objectContaining({ currentFocus: 'Do Not Disturb' }));
-    });
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(onUpdate).toHaveBeenCalledWith('focus', expect.objectContaining({currentFocus: 'Do Not Disturb'}))
+    })
 
     it('resumes gated polling once suppression is cleared', async () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-02T00:00:00Z', value: 1 }));
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-02T00:00:00Z', value: 1}))
+      vi.stubGlobal('fetch', fetchMock)
 
-      engine.setSuppressed(true);
-      await engine.pollResource('health');
-      expect(fetchMock).not.toHaveBeenCalled();
+      engine.setSuppressed(true)
+      await engine.pollResource('health')
+      expect(fetchMock).not.toHaveBeenCalled()
 
-      engine.setSuppressed(false);
-      await engine.pollResource('health');
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      expect(onUpdate).toHaveBeenCalledWith('health', { generatedAt: '2024-01-02T00:00:00Z', value: 1 });
-    });
+      engine.setSuppressed(false)
+      await engine.pollResource('health')
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(onUpdate).toHaveBeenCalledWith('health', {generatedAt: '2024-01-02T00:00:00Z', value: 1})
+    })
 
     it('pollNow() fetches every resource once suppression is cleared', async () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-02T00:00:00Z' }));
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-02T00:00:00Z'}))
+      vi.stubGlobal('fetch', fetchMock)
 
-      engine.setSuppressed(false);
-      await engine.pollNow();
+      engine.setSuppressed(false)
+      await engine.pollNow()
 
       // FAST (health, sleep, workouts, focus) + SLOW (books, articles, githubEvents,
       // starredRepos, theatreReviews) = 9 in production (location is DEV-only).
-      expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(9);
-    });
-  });
+      expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(9)
+    })
+  })
 
   describe('getStatus()', () => {
     it('returns correct shape', () => {
-      const status = engine.getStatus();
-      expect(status).toHaveProperty('connected');
-      expect(status).toHaveProperty('lastPollAt');
-      expect(status).toHaveProperty('errorCounts');
-      expect(status).toHaveProperty('wsConnected');
-    });
+      const status = engine.getStatus()
+      expect(status).toHaveProperty('connected')
+      expect(status).toHaveProperty('lastPollAt')
+      expect(status).toHaveProperty('errorCounts')
+      expect(status).toHaveProperty('wsConnected')
+    })
 
     it('connected reflects navigator.onLine', () => {
-      engine.start();
-      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
-      expect(engine.getStatus().connected).toBe(false);
-    });
-  });
+      engine.start()
+      Object.defineProperty(navigator, 'onLine', {value: false, configurable: true})
+      expect(engine.getStatus().connected).toBe(false)
+    })
+  })
 
   describe('visibility change', () => {
     it('pauses timers when document becomes hidden', () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-01T00:00:00Z' }));
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-01T00:00:00Z'}))
+      vi.stubGlobal('fetch', fetchMock)
 
-      engine.start();
+      engine.start()
 
       // Simulate tab hidden
-      Object.defineProperty(document, 'hidden', { value: true, configurable: true });
-      document.dispatchEvent(new Event('visibilitychange'));
+      Object.defineProperty(document, 'hidden', {value: true, configurable: true})
+      document.dispatchEvent(new Event('visibilitychange'))
 
-      fetchMock.mockClear();
-      vi.advanceTimersByTime(60_000);
-      expect(fetchMock).not.toHaveBeenCalled();
-    });
+      fetchMock.mockClear()
+      vi.advanceTimersByTime(60_000)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
 
     it('resumes and immediately polls when document becomes visible', async () => {
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValue(makeFetchResponse({ generatedAt: '2024-01-01T00:00:00Z' }));
-      vi.stubGlobal('fetch', fetchMock);
+      const fetchMock = vi.fn().mockResolvedValue(makeFetchResponse({generatedAt: '2024-01-01T00:00:00Z'}))
+      vi.stubGlobal('fetch', fetchMock)
 
-      engine.start();
+      engine.start()
 
       // Hide then show
-      Object.defineProperty(document, 'hidden', { value: true, configurable: true });
-      document.dispatchEvent(new Event('visibilitychange'));
+      Object.defineProperty(document, 'hidden', {value: true, configurable: true})
+      document.dispatchEvent(new Event('visibilitychange'))
 
-      fetchMock.mockClear();
+      fetchMock.mockClear()
 
-      Object.defineProperty(document, 'hidden', { value: false, configurable: true });
-      document.dispatchEvent(new Event('visibilitychange'));
+      Object.defineProperty(document, 'hidden', {value: false, configurable: true})
+      document.dispatchEvent(new Event('visibilitychange'))
 
       // Flush microtasks so the async pollNow() call can initiate fetches
-      await Promise.resolve();
-      await Promise.resolve();
+      await Promise.resolve()
+      await Promise.resolve()
 
-      expect(fetchMock).toHaveBeenCalled();
-    });
-  });
-});
+      expect(fetchMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/sa-collection.test.ts
+++ b/tests/unit/sa-collection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 // Unit test: Simple Analytics collection Function upstream-failure behaviour.
 // Asserts that a network error or upstream 5xx from queue.simpleanalyticscdn.com
@@ -6,129 +6,112 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // check stays green (Issue #83 / Plan finding #7 / Principle 3).
 
 // The Function module uses globalThis.fetch; stub it before importing.
-const fetchMock = vi.fn<typeof fetch>();
-vi.stubGlobal('fetch', fetchMock);
+const fetchMock = vi.fn<typeof fetch>()
+vi.stubGlobal('fetch', fetchMock)
 
 // Dynamic import after stubbing so the module picks up the mocked fetch.
-const { onRequest } = await import('../../functions/simple/[[path]]');
+const {onRequest} = await import('../../functions/simple/[[path]]')
 
 function makeContext(pathname: string, method = 'GET') {
   // Derive the [[path]] param from the pathname (strip leading /simple/)
-  const suffix = pathname.replace(/^\/simple\/?/, '');
-  const params: Record<string, string> = suffix ? { path: suffix } : {};
-  return {
-    request: new Request(`https://jonathanlloyd.me${pathname}`, { method }),
-    params,
-  };
+  const suffix = pathname.replace(/^\/simple\/?/, '')
+  const params: Record<string, string> = suffix ? {path: suffix} : {}
+  return {request: new Request(`https://jonathanlloyd.me${pathname}`, {method}), params}
 }
 
 beforeEach(() => {
-  fetchMock.mockReset();
-});
+  fetchMock.mockReset()
+})
 
 describe('SA collection Function — upstream failure → silent 2xx', () => {
   it('returns 204 when fetch throws (network error) for a non-gif path', async () => {
-    fetchMock.mockRejectedValueOnce(new Error('network failure'));
-    const res = await onRequest(makeContext('/simple/append'));
-    expect(res.status).toBe(204);
-    expect(res.headers.get('Cache-Control')).toBe('no-store');
-  });
+    fetchMock.mockRejectedValueOnce(new Error('network failure'))
+    const res = await onRequest(makeContext('/simple/append'))
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+  })
 
   it('returns transparent GIF (200) when fetch throws for a .gif path', async () => {
-    fetchMock.mockRejectedValueOnce(new Error('network failure'));
-    const res = await onRequest(makeContext('/simple/simple.gif'));
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('image/gif');
-    const body = new Uint8Array(await res.arrayBuffer());
+    fetchMock.mockRejectedValueOnce(new Error('network failure'))
+    const res = await onRequest(makeContext('/simple/simple.gif'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('image/gif')
+    const body = new Uint8Array(await res.arrayBuffer())
     // GIF89a magic bytes
-    expect(body[0]).toBe(0x47); // G
-    expect(body[1]).toBe(0x49); // I
-    expect(body[2]).toBe(0x46); // F
-  });
+    expect(body[0]).toBe(0x47) // G
+    expect(body[1]).toBe(0x49) // I
+    expect(body[2]).toBe(0x46) // F
+  })
 
   it('returns transparent GIF (200) when fetch throws for noscript.gif', async () => {
-    fetchMock.mockRejectedValueOnce(new Error('timeout'));
-    const res = await onRequest(makeContext('/simple/noscript.gif'));
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('image/gif');
-  });
+    fetchMock.mockRejectedValueOnce(new Error('timeout'))
+    const res = await onRequest(makeContext('/simple/noscript.gif'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('image/gif')
+  })
 
   it('returns 204 when upstream responds with 5xx for a non-gif path', async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response('upstream error', { status: 502 }),
-    );
-    const res = await onRequest(makeContext('/simple/append', 'POST'));
-    expect(res.status).toBe(204);
-  });
+    fetchMock.mockResolvedValueOnce(new Response('upstream error', {status: 502}))
+    const res = await onRequest(makeContext('/simple/append', 'POST'))
+    expect(res.status).toBe(204)
+  })
 
   it('returns transparent GIF (200) when upstream responds with 5xx for a .gif path', async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response('upstream error', { status: 503 }),
-    );
-    const res = await onRequest(makeContext('/simple/simple.gif'));
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('image/gif');
-  });
+    fetchMock.mockResolvedValueOnce(new Response('upstream error', {status: 503}))
+    const res = await onRequest(makeContext('/simple/simple.gif'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('image/gif')
+  })
 
   it('never returns a 5xx regardless of upstream failure', async () => {
-    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
-    const res = await onRequest(makeContext('/simple/append'));
-    expect(res.status).toBeLessThan(500);
-  });
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+    const res = await onRequest(makeContext('/simple/append'))
+    expect(res.status).toBeLessThan(500)
+  })
 
   it('proxies a successful upstream 200 response for a non-gif path', async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(null, {
-        status: 200,
-        headers: { 'Content-Type': 'text/plain' },
-      }),
-    );
-    const res = await onRequest(makeContext('/simple/append', 'POST'));
-    expect(res.status).toBe(200);
-  });
+    fetchMock.mockResolvedValueOnce(new Response(null, {status: 200, headers: {'Content-Type': 'text/plain'}}))
+    const res = await onRequest(makeContext('/simple/append', 'POST'))
+    expect(res.status).toBe(200)
+  })
 
   it('sets Cache-Control AND CDN-Cache-Control: no-store on the noop path', async () => {
-    fetchMock.mockRejectedValueOnce(new Error('fail'));
-    const res = await onRequest(makeContext('/simple/append'));
-    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    fetchMock.mockRejectedValueOnce(new Error('fail'))
+    const res = await onRequest(makeContext('/simple/append'))
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
     // CDN-Cache-Control is what Cloudflare's edge honors (it overrides the browser
     // Cache-Control); without it GET /simple/* is edge-cached for ~600s.
-    expect(res.headers.get('CDN-Cache-Control')).toBe('no-store');
-  });
+    expect(res.headers.get('CDN-Cache-Control')).toBe('no-store')
+  })
 
   it('sets CDN-Cache-Control: no-store on the success path too', async () => {
-    fetchMock.mockResolvedValueOnce(new Response(null, { status: 202 }));
-    const res = await onRequest(makeContext('/simple/simple.gif'));
-    expect(res.headers.get('CDN-Cache-Control')).toBe('no-store');
-  });
+    fetchMock.mockResolvedValueOnce(new Response(null, {status: 202}))
+    const res = await onRequest(makeContext('/simple/simple.gif'))
+    expect(res.headers.get('CDN-Cache-Control')).toBe('no-store')
+  })
 
   it('joins a multi-segment catch-all param array into the upstream path', async () => {
-    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    fetchMock.mockResolvedValueOnce(new Response(null, {status: 204}))
     // Cloudflare yields params.path as a string[] for a multi-segment match.
-    const ctx = {
-      request: new Request('https://jonathanlloyd.me/simple/a/b/c?q=1', { method: 'GET' }),
-      params: { path: ['a', 'b', 'c'] },
-    };
-    await onRequest(ctx);
-    expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://queue.simpleanalyticscdn.com/a/b/c?q=1',
-    );
-  });
+    const ctx = {request: new Request('https://jonathanlloyd.me/simple/a/b/c?q=1', {method: 'GET'}), params: {path: ['a', 'b', 'c']}}
+    await onRequest(ctx)
+    expect(fetchMock.mock.calls[0][0]).toBe('https://queue.simpleanalyticscdn.com/a/b/c?q=1')
+  })
 
   it('forwards the POST body with duplex:half and Content-Type for /append', async () => {
-    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    fetchMock.mockResolvedValueOnce(new Response(null, {status: 204}))
     const ctx = {
       request: new Request('https://jonathanlloyd.me/simple/append', {
         method: 'POST',
         body: 'type=event&name=scroll_depth_25',
-        headers: { 'Content-Type': 'text/plain' },
+        headers: {'Content-Type': 'text/plain'}
       }),
-      params: { path: 'append' },
-    };
-    await onRequest(ctx);
-    const init = fetchMock.mock.calls[0][1] as Record<string, unknown>;
-    expect(init.body).toBeTruthy(); // body forwarded, not dropped
-    expect(init.duplex).toBe('half'); // undici stream-body requirement
-    expect((init.headers as Record<string, string>)['Content-Type']).toBe('text/plain');
-  });
-});
+      params: {path: 'append'}
+    }
+    await onRequest(ctx)
+    const init = fetchMock.mock.calls[0][1] as Record<string, unknown>
+    expect(init.body).toBeTruthy() // body forwarded, not dropped
+    expect(init.duplex).toBe('half') // undici stream-body requirement
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('text/plain')
+  })
+})

--- a/tests/unit/updaters-status.test.ts
+++ b/tests/unit/updaters-status.test.ts
@@ -1,102 +1,80 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { updatePollStatus } from '../../src/lib/runtime/updaters-status';
-import type { PollStatus } from '../../src/lib/runtime/poll-engine';
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {updatePollStatus} from '../../src/lib/runtime/updaters-status'
+import type {PollStatus} from '../../src/lib/runtime/poll-engine'
 
 function setup() {
   document.body.innerHTML = `
     <span class="poll-dot"></span>
     <span class="poll-label"></span>
-  `;
+  `
 }
 
 function dot(): HTMLElement {
-  return document.querySelector('.poll-dot')!;
+  return document.querySelector('.poll-dot')!
 }
 function label(): HTMLElement {
-  return document.querySelector('.poll-label')!;
+  return document.querySelector('.poll-label')!
 }
 
 function status(overrides: Partial<PollStatus> = {}): PollStatus {
-  return {
-    connected: true,
-    lastPollAt: null,
-    errorCounts: {},
-    wsConnected: false,
-    ...overrides,
-  };
+  return {connected: true, lastPollAt: null, errorCounts: {}, wsConnected: false, ...overrides}
 }
 
 describe('updatePollStatus', () => {
   beforeEach(() => {
-    setup();
+    setup()
     // Default: navigator.onLine = true
-    vi.stubGlobal('navigator', { onLine: true });
-  });
+    vi.stubGlobal('navigator', {onLine: true})
+  })
 
   it('shows "Polling" when connected and no ws', () => {
-    updatePollStatus(status({ connected: true, wsConnected: false }));
-    expect(label().textContent).toBe('Polling');
-    expect(dot().className).toContain('poll-dot--ok');
-  });
+    updatePollStatus(status({connected: true, wsConnected: false}))
+    expect(label().textContent).toBe('Polling')
+    expect(dot().className).toContain('poll-dot--ok')
+  })
 
   it('shows "Live" when connected with wsConnected', () => {
-    updatePollStatus(status({ connected: true, wsConnected: true }));
-    expect(label().textContent).toBe('Live');
-    expect(dot().className).toContain('poll-dot--ok');
-  });
+    updatePollStatus(status({connected: true, wsConnected: true}))
+    expect(label().textContent).toBe('Live')
+    expect(dot().className).toContain('poll-dot--ok')
+  })
 
   it('shows "Partial" when some errors >= 3 but not all', () => {
-    updatePollStatus(
-      status({
-        connected: true,
-        wsConnected: false,
-        errorCounts: { health: 3, sleep: 0 },
-      }),
-    );
-    expect(label().textContent).toBe('Partial');
-    expect(dot().className).toContain('poll-dot--warn');
-  });
+    updatePollStatus(status({connected: true, wsConnected: false, errorCounts: {health: 3, sleep: 0}}))
+    expect(label().textContent).toBe('Partial')
+    expect(dot().className).toContain('poll-dot--warn')
+  })
 
   it('shows "Degraded" when all sources have errors >= 3 and online', () => {
-    updatePollStatus(
-      status({
-        connected: true,
-        wsConnected: false,
-        errorCounts: { health: 3, sleep: 5 },
-      }),
-    );
-    expect(label().textContent).toBe('Degraded');
-    expect(dot().className).toContain('poll-dot--error');
-  });
+    updatePollStatus(status({connected: true, wsConnected: false, errorCounts: {health: 3, sleep: 5}}))
+    expect(label().textContent).toBe('Degraded')
+    expect(dot().className).toContain('poll-dot--error')
+  })
 
   it('shows "Offline" when navigator.onLine is false', () => {
-    vi.stubGlobal('navigator', { onLine: false });
-    updatePollStatus(status({ connected: false, errorCounts: {} }));
-    expect(label().textContent).toBe('Offline');
-    expect(dot().className).toContain('poll-dot--error');
-  });
+    vi.stubGlobal('navigator', {onLine: false})
+    updatePollStatus(status({connected: false, errorCounts: {}}))
+    expect(label().textContent).toBe('Offline')
+    expect(dot().className).toContain('poll-dot--error')
+  })
 
   it('shows empty label when not connected and online', () => {
-    updatePollStatus(status({ connected: false, errorCounts: {} }));
-    expect(label().textContent).toBe('');
-    expect(dot().className).toContain('poll-dot--off');
-  });
+    updatePollStatus(status({connected: false, errorCounts: {}}))
+    expect(label().textContent).toBe('')
+    expect(dot().className).toContain('poll-dot--off')
+  })
 
   it('does not throw when dot/label elements are missing', () => {
-    document.body.innerHTML = '';
-    expect(() => updatePollStatus(status())).not.toThrow();
-  });
+    document.body.innerHTML = ''
+    expect(() => updatePollStatus(status())).not.toThrow()
+  })
 
   it('ignores null errorCount entries', () => {
     updatePollStatus(
-      status({
-        connected: true,
-        wsConnected: false,
-        errorCounts: { health: undefined as unknown as number, sleep: undefined as unknown as number },
-      }),
-    );
+      status({connected: true, wsConnected: false, errorCounts: {health: undefined as unknown as number, sleep: undefined as unknown as number}})
+    )
     // null entries filtered → no errors → Polling
-    expect(label().textContent).toBe('Polling');
-  });
-});
+    expect(label().textContent).toBe('Polling')
+  })
+})

--- a/tests/unit/ws-client.test.ts
+++ b/tests/unit/ws-client.test.ts
@@ -1,383 +1,369 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { WSClient } from '../../src/lib/runtime/ws-client';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {WSClient} from '../../src/lib/runtime/ws-client'
 
 // MockWebSocket with controllable event firing
 class MockWebSocket {
-  static OPEN = 1;
-  static CLOSING = 2;
-  static CLOSED = 3;
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
 
-  readyState: number;
-  url: string;
-  onopen: ((event: Event) => void) | null = null;
-  onmessage: ((event: MessageEvent) => void) | null = null;
-  onclose: ((event: CloseEvent) => void) | null = null;
-  onerror: ((event: Event) => void) | null = null;
+  readyState: number
+  url: string
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
 
-  static instances: MockWebSocket[] = [];
+  static instances: MockWebSocket[] = []
 
   constructor(url: string) {
-    this.url = url;
-    this.readyState = WebSocket.CONNECTING ?? 0;
-    MockWebSocket.instances.push(this);
+    this.url = url
+    this.readyState = WebSocket.CONNECTING ?? 0
+    MockWebSocket.instances.push(this)
   }
 
   send(_data: string): void {}
 
   close(): void {
-    this.readyState = MockWebSocket.CLOSED;
+    this.readyState = MockWebSocket.CLOSED
   }
 
   // Test helpers
   triggerOpen(): void {
-    this.readyState = MockWebSocket.OPEN;
-    this.onopen?.(new Event('open'));
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
   }
 
   triggerMessage(data: unknown): void {
-    const event = new MessageEvent('message', { data: JSON.stringify(data) });
-    this.onmessage?.(event);
+    const event = new MessageEvent('message', {data: JSON.stringify(data)})
+    this.onmessage?.(event)
   }
 
   triggerRawMessage(data: string): void {
-    const event = new MessageEvent('message', { data });
-    this.onmessage?.(event);
+    const event = new MessageEvent('message', {data})
+    this.onmessage?.(event)
   }
 
   triggerClose(): void {
-    this.readyState = MockWebSocket.CLOSED;
-    this.onclose?.(new CloseEvent('close'));
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
   }
 }
 
 function latestSocket(): MockWebSocket {
-  return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  return MockWebSocket.instances[MockWebSocket.instances.length - 1]
 }
 
 describe('WSClient', () => {
-  let onUpdate: ReturnType<typeof vi.fn>;
-  let onStateChange: ReturnType<typeof vi.fn>;
-  let client: WSClient;
+  let onUpdate: ReturnType<typeof vi.fn>
+  let onStateChange: ReturnType<typeof vi.fn>
+  let client: WSClient
 
   beforeEach(() => {
-    vi.useFakeTimers();
-    MockWebSocket.instances = [];
-    onUpdate = vi.fn();
-    onStateChange = vi.fn();
-    vi.stubGlobal('WebSocket', MockWebSocket);
-    client = new WSClient({
-      url: 'wss://test.example.com/live',
-      onUpdate,
-      onStateChange,
-      reconnectBaseMs: 1000,
-      reconnectMaxMs: 30_000,
-    });
-  });
+    vi.useFakeTimers()
+    MockWebSocket.instances = []
+    onUpdate = vi.fn()
+    onStateChange = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    client = new WSClient({url: 'wss://test.example.com/live', onUpdate, onStateChange, reconnectBaseMs: 1000, reconnectMaxMs: 30_000})
+  })
 
   afterEach(() => {
-    client.disconnect();
-    vi.useRealTimers();
-    vi.unstubAllGlobals();
-  });
+    client.disconnect()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
 
   describe('constructor', () => {
     it('starts in disconnected state', () => {
-      expect(client.getState()).toBe('disconnected');
-    });
+      expect(client.getState()).toBe('disconnected')
+    })
 
     it('does not create a WebSocket before connect() is called', () => {
-      expect(MockWebSocket.instances).toHaveLength(0);
-    });
-  });
+      expect(MockWebSocket.instances).toHaveLength(0)
+    })
+  })
 
   describe('connect()', () => {
     it('transitions to connecting state', () => {
-      client.connect();
-      expect(client.getState()).toBe('connecting');
-    });
+      client.connect()
+      expect(client.getState()).toBe('connecting')
+    })
 
     it('creates a WebSocket with the configured URL', () => {
-      client.connect();
-      expect(MockWebSocket.instances).toHaveLength(1);
-      expect(MockWebSocket.instances[0].url).toBe('wss://test.example.com/live');
-    });
+      client.connect()
+      expect(MockWebSocket.instances).toHaveLength(1)
+      expect(MockWebSocket.instances[0].url).toBe('wss://test.example.com/live')
+    })
 
     it('registers visibilitychange listener', () => {
-      const addSpy = vi.spyOn(document, 'addEventListener');
-      client.connect();
-      expect(addSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
-    });
-  });
+      const addSpy = vi.spyOn(document, 'addEventListener')
+      client.connect()
+      expect(addSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    })
+  })
 
   describe('onopen transition', () => {
     it('transitions to connected state on open', () => {
-      client.connect();
-      latestSocket().triggerOpen();
-      expect(client.getState()).toBe('connected');
-    });
+      client.connect()
+      latestSocket().triggerOpen()
+      expect(client.getState()).toBe('connected')
+    })
 
     it('calls onStateChange(true) on open', () => {
-      client.connect();
-      latestSocket().triggerOpen();
-      expect(onStateChange).toHaveBeenCalledWith(true);
-    });
+      client.connect()
+      latestSocket().triggerOpen()
+      expect(onStateChange).toHaveBeenCalledWith(true)
+    })
 
     it('resets reconnect attempt counter on open', () => {
-      client.connect();
-      const ws1 = latestSocket();
-      ws1.triggerOpen();
-      ws1.triggerClose();
+      client.connect()
+      const ws1 = latestSocket()
+      ws1.triggerOpen()
+      ws1.triggerClose()
 
       // First reconnect (attempt 1)
-      vi.advanceTimersByTime(1000);
-      latestSocket().triggerOpen();
-      latestSocket().triggerClose();
+      vi.advanceTimersByTime(1000)
+      latestSocket().triggerOpen()
+      latestSocket().triggerClose()
 
       // Second reconnect — now at attempt 2
-      vi.advanceTimersByTime(2000);
-      latestSocket().triggerOpen();
+      vi.advanceTimersByTime(2000)
+      latestSocket().triggerOpen()
       // After successful open, attempt resets to 0
       // Verify by closing and checking the delay is back to base (1s)
-      latestSocket().triggerClose();
-      vi.advanceTimersByTime(1000);
-      expect(MockWebSocket.instances).toHaveLength(4);
-    });
-  });
+      latestSocket().triggerClose()
+      vi.advanceTimersByTime(1000)
+      expect(MockWebSocket.instances).toHaveLength(4)
+    })
+  })
 
   describe('onmessage handling', () => {
     beforeEach(() => {
-      client.connect();
-      latestSocket().triggerOpen();
-    });
+      client.connect()
+      latestSocket().triggerOpen()
+    })
 
     it('calls onUpdate when message type is "update"', () => {
-      latestSocket().triggerMessage({ type: 'update', resource: 'health' });
-      expect(onUpdate).toHaveBeenCalledWith('health');
-    });
+      latestSocket().triggerMessage({type: 'update', resource: 'health'})
+      expect(onUpdate).toHaveBeenCalledWith('health')
+    })
 
     it('does not call onUpdate for "pong" messages', () => {
-      latestSocket().triggerMessage({ type: 'pong' });
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
+      latestSocket().triggerMessage({type: 'pong'})
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
 
     it('does not call onUpdate for unknown message types', () => {
-      latestSocket().triggerMessage({ type: 'other', resource: 'books' });
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
+      latestSocket().triggerMessage({type: 'other', resource: 'books'})
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
 
     it('ignores messages with type "update" but no resource', () => {
-      latestSocket().triggerMessage({ type: 'update' });
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
+      latestSocket().triggerMessage({type: 'update'})
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
 
     it('ignores invalid JSON without throwing', () => {
-      expect(() => latestSocket().triggerRawMessage('not-json')).not.toThrow();
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
-  });
+      expect(() => latestSocket().triggerRawMessage('not-json')).not.toThrow()
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
+  })
 
   describe('onclose and reconnect backoff', () => {
     it('schedules reconnect after close with base delay (1s)', () => {
-      client.connect();
-      latestSocket().triggerOpen();
-      latestSocket().triggerClose();
+      client.connect()
+      latestSocket().triggerOpen()
+      latestSocket().triggerClose()
 
-      expect(MockWebSocket.instances).toHaveLength(1);
-      vi.advanceTimersByTime(1000);
-      expect(MockWebSocket.instances).toHaveLength(2);
-    });
+      expect(MockWebSocket.instances).toHaveLength(1)
+      vi.advanceTimersByTime(1000)
+      expect(MockWebSocket.instances).toHaveLength(2)
+    })
 
     it('doubles the delay after each close (exponential backoff)', () => {
-      client.connect();
-      latestSocket().triggerOpen();
-      latestSocket().triggerClose();
-      vi.advanceTimersByTime(1000);
+      client.connect()
+      latestSocket().triggerOpen()
+      latestSocket().triggerClose()
+      vi.advanceTimersByTime(1000)
 
-      latestSocket().triggerOpen();
-      latestSocket().triggerClose();
+      latestSocket().triggerOpen()
+      latestSocket().triggerClose()
       // attempt=1, delay should be ~2s
-      vi.advanceTimersByTime(2000);
-      expect(MockWebSocket.instances).toHaveLength(3);
-    });
+      vi.advanceTimersByTime(2000)
+      expect(MockWebSocket.instances).toHaveLength(3)
+    })
 
     it('caps backoff delay at reconnectMaxMs (30s)', () => {
-      client.connect();
+      client.connect()
 
       // Exhaust backoff up to max: log2(30000/1000)=~4.9 → 5 doublings
       for (let i = 0; i < 6; i++) {
-        latestSocket().triggerOpen();
-        latestSocket().triggerClose();
-        vi.advanceTimersByTime(30_000); // always advance enough
+        latestSocket().triggerOpen()
+        latestSocket().triggerClose()
+        vi.advanceTimersByTime(30_000) // always advance enough
       }
 
       // After 6 attempts, still reconnects within 30s window
-      expect(MockWebSocket.instances.length).toBeGreaterThan(3);
-    });
+      expect(MockWebSocket.instances.length).toBeGreaterThan(3)
+    })
 
     it('does not reconnect after intentional close', () => {
-      client.connect();
-      latestSocket().triggerOpen();
-      client.disconnect();
+      client.connect()
+      latestSocket().triggerOpen()
+      client.disconnect()
 
-      vi.advanceTimersByTime(60_000);
-      expect(MockWebSocket.instances).toHaveLength(1);
-    });
+      vi.advanceTimersByTime(60_000)
+      expect(MockWebSocket.instances).toHaveLength(1)
+    })
 
     it('transitions to disconnected state on close', () => {
-      client.connect();
-      latestSocket().triggerOpen();
-      latestSocket().triggerClose();
-      expect(client.getState()).toBe('disconnected');
-    });
+      client.connect()
+      latestSocket().triggerOpen()
+      latestSocket().triggerClose()
+      expect(client.getState()).toBe('disconnected')
+    })
 
     it('calls onStateChange(false) on close', () => {
-      client.connect();
-      latestSocket().triggerOpen();
-      onStateChange.mockClear();
-      latestSocket().triggerClose();
-      expect(onStateChange).toHaveBeenCalledWith(false);
-    });
-  });
+      client.connect()
+      latestSocket().triggerOpen()
+      onStateChange.mockClear()
+      latestSocket().triggerClose()
+      expect(onStateChange).toHaveBeenCalledWith(false)
+    })
+  })
 
   describe('disconnect()', () => {
     it('clears all timers and closes the socket', () => {
-      client.connect();
-      latestSocket().triggerOpen();
-      client.disconnect();
-      expect(client.getState()).toBe('disconnected');
-    });
+      client.connect()
+      latestSocket().triggerOpen()
+      client.disconnect()
+      expect(client.getState()).toBe('disconnected')
+    })
 
     it('removes visibilitychange listener', () => {
-      const removeSpy = vi.spyOn(document, 'removeEventListener');
-      client.connect();
-      client.disconnect();
-      expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
-    });
+      const removeSpy = vi.spyOn(document, 'removeEventListener')
+      client.connect()
+      client.disconnect()
+      expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    })
 
     it('prevents reconnect timers from firing after disconnect', () => {
-      client.connect();
-      latestSocket().triggerOpen();
-      latestSocket().triggerClose();
-      client.disconnect();
+      client.connect()
+      latestSocket().triggerOpen()
+      latestSocket().triggerClose()
+      client.disconnect()
 
-      vi.advanceTimersByTime(60_000);
-      expect(MockWebSocket.instances).toHaveLength(1);
-    });
-  });
+      vi.advanceTimersByTime(60_000)
+      expect(MockWebSocket.instances).toHaveLength(1)
+    })
+  })
 
   describe('max connection timer (115 minutes)', () => {
     it('force-reconnects after 115 minutes', () => {
-      client.connect();
-      latestSocket().triggerOpen();
+      client.connect()
+      latestSocket().triggerOpen()
 
-      const MAX_MS = 115 * 60 * 1000;
-      vi.advanceTimersByTime(MAX_MS);
+      const MAX_MS = 115 * 60 * 1000
+      vi.advanceTimersByTime(MAX_MS)
 
       // Should have scheduled a reconnect
-      vi.advanceTimersByTime(100);
-      expect(MockWebSocket.instances).toHaveLength(2);
-    });
-  });
+      vi.advanceTimersByTime(100)
+      expect(MockWebSocket.instances).toHaveLength(2)
+    })
+  })
 
   describe('visibility change', () => {
     it('closes socket when document becomes hidden', () => {
-      client.connect();
-      latestSocket().triggerOpen();
+      client.connect()
+      latestSocket().triggerOpen()
 
-      Object.defineProperty(document, 'hidden', { value: true, configurable: true });
-      document.dispatchEvent(new Event('visibilitychange'));
+      Object.defineProperty(document, 'hidden', {value: true, configurable: true})
+      document.dispatchEvent(new Event('visibilitychange'))
 
-      expect(client.getState()).toBe('disconnected');
-    });
+      expect(client.getState()).toBe('disconnected')
+    })
 
     it('schedules reconnect immediately when document becomes visible', () => {
-      client.connect();
-      latestSocket().triggerOpen();
+      client.connect()
+      latestSocket().triggerOpen()
 
-      Object.defineProperty(document, 'hidden', { value: true, configurable: true });
-      document.dispatchEvent(new Event('visibilitychange'));
+      Object.defineProperty(document, 'hidden', {value: true, configurable: true})
+      document.dispatchEvent(new Event('visibilitychange'))
 
-      Object.defineProperty(document, 'hidden', { value: false, configurable: true });
-      document.dispatchEvent(new Event('visibilitychange'));
+      Object.defineProperty(document, 'hidden', {value: false, configurable: true})
+      document.dispatchEvent(new Event('visibilitychange'))
 
       // Reconnect delay=0 so next tick opens a new socket
-      vi.advanceTimersByTime(0);
-      expect(MockWebSocket.instances).toHaveLength(2);
-    });
-  });
+      vi.advanceTimersByTime(0)
+      expect(MockWebSocket.instances).toHaveLength(2)
+    })
+  })
 
   describe('app-update handling', () => {
-    let onUpdate: ReturnType<typeof vi.fn>;
-    let onAppUpdate: ReturnType<typeof vi.fn>;
-    let appClient: WSClient;
+    let onUpdate: ReturnType<typeof vi.fn>
+    let onAppUpdate: ReturnType<typeof vi.fn>
+    let appClient: WSClient
 
     beforeEach(() => {
-      onUpdate = vi.fn();
-      onAppUpdate = vi.fn();
-      appClient = new WSClient({
-        url: 'wss://test.example.com/live',
-        onUpdate,
-        onAppUpdate,
-      });
-      appClient.connect();
-      latestSocket().triggerOpen();
-    });
+      onUpdate = vi.fn()
+      onAppUpdate = vi.fn()
+      appClient = new WSClient({url: 'wss://test.example.com/live', onUpdate, onAppUpdate})
+      appClient.connect()
+      latestSocket().triggerOpen()
+    })
 
     afterEach(() => {
-      appClient.disconnect();
-    });
+      appClient.disconnect()
+    })
 
     it('calls onAppUpdate (not onUpdate) on an "app-update" push', () => {
-      latestSocket().triggerMessage({ type: 'app-update', build: 'abc123' });
-      expect(onAppUpdate).toHaveBeenCalledWith('abc123');
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
+      latestSocket().triggerMessage({type: 'app-update', build: 'abc123'})
+      expect(onAppUpdate).toHaveBeenCalledWith('abc123')
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
 
     it('tolerates an "app-update" push with no build id', () => {
-      latestSocket().triggerMessage({ type: 'app-update' });
-      expect(onAppUpdate).toHaveBeenCalledTimes(1);
-      expect(onAppUpdate).toHaveBeenCalledWith(undefined);
-    });
-  });
+      latestSocket().triggerMessage({type: 'app-update'})
+      expect(onAppUpdate).toHaveBeenCalledTimes(1)
+      expect(onAppUpdate).toHaveBeenCalledWith(undefined)
+    })
+  })
 
   describe('focus push handling', () => {
-    let onUpdate: ReturnType<typeof vi.fn>;
-    let onFocusChange: ReturnType<typeof vi.fn>;
-    let focusClient: WSClient;
+    let onUpdate: ReturnType<typeof vi.fn>
+    let onFocusChange: ReturnType<typeof vi.fn>
+    let focusClient: WSClient
 
     beforeEach(() => {
-      onUpdate = vi.fn();
-      onFocusChange = vi.fn();
-      focusClient = new WSClient({
-        url: 'wss://test.example.com/live',
-        onUpdate,
-        onFocusChange,
-      });
-      focusClient.connect();
-      latestSocket().triggerOpen();
-    });
+      onUpdate = vi.fn()
+      onFocusChange = vi.fn()
+      focusClient = new WSClient({url: 'wss://test.example.com/live', onUpdate, onFocusChange})
+      focusClient.connect()
+      latestSocket().triggerOpen()
+    })
 
     afterEach(() => {
-      focusClient.disconnect();
-    });
+      focusClient.disconnect()
+    })
 
     it('calls onFocusChange (not onUpdate) on a focus push carrying currentFocus', () => {
-      latestSocket().triggerMessage({ type: 'update', resource: 'focus', currentFocus: 'Do Not Disturb' });
-      expect(onFocusChange).toHaveBeenCalledWith('Do Not Disturb');
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
+      latestSocket().triggerMessage({type: 'update', resource: 'focus', currentFocus: 'Do Not Disturb'})
+      expect(onFocusChange).toHaveBeenCalledWith('Do Not Disturb')
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
 
     it('falls back to onUpdate for a focus push without currentFocus (older backend)', () => {
-      latestSocket().triggerMessage({ type: 'update', resource: 'focus' });
-      expect(onUpdate).toHaveBeenCalledWith('focus');
-      expect(onFocusChange).not.toHaveBeenCalled();
-    });
+      latestSocket().triggerMessage({type: 'update', resource: 'focus'})
+      expect(onUpdate).toHaveBeenCalledWith('focus')
+      expect(onFocusChange).not.toHaveBeenCalled()
+    })
 
     it('routes non-focus resources through onUpdate, never onFocusChange', () => {
-      latestSocket().triggerMessage({ type: 'update', resource: 'health', currentFocus: 'Work' });
-      expect(onUpdate).toHaveBeenCalledWith('health');
-      expect(onFocusChange).not.toHaveBeenCalled();
-    });
-  });
-});
+      latestSocket().triggerMessage({type: 'update', resource: 'health', currentFocus: 'Work'})
+      expect(onUpdate).toHaveBeenCalledWith('health')
+      expect(onFocusChange).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/visual/dashboard.spec.ts
+++ b/tests/visual/dashboard.spec.ts
@@ -1,25 +1,25 @@
-import { test } from './pw-fixtures';
-import { setupPage, stylePath, captureFullPage } from './helpers';
+import {test} from './pw-fixtures'
+import {captureFullPage, setupPage, stylePath} from './helpers'
 
 test.describe('Dashboard - populated', () => {
-  test.beforeEach(async ({ page }) => {
-    await setupPage(page, 'populated', { waitForScrollHeight: true });
-  });
+  test.beforeEach(async ({page}) => {
+    await setupPage(page, 'populated', {waitForScrollHeight: true})
+  })
 
-  test('full page', async ({ page }) => {
-    await captureFullPage(page, 'dashboard-populated.png', { stylePath });
-  });
-});
+  test('full page', async ({page}) => {
+    await captureFullPage(page, 'dashboard-populated.png', {stylePath})
+  })
+})
 
 test.describe('Dashboard - empty', () => {
-  test.beforeEach(async ({ page }) => {
-    await setupPage(page, 'empty', { waitForScrollHeight: true });
-  });
+  test.beforeEach(async ({page}) => {
+    await setupPage(page, 'empty', {waitForScrollHeight: true})
+  })
 
-  test('full page', async ({ page }) => {
-    await captureFullPage(page, 'dashboard-empty.png', { stylePath });
-  });
-});
+  test('full page', async ({page}) => {
+    await captureFullPage(page, 'dashboard-empty.png', {stylePath})
+  })
+})
 
 // The DS standard-triad `full` variation: the single maximally-populated dashboard
 // scenario (replaces the former `complex` scenario). Like every other dashboard
@@ -27,11 +27,11 @@ test.describe('Dashboard - empty', () => {
 // route interception + client re-hydration (helpers.ts `interceptRoutes`), NOT via
 // the SSR `FIXTURE_VARIATION` path. See the `full` scenario note in fixtures.ts.
 test.describe('Dashboard - full', () => {
-  test.beforeEach(async ({ page }) => {
-    await setupPage(page, 'full', { waitForScrollHeight: true });
-  });
+  test.beforeEach(async ({page}) => {
+    await setupPage(page, 'full', {waitForScrollHeight: true})
+  })
 
-  test('full page', async ({ page }) => {
-    await captureFullPage(page, 'dashboard-full.png', { stylePath });
-  });
-});
+  test('full page', async ({page}) => {
+    await captureFullPage(page, 'dashboard-full.png', {stylePath})
+  })
+})

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -6,12 +6,12 @@
  * CloudFront endpoints; the Playwright route-interception layer (helpers.ts)
  * fulfills `${CLOUDFRONT_BASE}/<endpoint>` from these files.
  */
-import { createRequire } from 'node:module';
+import {createRequire} from 'node:module'
 
-const require = createRequire(import.meta.url);
+const require = createRequire(import.meta.url)
 
 /** Map of CloudFront endpoint path -> absolute fixture file path */
-export type FixtureSet = Record<string, string>;
+export type FixtureSet = Record<string, string>
 
 /**
  * Resolve a raw fixture to its on-disk path inside `@lifegames/fixtures`.
@@ -24,8 +24,8 @@ export type FixtureSet = Record<string, string>;
  * `exports` map (`./generated/*`), so this works under yalc linking.
  */
 function fixture(dir: string, file: string): string {
-  const camelFile = file.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase());
-  return require.resolve(`@lifegames/fixtures/generated/${dir}/${camelFile}.json`);
+  const camelFile = file.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase())
+  return require.resolve(`@lifegames/fixtures/generated/${dir}/${camelFile}.json`)
 }
 
 /** Baseline fixtures for all 10 endpoints */
@@ -39,14 +39,14 @@ const BASELINE: FixtureSet = {
   '/articles.json': fixture('articles', 'baseline'),
   '/location.json': fixture('location', 'baseline'),
   '/focus.json': fixture('focus', 'empty'),
-  '/theatre-reviews.json': fixture('theatre-reviews', 'baseline'),
-};
+  '/theatre-reviews.json': fixture('theatre-reviews', 'baseline')
+}
 
 /**
  * Dashboard-level scenarios — each defines all 10 endpoints.
  */
 const DASHBOARD_SCENARIOS: Record<string, FixtureSet> = {
-  populated: { ...BASELINE },
+  populated: {...BASELINE},
 
   // True-empty state for every domain. Uses the DS triad `empty` variations
   // (real empties that did not exist before the triad — health/location formerly
@@ -63,7 +63,7 @@ const DASHBOARD_SCENARIOS: Record<string, FixtureSet> = {
     '/articles.json': fixture('articles', 'empty'),
     '/location.json': fixture('location', 'empty'),
     '/theatre-reviews.json': fixture('theatre-reviews', 'empty'),
-    '/github-starred-repos.json': fixture('github-starred-repos', 'empty'),
+    '/github-starred-repos.json': fixture('github-starred-repos', 'empty')
   },
 
   // The DS standard-triad `full` variation for every domain: the single
@@ -87,9 +87,9 @@ const DASHBOARD_SCENARIOS: Record<string, FixtureSet> = {
     '/github-events.json': fixture('github-events', 'full'),
     '/articles.json': fixture('articles', 'full'),
     '/location.json': fixture('location', 'full'),
-    '/theatre-reviews.json': fixture('theatre-reviews', 'full'),
-  },
-};
+    '/theatre-reviews.json': fixture('theatre-reviews', 'full')
+  }
+}
 
 /**
  * Per-widget variation scenarios — each overrides a single endpoint from baseline.
@@ -101,80 +101,80 @@ const DASHBOARD_SCENARIOS: Record<string, FixtureSet> = {
  */
 const WIDGET_VARIATION_SCENARIOS: Record<string, FixtureSet> = {
   // Heart Rate variations (also affects Hydration, NightSummary)
-  'hr-bradycardia': { ...BASELINE, '/health.json': fixture('health', 'bradycardia') },
-  'hr-peak': { ...BASELINE, '/health.json': fixture('health', 'peak') },
-  'hr-resting': { ...BASELINE, '/health.json': fixture('health', 'resting') },
+  'hr-bradycardia': {...BASELINE, '/health.json': fixture('health', 'bradycardia')},
+  'hr-peak': {...BASELINE, '/health.json': fixture('health', 'peak')},
+  'hr-resting': {...BASELINE, '/health.json': fixture('health', 'resting')},
 
   // Hydration variations (also affects HeartRate, NightSummary)
-  'hydration-zero': { ...BASELINE, '/health.json': fixture('health', 'zero-hydration') },
-  'hydration-max': { ...BASELINE, '/health.json': fixture('health', 'max-hydration') },
+  'hydration-zero': {...BASELINE, '/health.json': fixture('health', 'zero-hydration')},
+  'hydration-max': {...BASELINE, '/health.json': fixture('health', 'max-hydration')},
 
   // Movement Rings active state — the 2026-07-17 regression data: server goals
   // 650/40/12 (formerly hardcoded 500/30/12 client-side), standHours 4 vs
   // floor(4 standTime-min / 60) = 0, live solar vs frozen SSR placeholders.
-  'movement-active': { ...BASELINE, '/health.json': fixture('health', 'movement-active') },
+  'movement-active': {...BASELINE, '/health.json': fixture('health', 'movement-active')},
 
   // Missing-optional health: `dietaryWater` + `dietaryCaffeine` quantities are
   // entirely ABSENT (distinct from `hydration-zero`, where they are present and 0).
   // Preserves coverage of the absent-optional-field render path that the `empty`
   // dashboard scenario formerly exercised before it switched to the real `empty`.
-  'health-missing-optional': { ...BASELINE, '/health.json': fixture('health', 'missing-optional') },
+  'health-missing-optional': {...BASELINE, '/health.json': fixture('health', 'missing-optional')},
 
   // Night Summary variations
-  'sleep-deep-dominant': { ...BASELINE, '/sleep.json': fixture('sleep', 'deep-dominant') },
-  'sleep-rem-dominant': { ...BASELINE, '/sleep.json': fixture('sleep', 'rem-dominant') },
-  'sleep-short': { ...BASELINE, '/sleep.json': fixture('sleep', 'short-sleep') },
+  'sleep-deep-dominant': {...BASELINE, '/sleep.json': fixture('sleep', 'deep-dominant')},
+  'sleep-rem-dominant': {...BASELINE, '/sleep.json': fixture('sleep', 'rem-dominant')},
+  'sleep-short': {...BASELINE, '/sleep.json': fixture('sleep', 'short-sleep')},
 
   // Bookshelf variations
-  'books-all-reading': { ...BASELINE, '/books.json': fixture('books', 'all-reading') },
-  'books-all-completed': { ...BASELINE, '/books.json': fixture('books', 'all-completed') },
-  'books-no-covers': { ...BASELINE, '/books.json': fixture('books', 'no-covers') },
+  'books-all-reading': {...BASELINE, '/books.json': fixture('books', 'all-reading')},
+  'books-all-completed': {...BASELINE, '/books.json': fixture('books', 'all-completed')},
+  'books-no-covers': {...BASELINE, '/books.json': fixture('books', 'no-covers')},
 
   // Dev Activity Log variations
-  'github-commits-only': { ...BASELINE, '/github-events.json': fixture('github-events', 'commits-only') },
-  'github-prs-only': { ...BASELINE, '/github-events.json': fixture('github-events', 'prs-only') },
+  'github-commits-only': {...BASELINE, '/github-events.json': fixture('github-events', 'commits-only')},
+  'github-prs-only': {...BASELINE, '/github-events.json': fixture('github-events', 'prs-only')},
 
   // Workouts variations
-  'workouts-multi': { ...BASELINE, '/workouts.json': fixture('workouts', 'multi-workout') },
-  'workouts-barrys': { ...BASELINE, '/workouts.json': fixture('workouts', 'barrys-bootcamp') },
+  'workouts-multi': {...BASELINE, '/workouts.json': fixture('workouts', 'multi-workout')},
+  'workouts-barrys': {...BASELINE, '/workouts.json': fixture('workouts', 'barrys-bootcamp')},
 
   // Theatre Reviews variations
-  'theatre-all-grades': { ...BASELINE, '/theatre-reviews.json': fixture('theatre-reviews', 'all-grades') },
-  'theatre-no-images': { ...BASELINE, '/theatre-reviews.json': fixture('theatre-reviews', 'no-images') },
+  'theatre-all-grades': {...BASELINE, '/theatre-reviews.json': fixture('theatre-reviews', 'all-grades')},
+  'theatre-no-images': {...BASELINE, '/theatre-reviews.json': fixture('theatre-reviews', 'no-images')},
 
   // Reading Feed variations
   // Exercises bug-6 fix: articles with empty articleTitle ("") + long sourceTitle
   // must not crash or mis-render the reading widget. Named after Hoodline, a local
   // news aggregator that frequently produces empty-title entries.
-  'reading-empty-title': { ...BASELINE, '/articles.json': fixture('articles', 'hoodline-empty-title') },
+  'reading-empty-title': {...BASELINE, '/articles.json': fixture('articles', 'hoodline-empty-title')},
 
   // Watch-paused variations (HeartRate + MovementRings paused overlay)
-  'hr-paused-hr-gap': { ...BASELINE, '/health.json': fixture('health', 'paused-hr-gap') },
-  'hr-paused-charging': { ...BASELINE, '/health.json': fixture('health', 'paused-charging') },
+  'hr-paused-hr-gap': {...BASELINE, '/health.json': fixture('health', 'paused-hr-gap')},
+  'hr-paused-charging': {...BASELINE, '/health.json': fixture('health', 'paused-charging')},
 
   // Overlay variations
-  'focus-work': { ...BASELINE, '/focus.json': fixture('focus', 'baseline') },
-  'focus-dnd': { ...BASELINE, '/focus.json': fixture('focus', 'dnd') },
-};
+  'focus-work': {...BASELINE, '/focus.json': fixture('focus', 'baseline')},
+  'focus-dnd': {...BASELINE, '/focus.json': fixture('focus', 'dnd')}
+}
 
 /** All available scenario names */
-export type ScenarioName = keyof typeof DASHBOARD_SCENARIOS | keyof typeof WIDGET_VARIATION_SCENARIOS;
+export type ScenarioName = keyof typeof DASHBOARD_SCENARIOS | keyof typeof WIDGET_VARIATION_SCENARIOS
 
 /** Get the fixture set for a given scenario */
 export function getScenarioFixtures(scenario: ScenarioName): FixtureSet {
   if (scenario in DASHBOARD_SCENARIOS) {
-    return DASHBOARD_SCENARIOS[scenario];
+    return DASHBOARD_SCENARIOS[scenario]
   }
   if (scenario in WIDGET_VARIATION_SCENARIOS) {
-    return WIDGET_VARIATION_SCENARIOS[scenario];
+    return WIDGET_VARIATION_SCENARIOS[scenario]
   }
-  throw new Error(`Unknown scenario: ${scenario}`);
+  throw new Error(`Unknown scenario: ${scenario}`)
 }
 
 /** Whether a scenario includes non-empty workouts data */
 export function scenarioHasWorkouts(scenario: ScenarioName): boolean {
-  const fixtures = getScenarioFixtures(scenario);
-  const workoutsPath = fixtures['/workouts.json'];
+  const fixtures = getScenarioFixtures(scenario)
+  const workoutsPath = fixtures['/workouts.json']
   // Empty workouts fixture has no data to trigger the card
-  return !workoutsPath.includes('/empty.json');
+  return !workoutsPath.includes('/empty.json')
 }

--- a/tests/visual/global-setup.ts
+++ b/tests/visual/global-setup.ts
@@ -1,4 +1,4 @@
-import type { FullConfig } from '@playwright/test';
+import type {FullConfig} from '@playwright/test'
 
 /**
  * Guard against reusing an unrelated dev server on the configured port.
@@ -11,27 +11,29 @@ import type { FullConfig } from '@playwright/test';
 export default async function globalSetup(config: FullConfig): Promise<void> {
   const url = config.webServer && !Array.isArray(config.webServer)
     ? config.webServer.url
-    : undefined;
-  if (!url) return;
-
-  let html: string;
-  try {
-    const res = await fetch(url);
-    html = await res.text();
-  } catch {
-    return;
+    : undefined
+  if (!url) {
+    return
   }
 
-  const markers = ['id="cardHR"', 'Human Datastream'];
-  const missing = markers.filter((m) => !html.includes(m));
+  let html: string
+  try {
+    const res = await fetch(url)
+    html = await res.text()
+  } catch {
+    return
+  }
+
+  const markers = ['id="cardHR"', 'Human Datastream']
+  const missing = markers.filter((m) => !html.includes(m))
   if (missing.length > 0) {
-    const titleMatch = html.match(/<title>([^<]+)<\/title>/i);
-    const wrongTitle = titleMatch ? titleMatch[1] : '(no <title>)';
+    const titleMatch = html.match(/<title>([^<]+)<\/title>/i)
+    const wrongTitle = titleMatch ? titleMatch[1] : '(no <title>)'
     throw new Error(
-      `[playwright] ${url} is serving the wrong site. `
-        + `Expected portfolio markers: ${markers.join(', ')}. Missing: ${missing.join(', ')}. `
-        + `Got <title>: "${wrongTitle}". `
-        + `Another process is likely squatting the port — stop it and re-run.`,
-    );
+      `[playwright] ${url} is serving the wrong site. ` +
+        `Expected portfolio markers: ${markers.join(', ')}. Missing: ${missing.join(', ')}. ` +
+        `Got <title>: "${wrongTitle}". ` +
+        `Another process is likely squatting the port — stop it and re-run.`
+    )
   }
 }

--- a/tests/visual/global-teardown.ts
+++ b/tests/visual/global-teardown.ts
@@ -1,7 +1,7 @@
-import { createRequire } from 'node:module';
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import path from 'path';
-import type { FullConfig } from '@playwright/test';
+import {createRequire} from 'node:module'
+import {readdirSync, readFileSync, writeFileSync} from 'node:fs'
+import path from 'path'
+import type {FullConfig} from '@playwright/test'
 
 /**
  * Front-loaded lossless PNG optimization for the committed visual baselines.
@@ -40,61 +40,59 @@ import type { FullConfig } from '@playwright/test';
  * baselines.
  */
 
-const require = createRequire(import.meta.url);
-const { losslessCompressPngSync } = require('@napi-rs/image') as {
-  losslessCompressPngSync: (input: Buffer, options?: { filter?: number[]; strip?: boolean; }) => Buffer;
-};
+const require = createRequire(import.meta.url)
+const {losslessCompressPngSync} = require('@napi-rs/image') as {
+  losslessCompressPngSync: (input: Buffer, options?: {filter?: number[]; strip?: boolean}) => Buffer
+}
 
-const OXIPNG_OPTIONS: { filter: number[]; strip: boolean; } = { filter: [0, 1, 2, 3, 4], strip: false };
-const SCREENSHOTS_DIR = path.join(import.meta.dirname, '__screenshots__');
+const OXIPNG_OPTIONS: {filter: number[]; strip: boolean} = {filter: [0, 1, 2, 3, 4], strip: false}
+const SCREENSHOTS_DIR = path.join(import.meta.dirname, '__screenshots__')
 
 /** Recursively collect every .png under a directory. */
 function collectPngs(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
+  const out: string[] = []
+  for (const entry of readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name)
     if (entry.isDirectory()) {
-      out.push(...collectPngs(full));
+      out.push(...collectPngs(full))
     } else if (entry.isFile() && entry.name.endsWith('.png')) {
-      out.push(full);
+      out.push(full)
     }
   }
-  return out;
+  return out
 }
 
 export default async function globalTeardown(config: FullConfig): Promise<void> {
   // Only rewrite bytes on a regeneration pass. A bare compare run leaves
   // updateSnapshots as 'missing'/'none' and must not touch committed baselines.
   if (config.updateSnapshots !== 'all' && config.updateSnapshots !== 'changed') {
-    return;
+    return
   }
 
-  const files = collectPngs(SCREENSHOTS_DIR);
+  const files = collectPngs(SCREENSHOTS_DIR)
   if (files.length === 0) {
     // A regeneration pass that produced no baselines is a real failure, not a
     // no-op — fail loudly rather than silently "succeeding".
-    throw new Error(`[teardown] oxipng: no PNG baselines found under ${SCREENSHOTS_DIR}`);
+    throw new Error(`[teardown] oxipng: no PNG baselines found under ${SCREENSHOTS_DIR}`)
   }
 
-  let optimized = 0;
+  let optimized = 0
   for (const file of files) {
-    const input = readFileSync(file);
-    let output: Buffer;
+    const input = readFileSync(file)
+    let output: Buffer
     try {
-      output = losslessCompressPngSync(input, { ...OXIPNG_OPTIONS });
+      output = losslessCompressPngSync(input, {...OXIPNG_OPTIONS})
     } catch (err) {
       // Throw on failure so a broken optimizer fails the run instead of
       // committing un-optimized (or partially-optimized) baselines.
-      throw new Error(
-        `[teardown] oxipng failed on ${file}: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      throw new Error(`[teardown] oxipng failed on ${file}: ${err instanceof Error ? err.message : String(err)}`)
     }
     if (Buffer.compare(input, output) !== 0) {
-      writeFileSync(file, output);
-      optimized++;
+      writeFileSync(file, output)
+      optimized++
     }
   }
 
   // eslint-disable-next-line no-console
-  console.log(`[teardown] oxipng optimized ${optimized} of ${files.length} files`);
+  console.log(`[teardown] oxipng optimized ${optimized} of ${files.length} files`)
 }

--- a/tests/visual/heart-rate.spec.ts
+++ b/tests/visual/heart-rate.spec.ts
@@ -35,87 +35,82 @@
  * session): build the visual preview with `astro build --mode test`, then run
  * `npm run test:visual:update:docker` to mint the baselines below.
  */
-import { test, expect, type Page } from './pw-fixtures';
-import { setupPage, stylePath, WIDGET_SELECTORS } from './helpers';
+import {expect, type Page, test} from './pw-fixtures'
+import {setupPage, stylePath, WIDGET_SELECTORS} from './helpers'
 
 interface HeartRateSeam {
-  ready: boolean;
-  seed: (n: number) => void;
-  freezeAt: (ms: number | null) => void;
-  step: (frames?: number) => void;
-  state: () => { bpm: number; hrv: number; currentX: number; lastBeatAt: number; };
+  ready: boolean
+  seed: (n: number) => void
+  freezeAt: (ms: number | null) => void
+  step: (frames?: number) => void
+  state: () => {bpm: number; hrv: number; currentX: number; lastBeatAt: number}
 }
 
-type SeamWindow = typeof window & {
-  __hrEcg?: HeartRateSeam;
-  __ecgUpdate?: (bpm: number, hrv: number, stroke: string) => void;
-};
+type SeamWindow = typeof window & {__hrEcg?: HeartRateSeam; __ecgUpdate?: (bpm: number, hrv: number, stroke: string) => void}
 
 /** Opt the heart-rate card into the seam, then wait for it to install + be ready. */
 async function armSeam(page: Page): Promise<void> {
   await page.evaluate((cardSel) => {
-    document.querySelector(cardSel)?.setAttribute('data-test', '1');
-  }, WIDGET_SELECTORS.heartRate);
+    document.querySelector(cardSel)?.setAttribute('data-test', '1')
+  }, WIDGET_SELECTORS.heartRate)
   // The seam installs at island-bootstrap time. If MODE !== 'test' it never
   // appears; the describe-level skip below short-circuits before we get here.
-  await page.waitForFunction(() => Boolean((window as SeamWindow).__hrEcg));
+  await page.waitForFunction(() => Boolean((window as SeamWindow).__hrEcg))
 }
 
 async function seamAvailable(page: Page): Promise<boolean> {
-  await setupPage(page, 'populated');
-  return page.evaluate(() => Boolean((window as SeamWindow).__hrEcg));
+  await setupPage(page, 'populated')
+  return page.evaluate(() => Boolean((window as SeamWindow).__hrEcg))
 }
 
 test.describe('ECG canvas - deterministic seam', () => {
   // Runtime skip: the seam is absent in a production preview build (see header).
-  test.beforeEach(async ({ page }) => {
-    const available = await seamAvailable(page);
-    test.skip(!available, 'window.__hrEcg unavailable: visual preview is a production build (MODE !== "test")');
-  });
+  test.beforeEach(async ({page}) => {
+    const available = await seamAvailable(page)
+    test.skip(!available, 'window.__hrEcg unavailable: visual preview is a production build (MODE !== "test")')
+  })
 
-  test('ECG @ 60bpm baseline', async ({ page }) => {
-    await armSeam(page);
+  test('ECG @ 60bpm baseline', async ({page}) => {
+    await armSeam(page)
     await page.evaluate(() => {
-      const seam = (window as SeamWindow).__hrEcg!;
-      seam.seed(42);
-      seam.freezeAt(0);
-      seam.step(60);
-    });
-    await expect(page.locator(WIDGET_SELECTORS.heartRateCanvas)).toHaveScreenshot('ecg-60bpm.png', { stylePath });
-  });
+      const seam = (window as SeamWindow).__hrEcg!
+      seam.seed(42)
+      seam.freezeAt(0)
+      seam.step(60)
+    })
+    await expect(page.locator(WIDGET_SELECTORS.heartRateCanvas)).toHaveScreenshot('ecg-60bpm.png', {stylePath})
+  })
 
-  test('ECG @ 90bpm elevated', async ({ page }) => {
-    await armSeam(page);
+  test('ECG @ 90bpm elevated', async ({page}) => {
+    await armSeam(page)
     await page.evaluate(() => {
-      const w = window as SeamWindow;
-      w.__ecgUpdate?.(90, 42, '#f59e0b');
-      const seam = w.__hrEcg!;
-      seam.seed(42);
-      seam.freezeAt(0);
-      seam.step(60);
-    });
-    await expect(page.locator(WIDGET_SELECTORS.heartRateCanvas)).toHaveScreenshot('ecg-90bpm.png', { stylePath });
-  });
+      const w = window as SeamWindow
+      w.__ecgUpdate?.(90, 42, '#f59e0b')
+      const seam = w.__hrEcg!
+      seam.seed(42)
+      seam.freezeAt(0)
+      seam.step(60)
+    })
+    await expect(page.locator(WIDGET_SELECTORS.heartRateCanvas)).toHaveScreenshot('ecg-90bpm.png', {stylePath})
+  })
 
-  test('ECG @ 50bpm bradycardia', async ({ page }) => {
-    await armSeam(page);
+  test('ECG @ 50bpm bradycardia', async ({page}) => {
+    await armSeam(page)
     await page.evaluate(() => {
-      const w = window as SeamWindow;
-      w.__ecgUpdate?.(50, 60, '#3a86ff');
-      const seam = w.__hrEcg!;
-      seam.seed(42);
-      seam.freezeAt(0);
-      seam.step(60);
-    });
-    await expect(page.locator(WIDGET_SELECTORS.heartRateCanvas)).toHaveScreenshot('ecg-50bpm.png', { stylePath });
-  });
+      const w = window as SeamWindow
+      w.__ecgUpdate?.(50, 60, '#3a86ff')
+      const seam = w.__hrEcg!
+      seam.seed(42)
+      seam.freezeAt(0)
+      seam.step(60)
+    })
+    await expect(page.locator(WIDGET_SELECTORS.heartRateCanvas)).toHaveScreenshot('ecg-50bpm.png', {stylePath})
+  })
 
-  test('ECG reduced-motion static waveform', async ({ page }) => {
-    await page.emulateMedia({ reducedMotion: 'reduce' });
-    await armSeam(page);
+  test('ECG reduced-motion static waveform', async ({page}) => {
+    await page.emulateMedia({reducedMotion: 'reduce'})
+    await armSeam(page)
     // Reduced motion draws a single static waveform at bootstrap; no stepping.
-    await expect(page.locator(WIDGET_SELECTORS.heartRateCanvas)).toHaveScreenshot('ecg-reduced-motion.png', {
-      stylePath,
-    });
-  });
-});
+    await expect(page.locator(WIDGET_SELECTORS.heartRateCanvas)).toHaveScreenshot('ecg-reduced-motion.png', {stylePath})
+  })
+})

--- a/tests/visual/helpers.ts
+++ b/tests/visual/helpers.ts
@@ -3,12 +3,12 @@
  *
  * Provides route interception, navigation/wait logic, and widget selectors.
  */
-import path from 'path';
-import { expect, type Locator, type Page } from '@playwright/test';
-import { CLOUDFRONT_BASE, WEBSOCKET_URL } from '@lifegames/portal-contract/constants';
-import { getScenarioFixtures, scenarioHasWorkouts, type ScenarioName } from './fixtures';
+import path from 'path'
+import {expect, type Locator, type Page} from '@playwright/test'
+import {CLOUDFRONT_BASE, WEBSOCKET_URL} from '@lifegames/portal-contract/constants'
+import {getScenarioFixtures, scenarioHasWorkouts, type ScenarioName} from './fixtures'
 
-export const stylePath = path.join(import.meta.dirname, 'screenshot.css');
+export const stylePath = path.join(import.meta.dirname, 'screenshot.css')
 
 /** Widget selectors for element-level screenshots. */
 export const WIDGET_SELECTORS = {
@@ -27,15 +27,11 @@ export const WIDGET_SELECTORS = {
   starredRepos: '#cardStarredRepos',
   bookshelf: '#cardBooks',
   theatreReviews: '#cardTheatreReviews',
-  topBar: '.top-bar',
-} as const;
+  topBar: '.top-bar'
+} as const
 
 /** 1×1 transparent PNG (68 bytes) used as a placeholder for external images */
-const TRANSPARENT_PIXEL = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB'
-    + 'Nl7BcQAAAABJRU5ErkJggg==',
-  'base64',
-);
+const TRANSPARENT_PIXEL = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB' + 'Nl7BcQAAAABJRU5ErkJggg==', 'base64')
 
 /**
  * Set up route interception for all CloudFront endpoints + WebSocket block.
@@ -44,23 +40,20 @@ const TRANSPARENT_PIXEL = Buffer.from(
  * to prevent broken images in screenshots.
  */
 export async function interceptRoutes(page: Page, scenario: ScenarioName): Promise<void> {
-  const fixtures = getScenarioFixtures(scenario);
+  const fixtures = getScenarioFixtures(scenario)
 
   await page.route(`${CLOUDFRONT_BASE}/**`, async (route) => {
-    const url = new URL(route.request().url());
-    const fixturePath = fixtures[url.pathname];
+    const url = new URL(route.request().url())
+    const fixturePath = fixtures[url.pathname]
     if (fixturePath) {
-      await route.fulfill({
-        path: fixturePath,
-        contentType: 'application/json',
-      });
+      await route.fulfill({path: fixturePath, contentType: 'application/json'})
     } else {
-      await route.abort();
+      await route.abort()
     }
-  });
+  })
 
   // Block WebSocket connections
-  await page.route(`${WEBSOCKET_URL}/**`, (route) => route.abort());
+  await page.route(`${WEBSOCKET_URL}/**`, (route) => route.abort())
 
   // Catch-all: intercept any remaining external requests (Amazon images,
   // coasttocoastreviews.com posters, etc.). Image requests get a transparent
@@ -68,37 +61,33 @@ export async function interceptRoutes(page: Page, scenario: ScenarioName): Promi
   // Registered last but checked first (Playwright uses LIFO), so we use
   // route.fallback() for URLs already handled by earlier route handlers.
   await page.route('**/*', async (route) => {
-    const url = route.request().url();
+    const url = route.request().url()
     // Let local requests and already-handled domains fall through
     if (
-      url.startsWith('http://localhost')
-      || url.startsWith('data:')
-      || url.startsWith(CLOUDFRONT_BASE)
-      || url.startsWith(WEBSOCKET_URL.replace('wss://', 'https://'))
-      || url.startsWith('wss://')
+      url.startsWith('http://localhost') ||
+      url.startsWith('data:') ||
+      url.startsWith(CLOUDFRONT_BASE) ||
+      url.startsWith(WEBSOCKET_URL.replace('wss://', 'https://')) ||
+      url.startsWith('wss://')
     ) {
-      await route.fallback();
-      return;
+      await route.fallback()
+      return
     }
     // Serve transparent pixel for image requests
-    const resourceType = route.request().resourceType();
+    const resourceType = route.request().resourceType()
     if (resourceType === 'image') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'image/png',
-        body: TRANSPARENT_PIXEL,
-      });
+      await route.fulfill({status: 200, contentType: 'image/png', body: TRANSPARENT_PIXEL})
     } else {
-      await route.abort();
+      await route.abort()
     }
-  });
+  })
 }
 
 export interface NavigateOptions {
   /** Wait for #cardWorkouts to become visible. Set true when the scenario includes non-empty workouts data. */
-  waitForWorkouts?: boolean;
+  waitForWorkouts?: boolean
   /** Wait for documentElement.scrollHeight to stabilize. Only needed for fullPage screenshots. */
-  waitForScrollHeight?: boolean;
+  waitForScrollHeight?: boolean
 }
 
 /**
@@ -110,38 +99,32 @@ export interface NavigateOptions {
  * reveal animation. Data population is confirmed by skeleton removal below.
  */
 export async function navigateAndWait(page: Page, options: NavigateOptions = {}): Promise<void> {
-  await page.goto('/');
-  await page.evaluate(() => document.fonts.ready);
+  await page.goto('/')
+  await page.evaluate(() => document.fonts.ready)
 
   // Wait for all skeleton loading states to be removed -- this is the real
   // readiness signal (data has populated the DOM). Replaces `networkidle`,
   // which is unreliable on this page due to PollEngine and SW background fetches.
-  await page.waitForFunction(
-    () => document.querySelectorAll('.is-loading').length === 0,
-    { timeout: 10000 },
-  );
+  await page.waitForFunction(() => document.querySelectorAll('.is-loading').length === 0, {timeout: 10000})
 
   // Wait for every <img> in the document to finish loading (complete === true
   // OR naturalWidth === 0 for blocked images). Without this, an image that
   // resolves after fonts.ready can shift layout by a few pixels right before
   // capture, producing flaky page-height drift even within the same env.
-  await page.waitForFunction(
-    () => {
-      const imgs = Array.from(document.querySelectorAll('img'));
-      // Inlined copy of allImagesComplete() from ./predicates.ts (cannot import inside waitForFunction).
-      // If you change one, update the other.
-      return imgs.every((img) => img.complete);
-    },
-    { timeout: 10000 },
-  ).catch(() => {
+  await page.waitForFunction(() => {
+    const imgs = Array.from(document.querySelectorAll('img'))
+    // Inlined copy of allImagesComplete() from ./predicates.ts (cannot import inside waitForFunction).
+    // If you change one, update the other.
+    return imgs.every((img) => img.complete)
+  }, {timeout: 10000}).catch(() => {
     // Non-fatal: some intercepted/aborted images may never report complete.
     // We continue rather than fail the test.
-  });
+  })
 
   // If the scenario has workouts data, wait for the card to become visible
   // (#cardWorkouts starts display: none and is shown by updateWorkouts())
   if (options.waitForWorkouts) {
-    await page.locator('#cardWorkouts').waitFor({ state: 'visible', timeout: 10000 });
+    await page.locator('#cardWorkouts').waitFor({state: 'visible', timeout: 10000})
   }
 
   // Bio terminal + scroll-height stabilization are only needed for fullPage
@@ -154,32 +137,35 @@ export async function navigateAndWait(page: Page, options: NavigateOptions = {})
     // (<768px) lines are set visible immediately; on desktop the
     // IntersectionObserver triggers a sequential typing animation. Scroll the
     // card into view first to ensure the observer fires at all viewports.
-    const bioCard = page.locator('#cardBio');
+    const bioCard = page.locator('#cardBio')
     if (await bioCard.count() > 0) {
-      await bioCard.scrollIntoViewIfNeeded();
+      await bioCard.scrollIntoViewIfNeeded()
     }
-    await page.waitForFunction(
-      () => {
-        const lines = document.querySelectorAll('#terminalBody .terminal-line');
-        if (lines.length === 0) return true;
-        return lines[lines.length - 1].classList.contains('visible');
-      },
-      { timeout: 15000 },
-    ).catch(async () => {
+    await page.waitForFunction(() => {
+      const lines = document.querySelectorAll('#terminalBody .terminal-line')
+      if (lines.length === 0) {
+        return true
+      }
+      return lines[lines.length - 1].classList.contains('visible')
+    }, {timeout: 15000}).catch(async () => {
       // Fallback: force lines visible if the IntersectionObserver never fires.
       await page.evaluate(() => {
         document.querySelectorAll('#terminalBody .terminal-line').forEach((line) => {
-          line.classList.add('visible');
-          const el = line as HTMLElement;
-          const cmd = el.dataset.cmd;
-          const output = el.dataset.output;
-          const cmdSpan = el.querySelector('.terminal-command') as HTMLElement | null;
-          const outSpan = el.querySelector('.terminal-output') as HTMLElement | null;
-          if (cmd && cmdSpan && !cmdSpan.textContent) cmdSpan.textContent = cmd;
-          if (output && outSpan && !outSpan.textContent) outSpan.textContent = output;
-        });
-      });
-    });
+          line.classList.add('visible')
+          const el = line as HTMLElement
+          const cmd = el.dataset.cmd
+          const output = el.dataset.output
+          const cmdSpan = el.querySelector('.terminal-command') as HTMLElement | null
+          const outSpan = el.querySelector('.terminal-output') as HTMLElement | null
+          if (cmd && cmdSpan && !cmdSpan.textContent) {
+            cmdSpan.textContent = cmd
+          }
+          if (output && outSpan && !outSpan.textContent) {
+            outSpan.textContent = output
+          }
+        })
+      })
+    })
 
     // Wait for scroll height to stabilize so fullPage screenshots capture the
     // entire document. At responsive breakpoints the layout switches from
@@ -188,27 +174,24 @@ export async function navigateAndWait(page: Page, options: NavigateOptions = {})
     // Require THREE consecutive equal reads at 150ms intervals (~450ms min
     // settle window) to absorb async layout shifts (image decode, font swap,
     // late-arriving widget content) that a single 200ms check missed.
-    await page.waitForFunction(
-      () => {
-        return new Promise<boolean>((resolve) => {
-          const reads: number[] = [document.documentElement.scrollHeight];
-          let i = 0;
-          const tick = () => {
-            i++;
-            reads.push(document.documentElement.scrollHeight);
-            if (i < 3) {
-              setTimeout(tick, 150);
-              return;
-            }
-            // Inlined copy of scrollHeightStable() from ./predicates.ts (cannot import inside waitForFunction).
-            // If you change one, update the other.
-            resolve(reads.every((v) => v === reads[0]));
-          };
-          setTimeout(tick, 150);
-        });
-      },
-      { timeout: 10000 },
-    );
+    await page.waitForFunction(() => {
+      return new Promise<boolean>((resolve) => {
+        const reads: number[] = [document.documentElement.scrollHeight]
+        let i = 0
+        const tick = () => {
+          i++
+          reads.push(document.documentElement.scrollHeight)
+          if (i < 3) {
+            setTimeout(tick, 150)
+            return
+          }
+          // Inlined copy of scrollHeightStable() from ./predicates.ts (cannot import inside waitForFunction).
+          // If you change one, update the other.
+          resolve(reads.every((v) => v === reads[0]))
+        }
+        setTimeout(tick, 150)
+      })
+    }, {timeout: 10000})
   }
 }
 
@@ -217,12 +200,9 @@ export async function navigateAndWait(page: Page, options: NavigateOptions = {})
  * Automatically determines whether to wait for workouts based on the scenario.
  */
 export async function setupPage(page: Page, scenario: ScenarioName, options?: NavigateOptions): Promise<void> {
-  await interceptRoutes(page, scenario);
-  const hasWorkouts = options?.waitForWorkouts ?? scenarioHasWorkouts(scenario);
-  await navigateAndWait(page, {
-    waitForWorkouts: hasWorkouts,
-    waitForScrollHeight: options?.waitForScrollHeight ?? false,
-  });
+  await interceptRoutes(page, scenario)
+  const hasWorkouts = options?.waitForWorkouts ?? scenarioHasWorkouts(scenario)
+  await navigateAndWait(page, {waitForWorkouts: hasWorkouts, waitForScrollHeight: options?.waitForScrollHeight ?? false})
 }
 
 /**
@@ -247,20 +227,16 @@ export async function setupPage(page: Page, scenario: ScenarioName, options?: Na
  * `height: auto !important; overflow: visible !important` -- without that
  * rule, scrollHeight is capped by `height: 100dvh` and clip captures truncate.
  */
-export async function captureFullPage(
-  page: Page,
-  screenshotName: string,
-  opts?: { stylePath?: string; },
-): Promise<void> {
+export async function captureFullPage(page: Page, screenshotName: string, opts?: {stylePath?: string}): Promise<void> {
   // Stability: fonts + 2x rAF to absorb late layout shifts
   await page.evaluate(async () => {
-    await document.fonts.ready;
-    await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
-  });
+    await document.fonts.ready
+    await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+  })
 
-  const viewport = page.viewportSize();
+  const viewport = page.viewportSize()
   if (!viewport) {
-    throw new Error('captureFullPage: no viewport configured on page');
+    throw new Error('captureFullPage: no viewport configured on page')
   }
 
   // Measure the true content height. On desktop (>=1100px) the document body
@@ -281,31 +257,24 @@ export async function captureFullPage(
   // (<768px), where the columns become in-flow and the body scrolls, still
   // measure the full page correctly.
   const measuredHeight = await page.evaluate(() => {
-    const panels = Array.from(
-      document.querySelectorAll<HTMLElement>('.left-panel, .right-panel'),
-    );
+    const panels = Array.from(document.querySelectorAll<HTMLElement>('.left-panel, .right-panel'))
     panels.forEach((panel) => {
-      panel.scrollTop = 0;
-    });
-    const tallestPanel = panels.reduce((max, panel) => Math.max(max, panel.scrollHeight), 0);
-    return Math.max(document.documentElement.scrollHeight, tallestPanel);
-  });
+      panel.scrollTop = 0
+    })
+    const tallestPanel = panels.reduce((max, panel) => Math.max(max, panel.scrollHeight), 0)
+    return Math.max(document.documentElement.scrollHeight, tallestPanel)
+  })
   if (measuredHeight <= 0) {
-    throw new Error(`captureFullPage: scrollHeight is ${measuredHeight} — page may not have loaded`);
+    throw new Error(`captureFullPage: scrollHeight is ${measuredHeight} — page may not have loaded`)
   }
 
-  await page.setViewportSize({ width: viewport.width, height: measuredHeight });
+  await page.setViewportSize({width: viewport.width, height: measuredHeight})
 
   // Let the grown viewport reflow (100dvh recalculates against the new height)
   // before capturing.
-  await page.evaluate(
-    () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
-  );
+  await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))))
 
-  await expect(page).toHaveScreenshot(screenshotName, {
-    clip: { x: 0, y: 0, width: viewport.width, height: measuredHeight },
-    stylePath: opts?.stylePath,
-  });
+  await expect(page).toHaveScreenshot(screenshotName, {clip: {x: 0, y: 0, width: viewport.width, height: measuredHeight}, stylePath: opts?.stylePath})
 }
 
 /**
@@ -319,9 +288,9 @@ export async function captureFullPage(
  */
 export async function stabilizeForLocatorScreenshot(page: Page): Promise<void> {
   await page.evaluate(async () => {
-    await document.fonts.ready;
-    await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
-  });
+    await document.fonts.ready
+    await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+  })
 }
 
 /**
@@ -338,32 +307,26 @@ export async function stabilizeForLocatorScreenshot(page: Page): Promise<void> {
  * that race WITHOUT relaxing the pixel match -- the settled render is identical
  * to the committed baseline, so no baseline changes.
  */
-export async function waitForStableBox(
-  locator: Locator,
-  {
-    epsilonPx = 0.5,
-    framesRequired = 5,
-    timeoutMs = 2000,
-  }: { epsilonPx?: number; framesRequired?: number; timeoutMs?: number; } = {},
-): Promise<void> {
-  const nextFrame = () =>
-    locator
-      .page()
-      .evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+export async function waitForStableBox(locator: Locator, {
+  epsilonPx = 0.5,
+  framesRequired = 5,
+  timeoutMs = 2000
+}: {epsilonPx?: number; framesRequired?: number; timeoutMs?: number} = {}): Promise<void> {
+  const nextFrame = () => locator.page().evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())))
 
-  let prev = await locator.boundingBox();
-  let stableFrames = 0;
-  const deadline = Date.now() + timeoutMs;
+  let prev = await locator.boundingBox()
+  let stableFrames = 0
+  const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline && stableFrames < framesRequired) {
-    await nextFrame();
-    const box = await locator.boundingBox();
-    const settled = box !== null
-      && prev !== null
-      && Math.abs(box.x - prev.x) <= epsilonPx
-      && Math.abs(box.y - prev.y) <= epsilonPx
-      && Math.abs(box.width - prev.width) <= epsilonPx
-      && Math.abs(box.height - prev.height) <= epsilonPx;
-    stableFrames = settled ? stableFrames + 1 : 0;
-    prev = box;
+    await nextFrame()
+    const box = await locator.boundingBox()
+    const settled = box !== null &&
+      prev !== null &&
+      Math.abs(box.x - prev.x) <= epsilonPx &&
+      Math.abs(box.y - prev.y) <= epsilonPx &&
+      Math.abs(box.width - prev.width) <= epsilonPx &&
+      Math.abs(box.height - prev.height) <= epsilonPx
+    stableFrames = settled ? stableFrames + 1 : 0
+    prev = box
   }
 }

--- a/tests/visual/png-iend-truncate.ts
+++ b/tests/visual/png-iend-truncate.ts
@@ -32,16 +32,18 @@ const IEND_SIGNATURE = Buffer.from([
   0xae,
   0x42,
   0x60,
-  0x82, // pre-computed CRC for empty IEND
-]);
+  0x82 // pre-computed CRC for empty IEND
+])
 
 export function truncateAtIEND(buf: Buffer): Buffer {
   if (!Buffer.isBuffer(buf) || buf.length < IEND_SIGNATURE.length + 8) {
     // 8 = PNG signature size; not enough room for a valid PNG
-    return buf;
+    return buf
   }
-  const idx = buf.indexOf(IEND_SIGNATURE);
-  if (idx === -1) return buf;
-  const end = idx + IEND_SIGNATURE.length;
-  return end === buf.length ? buf : buf.subarray(0, end);
+  const idx = buf.indexOf(IEND_SIGNATURE)
+  if (idx === -1) {
+    return buf
+  }
+  const end = idx + IEND_SIGNATURE.length
+  return end === buf.length ? buf : buf.subarray(0, end)
 }

--- a/tests/visual/predicates.ts
+++ b/tests/visual/predicates.ts
@@ -9,12 +9,14 @@
  */
 
 /** Returns true if all images in the array report complete=true. Empty array returns true. */
-export function allImagesComplete(imgs: ReadonlyArray<{ complete: boolean; }>): boolean {
-  return imgs.every((img) => img.complete);
+export function allImagesComplete(imgs: ReadonlyArray<{complete: boolean}>): boolean {
+  return imgs.every((img) => img.complete)
 }
 
 /** Returns true if all scrollHeight reads are equal (i.e., layout has stabilized). */
 export function scrollHeightStable(reads: ReadonlyArray<number>): boolean {
-  if (reads.length === 0) return true;
-  return reads.every((v) => v === reads[0]);
+  if (reads.length === 0) {
+    return true
+  }
+  return reads.every((v) => v === reads[0])
 }

--- a/tests/visual/pw-fixtures.ts
+++ b/tests/visual/pw-fixtures.ts
@@ -34,11 +34,11 @@
  * Playwright upgrade).
  */
 
-import { test as base, expect, type Page } from '@playwright/test';
-import { createRequire } from 'node:module';
-import { truncateAtIEND } from './png-iend-truncate';
+import {expect, type Page, test as base} from '@playwright/test'
+import {createRequire} from 'node:module'
+import {truncateAtIEND} from './png-iend-truncate'
 
-const require = createRequire(import.meta.url);
+const require = createRequire(import.meta.url)
 
 /**
  * Apply the PNG.sync.read patch. Idempotent: re-patching is a no-op due to the
@@ -46,47 +46,47 @@ const require = createRequire(import.meta.url);
  */
 function applyPngTruncationPatch(): boolean {
   if (process.env.SKIP_PNG_TRUNCATION) {
-    return false;
+    return false
   }
   try {
-    const ub = require('playwright-core/lib/utilsBundle');
-    const origRead = ub.PNG.sync.read;
+    const ub = require('playwright-core/lib/utilsBundle')
+    const origRead = ub.PNG.sync.read
     if (origRead.name !== 'truncatedRead') {
       ub.PNG.sync.read = function truncatedRead(buf: Buffer, opts?: unknown) {
-        return origRead(truncateAtIEND(buf), opts);
-      };
+        return origRead(truncateAtIEND(buf), opts)
+      }
     }
-    return ub.PNG.sync.read.name === 'truncatedRead';
+    return ub.PNG.sync.read.name === 'truncatedRead'
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.warn('[pw-fixtures] PNG.sync.read patch FAILED:', err instanceof Error ? err.message : err);
-    return false;
+    console.warn('[pw-fixtures] PNG.sync.read patch FAILED:', err instanceof Error ? err.message : err)
+    return false
   }
 }
 
 // MODULE-LOAD: apply patch immediately when this file is imported. Each worker
 // runs this on its first import of a spec file, before any test code runs.
-const moduleLoadPatchOk = applyPngTruncationPatch();
+const moduleLoadPatchOk = applyPngTruncationPatch()
 if (!moduleLoadPatchOk && !process.env.SKIP_PNG_TRUNCATION) {
   // eslint-disable-next-line no-console
-  console.warn('[pw-fixtures] module-load patch did NOT take effect — check Playwright internals');
+  console.warn('[pw-fixtures] module-load patch did NOT take effect — check Playwright internals')
 }
 
-type WorkerFixtures = { pngTruncation: void; };
+type WorkerFixtures = {pngTruncation: void}
 
 export const test = base.extend<{}, WorkerFixtures>({
   pngTruncation: [
     async ({}, use) => {
       // Belt-and-suspenders: re-apply at fixture activation (idempotent).
-      const ok = applyPngTruncationPatch();
+      const ok = applyPngTruncationPatch()
       if (!ok && !process.env.SKIP_PNG_TRUNCATION) {
         // eslint-disable-next-line no-console
-        console.warn('[pw-fixtures] fixture-scoped patch did NOT take effect');
+        console.warn('[pw-fixtures] fixture-scoped patch did NOT take effect')
       }
-      await use();
+      await use()
     },
-    { scope: 'worker', auto: true },
-  ],
-});
+    {scope: 'worker', auto: true}
+  ]
+})
 
-export { expect, type Page };
+export { expect, type Page }

--- a/tests/visual/widgets.spec.ts
+++ b/tests/visual/widgets.spec.ts
@@ -5,15 +5,8 @@
  * 4b: Per-widget variation screenshots (each test uses its own scenario).
  * 4c: Overlay tests (focus-work, focus-dnd).
  */
-import { test, expect, type Page } from './pw-fixtures';
-import {
-  setupPage,
-  stylePath,
-  WIDGET_SELECTORS,
-  captureFullPage,
-  stabilizeForLocatorScreenshot,
-  waitForStableBox,
-} from './helpers';
+import {expect, type Page, test} from './pw-fixtures'
+import {captureFullPage, setupPage, stabilizeForLocatorScreenshot, stylePath, waitForStableBox, WIDGET_SELECTORS} from './helpers'
 
 // ---------------------------------------------------------------------------
 // 4a: Baseline Widget Screenshots (populated scenario)
@@ -25,357 +18,345 @@ import {
 // ---------------------------------------------------------------------------
 
 test.describe('Widgets - populated', () => {
-  test.describe.configure({ mode: 'serial' });
+  test.describe.configure({mode: 'serial'})
 
-  let page: Page;
+  let page: Page
 
-  test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
+  test.beforeAll(async ({browser}) => {
+    page = await browser.newPage()
     // waitForScrollHeight also gates the bio-terminal typewriter wait. The
     // bio-terminal widget screenshot below requires the typewriter to have
     // completed (or been forced visible via the fallback).
-    await setupPage(page, 'populated', { waitForScrollHeight: true });
-  });
+    await setupPage(page, 'populated', {waitForScrollHeight: true})
+  })
 
   test.afterAll(async () => {
-    await page.close();
-  });
+    await page.close()
+  })
 
   test('identity card', async () => {
-    const widget = page.locator(WIDGET_SELECTORS.identityCard);
-    await expect(widget).toHaveScreenshot('widget-identity-card.png', { stylePath });
-  });
+    const widget = page.locator(WIDGET_SELECTORS.identityCard)
+    await expect(widget).toHaveScreenshot('widget-identity-card.png', {stylePath})
+  })
 
   test('bio terminal', async () => {
-    const widget = page.locator(WIDGET_SELECTORS.bioTerminal);
+    const widget = page.locator(WIDGET_SELECTORS.bioTerminal)
 
     // Behavioral guard (non-screenshot, planning-protocol visual-state rule): the
     // interests command is the accurate `ls -m interests/` (not the old, broken
     // `wc -l interests/`), and the listing is alphabetical. Asserted on the SSR
     // data-* attributes so it holds independent of the typewriter + pixel baseline.
-    const body = page.locator('#terminalBody');
-    await expect(body.locator('[data-cmd="ls -m interests/"]')).toHaveCount(1);
-    await expect(body.locator('[data-cmd="wc -l interests/"]')).toHaveCount(0);
-    await expect(
-      body.locator('[data-output="conversation, edm, musical theatre, pc gaming, programming"]'),
-    ).toHaveCount(1);
+    const body = page.locator('#terminalBody')
+    await expect(body.locator('[data-cmd="ls -m interests/"]')).toHaveCount(1)
+    await expect(body.locator('[data-cmd="wc -l interests/"]')).toHaveCount(0)
+    await expect(body.locator('[data-output="conversation, edm, musical theatre, pc gaming, programming"]')).toHaveCount(1)
 
     // Skills line is now `printenv STACK` (reframed as an env var), not a second
     // `ls skills/` — differentiated from `ls -m interests/`; output is single-spaced.
-    await expect(body.locator('[data-cmd="printenv STACK"]')).toHaveCount(1);
-    await expect(body.locator('[data-cmd="ls skills/"]')).toHaveCount(0);
-    await expect(
-      body.locator('[data-output="aws typescript serverless swift go perl"]'),
-    ).toHaveCount(1);
+    await expect(body.locator('[data-cmd="printenv STACK"]')).toHaveCount(1)
+    await expect(body.locator('[data-cmd="ls skills/"]')).toHaveCount(0)
+    await expect(body.locator('[data-output="aws typescript serverless swift go perl"]')).toHaveCount(1)
 
     // Identity block is the accurate `gpg -k` pub/uid pair — `cat about.txt` is
     // retired. The uid comment is deliberately "Software Engineer" (the gpg
     // self-identity, DS #121 owner decision) — NOT person.jobTitle ("Engineering
     // Director", which the identity card shows); do not align it back to jobTitle.
     // The pub/uid gutters are real multi-space gpg columns (via .terminal-line pre-wrap).
-    await expect(body.locator('[data-cmd="gpg -k"]')).toHaveCount(1);
-    await expect(body.locator('[data-cmd="cat about.txt"]')).toHaveCount(0);
-    await expect(body.locator('[data-output="pub   rsa4096 2002-01-01 [SC]"]')).toHaveCount(1);
-    await expect(
-      body.locator('[data-output="uid   Jonathan Lloyd (Software Engineer)"]'),
-    ).toHaveCount(1);
+    await expect(body.locator('[data-cmd="gpg -k"]')).toHaveCount(1)
+    await expect(body.locator('[data-cmd="cat about.txt"]')).toHaveCount(0)
+    await expect(body.locator('[data-output="pub   rsa4096 2002-01-01 [SC]"]')).toHaveCount(1)
+    await expect(body.locator('[data-output="uid   Jonathan Lloyd (Software Engineer)"]')).toHaveCount(1)
 
     // philosophy.txt is the sole remaining `cat`, holding BOTH quoted lines
     // (about.txt's tagline moved here); uptime output begins with a real `up`.
-    await expect(body.locator('[data-cmd="cat philosophy.txt"]')).toHaveCount(1);
-    await expect(
-      body.locator(`[data-output="\\"Creating things I'm proud of\\""]`),
-    ).toHaveCount(1);
-    await expect(
-      body.locator(`[data-output="\\"Enjoying the passage of time\\""]`),
-    ).toHaveCount(1);
-    await expect(
-      body.locator('[data-output="up 24+ years professionally and counting"]'),
-    ).toHaveCount(1);
+    await expect(body.locator('[data-cmd="cat philosophy.txt"]')).toHaveCount(1)
+    await expect(body.locator(`[data-output="\\"Creating things I'm proud of\\""]`)).toHaveCount(1)
+    await expect(body.locator(`[data-output="\\"Enjoying the passage of time\\""]`)).toHaveCount(1)
+    await expect(body.locator('[data-output="up 24+ years professionally and counting"]')).toHaveCount(1)
 
-    await expect(widget).toHaveScreenshot('widget-bio-terminal.png', { stylePath });
-  });
+    await expect(widget).toHaveScreenshot('widget-bio-terminal.png', {stylePath})
+  })
 
   test('system status', async () => {
-    const widget = page.locator(WIDGET_SELECTORS.systemStatus);
-    await expect(widget).toHaveScreenshot('widget-system-status.png', { stylePath });
-  });
+    const widget = page.locator(WIDGET_SELECTORS.systemStatus)
+    await expect(widget).toHaveScreenshot('widget-system-status.png', {stylePath})
+  })
 
   test('heart rate', async () => {
-    const widget = page.locator(WIDGET_SELECTORS.heartRate);
-    await expect(widget).toHaveScreenshot('widget-heart-rate.png', { stylePath });
-  });
+    const widget = page.locator(WIDGET_SELECTORS.heartRate)
+    await expect(widget).toHaveScreenshot('widget-heart-rate.png', {stylePath})
+  })
 
   test('workouts', async () => {
-    const widget = page.locator(WIDGET_SELECTORS.workouts);
-    await expect(widget).toHaveScreenshot('widget-workouts.png', { stylePath });
-  });
+    const widget = page.locator(WIDGET_SELECTORS.workouts)
+    await expect(widget).toHaveScreenshot('widget-workouts.png', {stylePath})
+  })
 
   test('hydration', async () => {
-    const widget = page.locator(WIDGET_SELECTORS.hydration);
-    await expect(widget).toHaveScreenshot('widget-hydration.png', { stylePath });
-  });
+    const widget = page.locator(WIDGET_SELECTORS.hydration)
+    await expect(widget).toHaveScreenshot('widget-hydration.png', {stylePath})
+  })
 
   test('night summary', async () => {
-    const widget = page.locator(WIDGET_SELECTORS.nightSummary);
-    await expect(widget).toHaveScreenshot('widget-night-summary.png', { stylePath });
-  });
+    const widget = page.locator(WIDGET_SELECTORS.nightSummary)
+    await expect(widget).toHaveScreenshot('widget-night-summary.png', {stylePath})
+  })
 
   test('dev activity log', async () => {
-    await stabilizeForLocatorScreenshot(page);
-    const widget = page.locator(WIDGET_SELECTORS.devActivityLog);
-    await expect(widget).toHaveScreenshot('widget-dev-activity-log.png', { stylePath });
-  });
+    await stabilizeForLocatorScreenshot(page)
+    const widget = page.locator(WIDGET_SELECTORS.devActivityLog)
+    await expect(widget).toHaveScreenshot('widget-dev-activity-log.png', {stylePath})
+  })
 
   test('reading feed', async () => {
-    await stabilizeForLocatorScreenshot(page);
-    const widget = page.locator(WIDGET_SELECTORS.readingFeed);
-    await expect(widget).toHaveScreenshot('widget-reading-feed.png', { stylePath });
-  });
+    await stabilizeForLocatorScreenshot(page)
+    const widget = page.locator(WIDGET_SELECTORS.readingFeed)
+    await expect(widget).toHaveScreenshot('widget-reading-feed.png', {stylePath})
+  })
 
   test('bookshelf', async () => {
-    const widget = page.locator(WIDGET_SELECTORS.bookshelf);
-    await expect(widget).toHaveScreenshot('widget-bookshelf.png', { stylePath });
-  });
+    const widget = page.locator(WIDGET_SELECTORS.bookshelf)
+    await expect(widget).toHaveScreenshot('widget-bookshelf.png', {stylePath})
+  })
 
   test('starred repos', async () => {
-    await stabilizeForLocatorScreenshot(page);
-    const widget = page.locator(WIDGET_SELECTORS.starredRepos);
-    await expect(widget).toHaveScreenshot('widget-starred-repos.png', { stylePath });
-  });
+    await stabilizeForLocatorScreenshot(page)
+    const widget = page.locator(WIDGET_SELECTORS.starredRepos)
+    await expect(widget).toHaveScreenshot('widget-starred-repos.png', {stylePath})
+  })
 
   test('theatre reviews', async () => {
-    const widget = page.locator(WIDGET_SELECTORS.theatreReviews);
-    await expect(widget).toHaveScreenshot('widget-theatre-reviews.png', { stylePath });
-  });
+    const widget = page.locator(WIDGET_SELECTORS.theatreReviews)
+    await expect(widget).toHaveScreenshot('widget-theatre-reviews.png', {stylePath})
+  })
 
   test('top bar', async () => {
-    const widget = page.locator(WIDGET_SELECTORS.topBar);
-    await expect(widget).toHaveScreenshot('widget-top-bar.png', { stylePath });
-  });
-});
+    const widget = page.locator(WIDGET_SELECTORS.topBar)
+    await expect(widget).toHaveScreenshot('widget-top-bar.png', {stylePath})
+  })
+})
 
 // ---------------------------------------------------------------------------
 // 4b: Widget Variation Screenshots
 // ---------------------------------------------------------------------------
 
 test.describe('Widget variations - Heart Rate', () => {
-  test('bradycardia', async ({ page }) => {
-    await setupPage(page, 'hr-bradycardia');
-    const widget = page.locator('#cardHR');
-    await expect(widget).toHaveScreenshot('hr-bradycardia.png', { stylePath });
-  });
+  test('bradycardia', async ({page}) => {
+    await setupPage(page, 'hr-bradycardia')
+    const widget = page.locator('#cardHR')
+    await expect(widget).toHaveScreenshot('hr-bradycardia.png', {stylePath})
+  })
 
-  test('peak', async ({ page }) => {
-    await setupPage(page, 'hr-peak');
-    const widget = page.locator('#cardHR');
-    await expect(widget).toHaveScreenshot('hr-peak.png', { stylePath });
-  });
+  test('peak', async ({page}) => {
+    await setupPage(page, 'hr-peak')
+    const widget = page.locator('#cardHR')
+    await expect(widget).toHaveScreenshot('hr-peak.png', {stylePath})
+  })
 
-  test('resting', async ({ page }) => {
-    await setupPage(page, 'hr-resting');
-    const widget = page.locator('#cardHR');
-    await expect(widget).toHaveScreenshot('hr-resting.png', { stylePath });
-  });
-});
+  test('resting', async ({page}) => {
+    await setupPage(page, 'hr-resting')
+    const widget = page.locator('#cardHR')
+    await expect(widget).toHaveScreenshot('hr-resting.png', {stylePath})
+  })
+})
 
 test.describe('Widget variations - Heart Rate Paused', () => {
-  test('paused hr gap', async ({ page }) => {
-    await setupPage(page, 'hr-paused-hr-gap');
-    const widget = page.locator('#cardHR');
+  test('paused hr gap', async ({page}) => {
+    await setupPage(page, 'hr-paused-hr-gap')
+    const widget = page.locator('#cardHR')
     // Behavioral guard: paused block must be visible; data values must not be.
     // If the class-toggle is a no-op (e.g. paused node missing from DOM), the
     // screenshot would show full-brightness BPM data — this assertion catches that.
-    await expect(widget.locator('#hrPaused')).toBeVisible();
-    await expect(widget.locator('.hr-data')).toBeHidden();
-    await expect(widget).toHaveScreenshot('hr-paused-hr-gap.png', { stylePath });
-  });
+    await expect(widget.locator('#hrPaused')).toBeVisible()
+    await expect(widget.locator('.hr-data')).toBeHidden()
+    await expect(widget).toHaveScreenshot('hr-paused-hr-gap.png', {stylePath})
+  })
 
-  test('paused charging', async ({ page }) => {
-    await setupPage(page, 'hr-paused-charging');
-    const widget = page.locator('#cardHR');
-    await expect(widget.locator('#hrPaused')).toBeVisible();
-    await expect(widget.locator('.hr-data')).toBeHidden();
-    await expect(widget).toHaveScreenshot('hr-paused-charging.png', { stylePath });
-  });
-});
+  test('paused charging', async ({page}) => {
+    await setupPage(page, 'hr-paused-charging')
+    const widget = page.locator('#cardHR')
+    await expect(widget.locator('#hrPaused')).toBeVisible()
+    await expect(widget.locator('.hr-data')).toBeHidden()
+    await expect(widget).toHaveScreenshot('hr-paused-charging.png', {stylePath})
+  })
+})
 
 test.describe('Widget variations - Movement Rings Active', () => {
-  test('active state renders server goals, standHours, daylight, and solar', async ({ page }) => {
-    await setupPage(page, 'movement-active');
-    const widget = page.locator(WIDGET_SELECTORS.movementRings);
+  test('active state renders server goals, standHours, daylight, and solar', async ({page}) => {
+    await setupPage(page, 'movement-active')
+    const widget = page.locator(WIDGET_SELECTORS.movementRings)
     // Behavioral guards (non-screenshot): the 2026-07-17 regression trio.
     // 1. Goal denominators come from health.json's goals, not client defaults.
-    await expect(widget.locator('#legendMove')).toHaveText('103/650');
-    await expect(widget.locator('#legendExercise')).toHaveText('0/40');
+    await expect(widget.locator('#legendMove')).toHaveText('103/650')
+    await expect(widget.locator('#legendExercise')).toHaveText('0/40')
     // 2. Stand uses the synced standHours ring count (NOT floor(4 min / 60) = 0).
-    await expect(widget.locator('#legendStand')).toHaveText('4/12');
+    await expect(widget.locator('#legendStand')).toHaveText('4/12')
     // 3. Daylight + solar hydrate from live data (formerly frozen SSR fixture text).
-    await expect(widget.locator('#mvDaylightMin')).toHaveText('48');
-    await expect(widget.locator('#mvDaylightHit')).toBeVisible();
-    await expect(widget.locator('#mvSunrise')).toHaveText('05:39');
-    await expect(widget.locator('#mvSunset')).toHaveText('20:24');
-    await expect(widget).toHaveScreenshot('mv-active.png', { stylePath });
-  });
-});
+    await expect(widget.locator('#mvDaylightMin')).toHaveText('48')
+    await expect(widget.locator('#mvDaylightHit')).toBeVisible()
+    await expect(widget.locator('#mvSunrise')).toHaveText('05:39')
+    await expect(widget.locator('#mvSunset')).toHaveText('20:24')
+    await expect(widget).toHaveScreenshot('mv-active.png', {stylePath})
+  })
+})
 
 test.describe('Widget variations - Movement Rings Paused', () => {
-  test('paused hr gap', async ({ page }) => {
-    await setupPage(page, 'hr-paused-hr-gap');
-    const widget = page.locator(WIDGET_SELECTORS.movementRings);
+  test('paused hr gap', async ({page}) => {
+    await setupPage(page, 'hr-paused-hr-gap')
+    const widget = page.locator(WIDGET_SELECTORS.movementRings)
     // Behavioral guard: paused block visible; data container (rings + chips) hidden.
-    await expect(widget.locator('#mvPaused')).toBeVisible();
-    await expect(widget.locator('.mv-data')).toBeHidden();
-    await expect(widget).toHaveScreenshot('mv-paused-hr-gap.png', { stylePath });
-  });
+    await expect(widget.locator('#mvPaused')).toBeVisible()
+    await expect(widget.locator('.mv-data')).toBeHidden()
+    await expect(widget).toHaveScreenshot('mv-paused-hr-gap.png', {stylePath})
+  })
 
-  test('paused charging', async ({ page }) => {
-    await setupPage(page, 'hr-paused-charging');
-    const widget = page.locator(WIDGET_SELECTORS.movementRings);
-    await expect(widget.locator('#mvPaused')).toBeVisible();
-    await expect(widget.locator('.mv-data')).toBeHidden();
-    await expect(widget).toHaveScreenshot('mv-paused-charging.png', { stylePath });
-  });
-});
+  test('paused charging', async ({page}) => {
+    await setupPage(page, 'hr-paused-charging')
+    const widget = page.locator(WIDGET_SELECTORS.movementRings)
+    await expect(widget.locator('#mvPaused')).toBeVisible()
+    await expect(widget.locator('.mv-data')).toBeHidden()
+    await expect(widget).toHaveScreenshot('mv-paused-charging.png', {stylePath})
+  })
+})
 
 test.describe('Widget variations - Hydration', () => {
-  test('zero', async ({ page }) => {
-    await setupPage(page, 'hydration-zero');
-    const widget = page.locator('#cardHydration');
-    await expect(widget).toHaveScreenshot('hydration-zero.png', { stylePath });
-  });
+  test('zero', async ({page}) => {
+    await setupPage(page, 'hydration-zero')
+    const widget = page.locator('#cardHydration')
+    await expect(widget).toHaveScreenshot('hydration-zero.png', {stylePath})
+  })
 
-  test('max', async ({ page }) => {
-    await setupPage(page, 'hydration-max');
-    const widget = page.locator('#cardHydration');
-    await expect(widget).toHaveScreenshot('hydration-max.png', { stylePath });
-  });
+  test('max', async ({page}) => {
+    await setupPage(page, 'hydration-max')
+    const widget = page.locator('#cardHydration')
+    await expect(widget).toHaveScreenshot('hydration-max.png', {stylePath})
+  })
 
   // Optional dietaryWater/dietaryCaffeine quantities entirely absent (not zero).
   // Preserves the missing-optional health render path that the `empty` dashboard
   // scenario previously covered before it moved to the real `empty` fixtures.
-  test('missing optional', async ({ page }) => {
-    await setupPage(page, 'health-missing-optional');
-    const widget = page.locator('#cardHydration');
-    await expect(widget).toHaveScreenshot('hydration-missing-optional.png', { stylePath });
-  });
-});
+  test('missing optional', async ({page}) => {
+    await setupPage(page, 'health-missing-optional')
+    const widget = page.locator('#cardHydration')
+    await expect(widget).toHaveScreenshot('hydration-missing-optional.png', {stylePath})
+  })
+})
 
 test.describe('Widget variations - Night Summary', () => {
-  test('deep dominant', async ({ page }) => {
-    await setupPage(page, 'sleep-deep-dominant');
-    const widget = page.locator('#cardSleep');
-    await expect(widget).toHaveScreenshot('sleep-deep-dominant.png', { stylePath });
-  });
+  test('deep dominant', async ({page}) => {
+    await setupPage(page, 'sleep-deep-dominant')
+    const widget = page.locator('#cardSleep')
+    await expect(widget).toHaveScreenshot('sleep-deep-dominant.png', {stylePath})
+  })
 
-  test('rem dominant', async ({ page }) => {
-    await setupPage(page, 'sleep-rem-dominant');
-    const widget = page.locator('#cardSleep');
-    await expect(widget).toHaveScreenshot('sleep-rem-dominant.png', { stylePath });
-  });
+  test('rem dominant', async ({page}) => {
+    await setupPage(page, 'sleep-rem-dominant')
+    const widget = page.locator('#cardSleep')
+    await expect(widget).toHaveScreenshot('sleep-rem-dominant.png', {stylePath})
+  })
 
-  test('short sleep', async ({ page }) => {
-    await setupPage(page, 'sleep-short');
-    const widget = page.locator('#cardSleep');
-    await expect(widget).toHaveScreenshot('sleep-short.png', { stylePath });
-  });
-});
+  test('short sleep', async ({page}) => {
+    await setupPage(page, 'sleep-short')
+    const widget = page.locator('#cardSleep')
+    await expect(widget).toHaveScreenshot('sleep-short.png', {stylePath})
+  })
+})
 
 test.describe('Widget variations - Bookshelf', () => {
-  test('all reading', async ({ page }) => {
-    await setupPage(page, 'books-all-reading');
-    const widget = page.locator('#cardBooks');
-    await expect(widget).toHaveScreenshot('books-all-reading.png', { stylePath });
-  });
+  test('all reading', async ({page}) => {
+    await setupPage(page, 'books-all-reading')
+    const widget = page.locator('#cardBooks')
+    await expect(widget).toHaveScreenshot('books-all-reading.png', {stylePath})
+  })
 
-  test('all completed', async ({ page }) => {
-    await setupPage(page, 'books-all-completed');
-    const widget = page.locator('#cardBooks');
-    await expect(widget).toHaveScreenshot('books-all-completed.png', { stylePath });
-  });
+  test('all completed', async ({page}) => {
+    await setupPage(page, 'books-all-completed')
+    const widget = page.locator('#cardBooks')
+    await expect(widget).toHaveScreenshot('books-all-completed.png', {stylePath})
+  })
 
-  test('no covers', async ({ page }) => {
-    await setupPage(page, 'books-no-covers');
-    const widget = page.locator('#cardBooks');
-    await expect(widget).toHaveScreenshot('books-no-covers.png', { stylePath });
-  });
-});
+  test('no covers', async ({page}) => {
+    await setupPage(page, 'books-no-covers')
+    const widget = page.locator('#cardBooks')
+    await expect(widget).toHaveScreenshot('books-no-covers.png', {stylePath})
+  })
+})
 
 test.describe('Widget variations - Dev Activity Log', () => {
-  test('commits only', async ({ page }) => {
-    await setupPage(page, 'github-commits-only');
-    await stabilizeForLocatorScreenshot(page);
-    const widget = page.locator('#cardDevLog');
-    await expect(widget).toHaveScreenshot('github-commits-only.png', { stylePath });
-  });
+  test('commits only', async ({page}) => {
+    await setupPage(page, 'github-commits-only')
+    await stabilizeForLocatorScreenshot(page)
+    const widget = page.locator('#cardDevLog')
+    await expect(widget).toHaveScreenshot('github-commits-only.png', {stylePath})
+  })
 
-  test('prs only', async ({ page }) => {
-    await setupPage(page, 'github-prs-only');
-    await stabilizeForLocatorScreenshot(page);
-    const widget = page.locator('#cardDevLog');
-    await expect(widget).toHaveScreenshot('github-prs-only.png', { stylePath });
-  });
-});
+  test('prs only', async ({page}) => {
+    await setupPage(page, 'github-prs-only')
+    await stabilizeForLocatorScreenshot(page)
+    const widget = page.locator('#cardDevLog')
+    await expect(widget).toHaveScreenshot('github-prs-only.png', {stylePath})
+  })
+})
 
 test.describe('Widget variations - Workouts', () => {
-  test('multi workout', async ({ page }) => {
-    await setupPage(page, 'workouts-multi');
-    await stabilizeForLocatorScreenshot(page);
-    const workouts = page.locator('#cardWorkouts');
-    await expect(workouts).toBeVisible();
-    await expect(workouts).toHaveScreenshot('workouts-multi.png', { stylePath });
-  });
+  test('multi workout', async ({page}) => {
+    await setupPage(page, 'workouts-multi')
+    await stabilizeForLocatorScreenshot(page)
+    const workouts = page.locator('#cardWorkouts')
+    await expect(workouts).toBeVisible()
+    await expect(workouts).toHaveScreenshot('workouts-multi.png', {stylePath})
+  })
 
-  test('barrys bootcamp', async ({ page }) => {
-    await setupPage(page, 'workouts-barrys');
-    const workouts = page.locator('#cardWorkouts');
-    await expect(workouts).toBeVisible();
-    await expect(workouts).toHaveScreenshot('workouts-barrys.png', { stylePath });
-  });
-});
+  test('barrys bootcamp', async ({page}) => {
+    await setupPage(page, 'workouts-barrys')
+    const workouts = page.locator('#cardWorkouts')
+    await expect(workouts).toBeVisible()
+    await expect(workouts).toHaveScreenshot('workouts-barrys.png', {stylePath})
+  })
+})
 
 test.describe('Widget variations - Theatre Reviews', () => {
-  test('all grades', async ({ page }) => {
-    await setupPage(page, 'theatre-all-grades');
-    const widget = page.locator('#cardTheatreReviews');
-    await expect(widget).toHaveScreenshot('theatre-all-grades.png', { stylePath });
-  });
+  test('all grades', async ({page}) => {
+    await setupPage(page, 'theatre-all-grades')
+    const widget = page.locator('#cardTheatreReviews')
+    await expect(widget).toHaveScreenshot('theatre-all-grades.png', {stylePath})
+  })
 
-  test('no images', async ({ page }) => {
-    await setupPage(page, 'theatre-no-images');
-    const widget = page.locator('#cardTheatreReviews');
-    await expect(widget).toHaveScreenshot('theatre-no-images.png', { stylePath });
-  });
-});
+  test('no images', async ({page}) => {
+    await setupPage(page, 'theatre-no-images')
+    const widget = page.locator('#cardTheatreReviews')
+    await expect(widget).toHaveScreenshot('theatre-no-images.png', {stylePath})
+  })
+})
 
 test.describe('Widget variations - Reading Feed', () => {
   // Bug-6 regression: articles with empty articleTitle ("") + long sourceTitle
   // must render without crashing or producing a blank/broken widget row.
-  test('empty title', async ({ page }) => {
-    await setupPage(page, 'reading-empty-title');
-    await stabilizeForLocatorScreenshot(page);
-    const widget = page.locator(WIDGET_SELECTORS.readingFeed);
-    await expect(widget).toHaveScreenshot('reading-empty-title.png', { stylePath });
-  });
-});
+  test('empty title', async ({page}) => {
+    await setupPage(page, 'reading-empty-title')
+    await stabilizeForLocatorScreenshot(page)
+    const widget = page.locator(WIDGET_SELECTORS.readingFeed)
+    await expect(widget).toHaveScreenshot('reading-empty-title.png', {stylePath})
+  })
+})
 
 // ---------------------------------------------------------------------------
 // 4c: Overlay Tests
 // ---------------------------------------------------------------------------
 
 test.describe('Overlays', () => {
-  test('focus overlay', async ({ page }) => {
-    await setupPage(page, 'focus-work', { waitForScrollHeight: true });
-    await page.locator('#focusOverlay').waitFor({ state: 'visible', timeout: 10000 });
-    await captureFullPage(page, 'focus-overlay.png', { stylePath });
-  });
+  test('focus overlay', async ({page}) => {
+    await setupPage(page, 'focus-work', {waitForScrollHeight: true})
+    await page.locator('#focusOverlay').waitFor({state: 'visible', timeout: 10000})
+    await captureFullPage(page, 'focus-overlay.png', {stylePath})
+  })
 
-  test('dnd overlay', async ({ page }) => {
-    await setupPage(page, 'focus-dnd', { waitForScrollHeight: true });
-    await page.locator('#dndOverlay').waitFor({ state: 'visible', timeout: 10000 });
-    await captureFullPage(page, 'dnd-overlay.png', { stylePath });
-  });
-});
+  test('dnd overlay', async ({page}) => {
+    await setupPage(page, 'focus-dnd', {waitForScrollHeight: true})
+    await page.locator('#dndOverlay').waitFor({state: 'visible', timeout: 10000})
+    await captureFullPage(page, 'dnd-overlay.png', {stylePath})
+  })
+})
 
 // ---------------------------------------------------------------------------
 // 4d: System-status provenance popover — OPEN state (with caret)
@@ -392,19 +373,16 @@ test.describe('Overlays', () => {
 // by clip-path) and the drop-shadow.
 // ---------------------------------------------------------------------------
 test.describe('System status — open popover with caret', () => {
-  test('health popover open', async ({ page }, testInfo) => {
-    test.skip(
-      testInfo.project.name !== 'desktop-1400',
-      'Chromium single-viewport guard — one deterministic baseline, no cross-engine fallback',
-    );
+  test('health popover open', async ({page}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop-1400', 'Chromium single-viewport guard — one deterministic baseline, no cross-engine fallback')
 
-    await setupPage(page, 'populated');
+    await setupPage(page, 'populated')
 
-    const button = page.locator('#systemStatus .sys-line[data-source="health"] .sys-info');
-    await button.click();
+    const button = page.locator('#systemStatus .sys-line[data-source="health"] .sys-info')
+    await button.click()
 
-    const popover = page.locator('#tip-health');
-    await expect(popover).toBeVisible();
+    const popover = page.locator('#tip-health')
+    await expect(popover).toBeVisible()
 
     // Pin the popover to its production width. The Health popover's content
     // exceeds the 280px cap, so in production `width: max-content` clamps to
@@ -412,8 +390,8 @@ test.describe('System status — open popover with caret', () => {
     // max-content flake that otherwise varies the box (and thus a float-derived
     // clip) a few px run-to-run. Determinism stabilization only (cf. screenshot.css).
     await popover.evaluate((el) => {
-      (el as HTMLElement).style.width = '280px';
-    });
+      ;(el as HTMLElement).style.width = '280px'
+    })
     // Apply the stabilization stylesheet (screenshot.css) BEFORE measuring the
     // box -- this is the crux of the popover's determinism. toHaveScreenshot
     // injects that same stylesheet at capture time; it reflows the panel and
@@ -426,32 +404,29 @@ test.describe('System status — open popover with caret', () => {
     // with the capture; verified byte-identical across 10 consecutive workers=1
     // renders (an element screenshot is also stable but would clip off the caret,
     // and an earlier `translate` grid-snap broke local<->CI byte parity).
-    await page.addStyleTag({ path: stylePath });
-    await stabilizeForLocatorScreenshot(page);
+    await page.addStyleTag({path: stylePath})
+    await stabilizeForLocatorScreenshot(page)
     // The native popover's anchor-positioned placement can settle a frame or two
     // after open; on loaded CI runners the fixed clip below was measured (and the
     // page captured) mid-settle, so the clip disagreed with the settled popover
     // and flaked ~5-7% (the diff shrank on retry as it settled). Wait for the box
     // to stop moving before deriving the clip. No baseline change: the settled
     // render is what the committed baseline already holds.
-    await waitForStableBox(popover);
+    await waitForStableBox(popover)
 
-    const box = await popover.boundingBox();
-    if (!box) throw new Error('health popover has no bounding box');
+    const box = await popover.boundingBox()
+    if (!box) {
+      throw new Error('health popover has no bounding box')
+    }
 
     // Fixed integer clip anchored to the (now-stable) box origin. Fixed
     // width/height avoid any dependence on the fractional box size; the pad
     // covers the caret (~8px above the top edge, in the margin) and the layered
     // drop-shadow (~20px). No transform, so parity with the other captures holds.
-    const padX = 16;
-    const padTop = 16;
-    const clip = {
-      x: Math.round(box.x) - padX,
-      y: Math.round(box.y) - padTop,
-      width: 280 + padX * 2,
-      height: 120,
-    };
+    const padX = 16
+    const padTop = 16
+    const clip = {x: Math.round(box.x) - padX, y: Math.round(box.y) - padTop, width: 280 + padX * 2, height: 120}
 
-    await expect(page).toHaveScreenshot('system-status-popover-open.png', { clip, stylePath });
-  });
-});
+    await expect(page).toHaveScreenshot('system-status-popover-open.png', {clip, stylePath})
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "astro/tsconfigs/strict",
+  "extends": ["astro/tsconfigs/strict", "@j0nathan-ll0yd/config/tsconfig-base.json"],
   "exclude": ["tests/**"]
 }

--- a/vitest.build.config.ts
+++ b/vitest.build.config.ts
@@ -1,8 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import {defineConfig} from 'vitest/config'
 
-export default defineConfig({
-  test: {
-    include: ['tests/build/**/*.test.ts'],
-    globalSetup: ['tests/build/setup.ts'],
-  },
-});
+export default defineConfig({test: {include: ['tests/build/**/*.test.ts'], globalSetup: ['tests/build/setup.ts']}})

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import {defineConfig} from 'vitest/config'
 
 // Unit tests for the app-owned client runtime (src/lib/runtime/*): fetch/poll/
 // WebSocket logic relocated from @lifegames/web. These mock the network and run
@@ -10,10 +10,4 @@ import { defineConfig } from 'vitest/config';
 // fixtures -- no network, no jsdom-specific APIs needed, but jsdom is a
 // superset environment so plain Node/string-logic tests run fine under it
 // without a third vitest config.
-export default defineConfig({
-  test: {
-    environment: 'jsdom',
-    include: ['tests/unit/**/*.test.ts', 'tests/audit/**/*.test.ts'],
-    clearMocks: true,
-  },
-});
+export default defineConfig({test: {environment: 'jsdom', include: ['tests/unit/**/*.test.ts', 'tests/audit/**/*.test.ts'], clearMocks: true}})


### PR DESCRIPTION
## What

Wave 2 of unifying the estate TypeScript standard. Adopts the published
`@j0nathan-ll0yd/config@1.1.0` (dprint + tsconfig floor + ESLint flat-config) and
adds the two quality gates this repo lacked entirely: **type-checking** and **linting**.

Two commits, deliberately split for review:

1. **`feat(config)` — config + gates + fixes** (14 files). The mechanical churn is NOT here.
2. **`style` — `dprint fmt` reflow** (85 files). Pure formatting: 120->157 width, semicolons
   stripped (ASI), single quotes, no trailing commas. No behavioral change.

## Config (commit 1)

- **dprint**: `dprint.json` now `extends`
  `./node_modules/@j0nathan-ll0yd/config/dprint.json`; local `includes`/`excludes` kept
  (incl. `**/*.astro`). Local plugin/typescript/width settings removed (now inherited —
  this flips 120->157, semicolons->ASI, trailing-commas->never).
- **`.npmrc`** (committed): routes the `@j0nathan-ll0yd` scope to GitHub Packages with
  `_authToken=${GITHUB_TOKEN}` (npm expands it; CI uses the Actions token, local uses
  the machine `~/.npmrc`).
- **tsconfig (array extends)**: `["astro/tsconfigs/strict", "@j0nathan-ll0yd/config/tsconfig-base.json"]`
  — the floor wins for its flags. New `typecheck` script -> `astro check`
  (`@astrojs/check` + `typescript` added).
- **ESLint**: new `eslint.config.mjs` = `createBaseConfig({ tsconfigRootDir: import.meta.dirname })`
  (type-aware). JS build scripts (`.mjs/.cjs/.js`) get Node globals + `disableTypeChecked`
  (also fixes the project-service parse error on `.puppeteerrc.cjs`). `tests/**` are ignored
  (excluded from the tsconfig project graph — a tests tsconfig is a follow-up). New `lint`
  script -> `eslint .`.

### Errors the new gates surfaced (fixed in commit 1)

- **typecheck**: 31 `noUncheckedIndexedAccess` violations, all in `src/lib/mobile-bg.ts` —
  fixed with explicit guards on constant-data / bounded-loop index access (no `!` assertions).
- **lint**: 146 -> 0. 128 `no-undef` + a parse error were config gaps (resolved by the JS
  Node-globals / non-type-checked block). 9 genuine findings fixed:
  floating/misused-promise (`void`) + `prefer-const` in `src/lib/runtime/{live-data,poll-engine}.ts`,
  and a dead-store in `scripts/audit/validate-sitemap.mjs`.

## Enforcement (both tiers)

- **Local (pre-push)**: previously ran ONLY the Docker visual suite. Now runs
  `format:check` -> `typecheck` -> `lint` first (always; `SKIP_VISUAL` does not skip them),
  then the visual suite. (pre-commit still auto-formats staged TS.)
- **CI**:
  - `format-check.yml`: switched from the standalone `dprint/check` action to
    `ci-setup.sh` + `npm run format:check`, because dprint must now resolve a **package**
    `extends` from `node_modules`. Grants `permissions: packages: read` + `GITHUB_TOKEN` so
    the `@j0nathan-ll0yd/config` install authenticates against GitHub Packages.
  - new **`static-checks.yml`**: `lint` + `typecheck` jobs (ubuntu-latest), same
    `ci-setup.sh` + `packages: read` + `GITHUB_TOKEN` pattern; the lint job runs
    `astro sync` first so type-aware ESLint can resolve `astro:content`.

## Dependency strategy

`typescript` is pinned to `^5` (`<6.0.0`). The latest published TypeScript is the native
**TS 7** line, but `@astrojs/check` (peer `^5 || ^6`) and `typescript-eslint` v8
(peer `>=4.8.4 <6.1.0`) both exclude it. Dependabot now skips `typescript` major bumps
(matching the existing `astro`/`@napi-rs/image` ignores).

## Verification

`format:check` clean, `eslint .` clean, `astro check` 0 errors, `npm test` 91/91 passing
(includes a real `astro build`).

Do not merge — review first.
