### PR TITLE
audit: point surfaces.yaml reference at atlas (monorepo hub retired)

### DIFF
--- a/scripts/audit/lib/http.mjs
+++ b/scripts/audit/lib/http.mjs
@@ -1,6 +1,6 @@
 // Shared HTTP helpers for scripts/audit/*.mjs. Every audit check fetches the
 // same live origins (jonathanlloyd.me + the staging CloudFront data plane,
-// which IS the live-serving data plane per monorepo-LifegamesPortal/surfaces.yaml)
+// which IS the live-serving data plane per atlas/surfaces.yaml)
 // and needs the same resilience: a transient 5xx in the seconds after a deploy
 // is not an outage (see web's tests/smoke/home.smoke.ts getStable(), issue #106)
 // but a steady-state 5xx still fails once the retry budget is spent.


### PR DESCRIPTION
One-line comment update in `scripts/audit/lib/http.mjs`: the surface registry that documents the staging CloudFront as the live-serving data plane moved from `monorepo-LifegamesPortal/surfaces.yaml` into `atlas/surfaces.yaml` (the `monorepo-LifegamesPortal` hub was retired 2026-07-20). No code change.

Pushed with `SKIP_VISUAL=1` (comment-only, no rendered-output change); the fast static gates (format:check / typecheck / lint) ran and passed.
