### PR TITLE
chore: resolve astro check hints (fix unreachable-code bugs)

### DIFF
--- a/.claude/principles/widget-checks.md
+++ b/.claude/principles/widget-checks.md
@@ -79,15 +79,15 @@ For full context, read the spec. For the new-widget workflow, use `/new-widget`.
 
 **Fix:** Add updater function that selects DOM elements by ID and updates content. Wire into `live-data.ts` poll callbacks.
 
-### W9: Inline Scripts — ES5 Only
+### W9: Inline Scripts — Externalized, ES2017 Syntax
 
-**Rule:** All JavaScript in `<script is:inline>` blocks MUST use ES5 syntax: `var`, `function` declarations, IIFEs. No `let`, `const`, arrow functions, or template literals.
+**Rule:** JavaScript in `<script is:inline>` blocks and any `public/js/*.js` runtime is served raw (never transpiled by Vite), so its syntax floor is **ES2017** — `const`/`let`, arrow functions, template literals, and `async`/`await` are all allowed. Avoid post-ES2017 syntax that lacks universal browser support. Rationale: raw-served scripts run directly in the browser, and this site's real floor (service workers, PWA, canvas islands) is well above ES5. Bundled module scripts (processed by Vite) may use any modern syntax. (Consistent with AGENTS.md "Raw scripts are ES2017".)
 
-**Production constraint:** CSP `script-src 'self'` rejects inline JS in production. `<script is:inline>` blocks WITH content (not `src=`) and inline `on*=` event handlers ARE forbidden in markup — they silently fail at runtime. Use `<script is:inline src="/js/..." defer>` to reference an external file under `public/js/`, and attach event listeners in those files (never as `on*=` attributes). The `npm run audit:inline-scripts` prebuild gate enforces this; bundled `<script>` (no `is:inline`) and `type="application/ld+json"` data scripts are exempt.
+**Production constraint:** CSP `script-src 'self'` rejects inline JS in production. `<script is:inline>` blocks WITH content (not `src=`) and inline `on*=` event handlers ARE forbidden in markup — they silently fail at runtime. Use `<script is:inline src="/js/..." defer>` to reference an external file under `public/js/`, and attach event listeners in those files (never as `on*=` attributes). The `npm run audit:inline-scripts` prebuild gate enforces this externalization/CSP rule — it checks _where_ scripts load and forbids `on*=` handlers, and does NOT constrain syntax; bundled `<script>` (no `is:inline`) and `type="application/ld+json"` data scripts are exempt.
 
-**Check:** Grep `<script is:inline>` blocks for `let `, `const `, `=>`, or backtick template literals. Run `npm run audit:inline-scripts` to confirm no inline `<script is:inline>` bodies or inline event handlers exist in `src/**/*.{astro,html}`.
+**Check:** Run `npm run audit:inline-scripts` to confirm no inline `<script is:inline>` bodies or inline event handlers exist in `src/**/*.{astro,html}`. Syntax is not gated — ES2017 features are fine in externalized `public/js/*.js`.
 
-**Fix:** Replace with `var`, `function` expressions, string concatenation. Extract any inline `<script is:inline>` body or `on*=` handler to a `public/js/*.js` file referenced via `<script is:inline src="..." defer>`.
+**Fix:** Extract any inline `<script is:inline>` body or `on*=` handler to a `public/js/*.js` file referenced via `<script is:inline src="..." defer>`. Modern ES2017 syntax (`const`/`let`, arrow functions, template literals, `async`/`await`) may be used freely in that externalized file.
 
 ---
 

--- a/.claude/skills/new-widget/SKILL.md
+++ b/.claude/skills/new-widget/SKILL.md
@@ -50,7 +50,7 @@ For production widgets, complete ALL of the following. Check off each item as yo
 - [ ] Import component in `src/pages/index.astro`
 - [ ] Load build-time data in frontmatter via `fs.readFileSync` (if applicable)
 - [ ] Render component with props in the appropriate dashboard column
-- [ ] Inline script uses ES5 only: `var`, `function`, IIFEs — no `let`/`const`/arrows
+- [ ] Inline script is externalized to `public/js/*.js` (CSP `script-src 'self'`) and may use ES2017 syntax: `const`/`let`, arrow functions, template literals, `async`/`await`
 
 ### Showcase
 
@@ -113,7 +113,7 @@ For sandbox widgets, complete this lighter checklist:
 
 ## Important Conventions
 
-- ES5 only in `<script is:inline>` blocks — this is a hard rule, violations break the build
+- Externalize scripts to `public/js/*.js` for CSP (`script-src 'self'`) — this is the hard rule the `audit:inline-scripts` gate enforces; raw-served script syntax may be ES2017 (`const`/`let`, arrow functions, template literals, `async`/`await`), which is NOT gated
 - Glass-morphism: `background: var(--glass-bg); border: 1px solid var(--glass-border); backdrop-filter: blur(var(--blur-md));`
 - Widget header right section: `.live-dot` + `.widget-timestamp[data-live="{endpoint}"]`
 - Image widgets: use `imgFallbackAttrs()` from `src/lib/image-utils.ts` for onerror fallback

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ Production widgets, CSS, and runtime scripts come from `@lifegames/web/productio
 
 - **No hardcoded values**: all colors, spacing, and typography come from `@lifegames/tokens` `var()` custom properties.
 - **No new widgets here**: never create `src/components/*.astro`; widgets belong in the Design System.
-- **Inline JS is ES5 only**: in `<script is:inline>` blocks and any `public/js/*.js`, use `var`, `function` declarations, and IIFEs -- no `let`/`const`/arrow functions/template literals. Bundled module scripts may use modern syntax.
-- **Externalize inline scripts**: all inline scripts live in `public/js/` for CSP compliance (10 total: `card-reveal`, `clock`, `leaflet-lazy`, `sa-loader`, `sa-stub`, `scroll-depth`, `sw-register`, `webmcp`, `book-modal`, `social-click-track`). CSP is `script-src 'self'` -- no `'unsafe-inline'`.
+- **Raw scripts are ES2017 (SYNTAX rule)**: `<script is:inline>` bodies and any `public/js/*.js` are served raw (never transpiled by Vite), so their syntax floor is **ES2017** -- `const`/`let`, arrow functions, template literals, and `async`/`await` are all allowed. The site's real browser floor (service workers, PWA, canvas islands) is well above ES5, and async/await has had universal browser support since 2017. Avoid post-ES2017 syntax that lacks universal support. Bundled module scripts (processed by Vite) may use any modern syntax. This rule governs SYNTAX only and is independent of the CSP externalization rule below (CSP dictates _where_ scripts load, not what syntax they use).
+- **Externalize inline scripts (CSP rule)**: all inline scripts live in `public/js/` for CSP compliance (10 total: `card-reveal`, `clock`, `leaflet-lazy`, `sa-loader`, `sa-stub`, `scroll-depth`, `sw-register`, `webmcp`, `book-modal`, `social-click-track`). CSP is `script-src 'self'` -- no `'unsafe-inline'`. This is a _where-scripts-load_ rule; it does not constrain syntax.
 - **No inline `on*=` handlers**: markup event attributes are CSP-rejected without `'unsafe-hashes'`; attach listeners in `public/js/*.js` instead.
 - **Inline-script gate**: `npm run audit:inline-scripts` runs as a prebuild gate. Any unavoidable inline JS requires a documented exception.
 - **SW precache gate (Astro 7)**: `scripts/check-sw-precache.mjs` runs in `postbuild` and asserts the Workbox precache manifest in `dist/sw.js` is populated (entry count >= 80% of built assets, app shell present). Catches the silent failure where the PWA build succeeds but ships an empty precache (offline broken) -- the specific risk from `@vite-pwa/astro` (peer-capped at astro ^5) driving Workbox under Vite 8 / Rolldown. The wrapper is kept working via `--legacy-peer-deps` (`.npmrc`) + a `vite-plugin-pwa ^1.3.0` `overrides` pin (`package.json`); see those files for the standing-workaround rationale.
@@ -88,7 +88,7 @@ Production widgets, CSS, and runtime scripts come from `@lifegames/web/productio
 
 ## Do Not
 
-- Use ES6+ syntax in inline scripts.
+- Rely on post-ES2017 syntax in raw-served scripts (`public/js/*.js`, `<script is:inline>` bodies). ES2017 -- `const`/`let`, arrow functions, template literals, `async`/`await` -- is allowed; only avoid newer syntax that lacks universal browser support.
 - Create new `src/components/*.astro` files or hand-edit CSS (everything comes from the DS).
 - Import from relative `../lib/` or `../scripts/` paths instead of the `@lifegames/*` namespace.
 - Hardcode hex colors or pixel values.

--- a/docs/wiki/LLM-Content-Spec.md
+++ b/docs/wiki/LLM-Content-Spec.md
@@ -156,7 +156,7 @@ This is required because Cloudflare Pages caches HTML at the edge and bypasses P
 | OAuth Protected Resource | SKIP | No auth surface (static portfolio) |
 | MCP Server Card | PASS | Static JSON file |
 | Agent Skills | PASS | Static JSON + SKILL.md |
-| WebMCP | PASS | Inline ES5 script with feature detection |
+| WebMCP | PASS | External ES2017 async script with feature detection |
 
 ## Consumers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@lifegames/schemas": "file:.yalc/@lifegames/schemas",
         "@lifegames/tokens": "file:.yalc/@lifegames/tokens",
         "@lifegames/web": "file:.yalc/@lifegames/web",
-        "astro": "^7.1.3"
+        "astro": "^7.1.3",
+        "fast-xml-validator": "^1.4.0"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
@@ -5109,6 +5110,64 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodable/base-output-builder": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/base-output-builder/-/base-output-builder-2.0.0.tgz",
+      "integrity": "sha512-DECrOg3zZuhOx2Iesj1mkINjFvasP3HV3pjGBs3A104V4zJIZJOeqOzF5qNWRl17oGheNsfnqINwUBVu6n7wrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.6.1",
+        "strnum": "^2.4.1"
+      }
+    },
+    "node_modules/@nodable/base-output-builder/node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@nodable/base-output-builder/node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@nodable/compact-builder": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/compact-builder/-/compact-builder-2.0.0.tgz",
+      "integrity": "sha512-TLyrdyV+KIh9n7waO45m9LsbxpoNXkHfXmQ4tWgXJynsJwCCZm2qT5NFvcjzWq3AN+tsA7XpmQOwAC5vbqzjkg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/base-output-builder": "^2.0.0",
+        "path-expression-matcher": "^1.6.1"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
@@ -5121,6 +5180,24 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@nodable/flexible-xml-parser": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@nodable/flexible-xml-parser/-/flexible-xml-parser-1.11.2.tgz",
+      "integrity": "sha512-vX3/kbIuUKJ+CPNz1zR3TmV2xtOClcAdNoT4PfiGFo5hMmdfZHMD5RlORrAIvuWg52m3dD+O1FuuAC8Hmkd7yg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/base-output-builder": "^2.0.0",
+        "@nodable/compact-builder": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
@@ -7188,7 +7265,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
       "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9397,6 +9473,17 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detailed-xml-validator": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/detailed-xml-validator/-/detailed-xml-validator-2.2.0.tgz",
+      "integrity": "sha512-dffr/kTqIqq2BpybOEddhQRF1KBQcLdKHww9/urAKwZC1+epDnPnbT5IOb0ffCT4QTioAvKYEsojXeOYk030UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/base-output-builder": "^2.0.0",
+        "@nodable/compact-builder": "^2.0.0",
+        "@nodable/flexible-xml-parser": "^1.11.2"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -10636,6 +10723,23 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fast-xml-validator": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-validator/-/fast-xml-validator-1.4.0.tgz",
+      "integrity": "sha512-GULVy05S3NMGFrRhKge84olosODhSIYbYmIrEigfBR/dXSQRdLh6Oz6rEoYxHFHTyPTaOUuaz2vJXkcHn/e/Tg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "detailed-xml-validator": "^2.2.0",
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
       }
     },
     "node_modules/fd-slicer": {
@@ -14699,7 +14803,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
       "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16569,7 +16672,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
       "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19415,7 +19517,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
       "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "@lifegames/schemas": "file:.yalc/@lifegames/schemas",
     "@lifegames/tokens": "file:.yalc/@lifegames/tokens",
     "@lifegames/web": "file:.yalc/@lifegames/web",
-    "astro": "^7.1.3"
+    "astro": "^7.1.3",
+    "fast-xml-validator": "^1.4.0"
   },
   "overrides": {
     "vite-plugin-pwa": "^1.3.0"

--- a/public/js/webmcp.js
+++ b/public/js/webmcp.js
@@ -50,16 +50,14 @@
           name: 'get_current_reading',
           description: 'Fetches the current bookshelf from the live API and returns books being read, up next, and recently finished.',
           inputSchema: { type: 'object', properties: {}, required: [] },
-          execute: function() {
-            return fetch('https://d1pfm520aduift.cloudfront.net/books.json')
-              .then(function(res) { return res.json(); })
-              .then(function(data) {
-                var books = data.books || [];
-                var reading = books.filter(function(b) { return b.status === 'reading'; });
-                var upNext = books.filter(function(b) { return b.status === 'up-next'; });
-                var finished = books.filter(function(b) { return b.status === 'finished'; }).slice(0, 5);
-                return { content: [{ type: 'text', text: JSON.stringify({ reading: reading, upNext: upNext, recentlyFinished: finished }) }] };
-              });
+          execute: async function() {
+            const res = await fetch('https://d1pfm520aduift.cloudfront.net/books.json');
+            const data = await res.json();
+            const books = data.books || [];
+            const reading = books.filter((b) => b.status === 'reading');
+            const upNext = books.filter((b) => b.status === 'up-next');
+            const finished = books.filter((b) => b.status === 'finished').slice(0, 5);
+            return { content: [{ type: 'text', text: JSON.stringify({ reading, upNext, recentlyFinished: finished }) }] };
           }
         },
         {

--- a/scripts/audit/check-feeds.mjs
+++ b/scripts/audit/check-feeds.mjs
@@ -27,6 +27,19 @@ export function validateFeedXml(xml, now = new Date()) {
   // -- fast-xml-parser recovers rather than erroring). XMLValidator.validate()
   // is the library's own stricter well-formedness check (bundled, no new
   // dependency) and is what actually catches malformed XML.
+  //
+  // NB (deprecation, deliberately retained): fast-xml-parser v5 flags
+  // XMLValidator @deprecated because it split validation into the SEPARATE
+  // `fast-xml-validator` package -- every in-package validation path
+  // (XMLValidator.validate + the XMLParser.parse validationOptions overload) is
+  // deprecated, and no non-deprecated same-package alternative exists. Adopting
+  // fast-xml-validator would add a new runtime dependency, which this file's
+  // design explicitly avoids; the deprecated API is fully functional, so the
+  // ts6385 hint is accepted rather than resolved by taking on a dependency.
+  // This is unrelated to GHSA-8r6m-32jq-jx6q (DOCTYPE entity-expansion DoS):
+  // that is patched in the pinned fast-xml-parser 5.10.1 -- `npm audit` is clean
+  // here, so this repo is not vulnerable (the sibling repos flagged by the
+  // advisory are on an older 5.9.3-5.10.0 and need the 5.10.1 bump, not us).
   const validation = XMLValidator.validate(xml)
   if (validation !== true) {
     return [{

--- a/scripts/audit/check-feeds.mjs
+++ b/scripts/audit/check-feeds.mjs
@@ -10,7 +10,8 @@
 // structural parsing already gives us -- the same judgment call the plan
 // makes for CrUX/PSI (D10).
 
-import {XMLParser, XMLValidator} from 'fast-xml-parser'
+import {XMLParser} from 'fast-xml-parser'
+import {SyntaxValidator} from 'fast-xml-validator'
 import {SITE_URL} from '@lifegames/portal-contract/constants'
 import {fetchStable, isMain, report} from './lib/http.mjs'
 
@@ -24,29 +25,24 @@ export function validateFeedXml(xml, now = new Date()) {
 
   // XMLParser.parse() is deliberately lenient (verified: it does not throw on
   // `<rss><channel><title>unclosed`, mismatched tags, or even `<<<garbage>>>`
-  // -- fast-xml-parser recovers rather than erroring). XMLValidator.validate()
-  // is the library's own stricter well-formedness check (bundled, no new
-  // dependency) and is what actually catches malformed XML.
+  // -- fast-xml-parser recovers rather than erroring). fast-xml-validator's
+  // SyntaxValidator is the stricter well-formedness check that actually catches
+  // malformed XML.
   //
-  // NB (deprecation, deliberately retained): fast-xml-parser v5 flags
-  // XMLValidator @deprecated because it split validation into the SEPARATE
-  // `fast-xml-validator` package -- every in-package validation path
-  // (XMLValidator.validate + the XMLParser.parse validationOptions overload) is
-  // deprecated, and no non-deprecated same-package alternative exists. Adopting
-  // fast-xml-validator would add a new runtime dependency, which this file's
-  // design explicitly avoids; the deprecated API is fully functional, so the
-  // ts6385 hint is accepted rather than resolved by taking on a dependency.
-  // This is unrelated to GHSA-8r6m-32jq-jx6q (DOCTYPE entity-expansion DoS):
-  // that is patched in the pinned fast-xml-parser 5.10.1 -- `npm audit` is clean
-  // here, so this repo is not vulnerable (the sibling repos flagged by the
-  // advisory are on an older 5.9.3-5.10.0 and need the 5.10.1 bump, not us).
-  const validation = XMLValidator.validate(xml)
-  if (validation !== true) {
-    return [{
-      severity: 'fail',
-      id: 'feed-xml-parse',
-      message: `not well-formed XML (${validation.err.code} at line ${validation.err.line}): ${validation.err.msg}`
-    }]
+  // Migration: fast-xml-parser v5 deprecated its bundled XMLValidator (and the
+  // XMLParser.parse validationOptions overload), splitting validation into the
+  // SEPARATE `fast-xml-validator` package from the same maintainer
+  // (NaturalIntelligence). SyntaxValidator.validate() is the non-deprecated
+  // successor. Behavioral note: XMLValidator.validate() RETURNED
+  // `true | ValidationError`, whereas SyntaxValidator.validate() returns `true`
+  // on success and THROWS a ValidationError (`.code` / `.line` / `.col` /
+  // `.message`) on malformed XML -- so we wrap it in try/catch to preserve this
+  // function's return-a-finding, never-throw contract. Same inputs -> same
+  // pass/fail semantics on the feeds.
+  try {
+    SyntaxValidator.validate(xml)
+  } catch (err) {
+    return [{severity: 'fail', id: 'feed-xml-parse', message: `not well-formed XML (${err.code} at line ${err.line}): ${err.message}`}]
   }
 
   const parser = new XMLParser({ignoreAttributes: false, attributeNamePrefix: '@_'})

--- a/scripts/audit/check-security-txt.mjs
+++ b/scripts/audit/check-security-txt.mjs
@@ -59,14 +59,12 @@ async function main() {
       process.exit(report('check-security-txt', [
         {severity: 'fail', id: 'security-txt-fetch', message: `HTTP ${res.status} fetching ${SECURITY_TXT_URL}`}
       ]))
-      return
     }
     body = await res.text()
   } catch (err) {
     process.exit(report('check-security-txt', [
       {severity: 'fail', id: 'security-txt-fetch', message: `fetch failed: ${err.message}`}
     ]))
-    return
   }
 
   process.exit(report('check-security-txt', validateSecurityTxt(body)))

--- a/scripts/audit/validate-robots.mjs
+++ b/scripts/audit/validate-robots.mjs
@@ -97,14 +97,12 @@ async function main() {
       process.exit(report('validate-robots', [
         {severity: 'fail', id: 'robots-fetch', message: `HTTP ${res.status} fetching ${ROBOTS_URL}`}
       ]))
-      return
     }
     body = await res.text()
   } catch (err) {
     process.exit(report('validate-robots', [
       {severity: 'fail', id: 'robots-fetch', message: `fetch failed: ${err.message}`}
     ]))
-    return
   }
 
   const golden = JSON.parse(readFileSync(GOLDEN_PATH, 'utf-8'))

--- a/scripts/audit/validate-sitemap.mjs
+++ b/scripts/audit/validate-sitemap.mjs
@@ -60,13 +60,11 @@ async function main() {
     process.exit(report('validate-sitemap', [
       {severity: 'fail', id: 'sitemap-index-fetch', message: `fetch failed: ${err.message}`}
     ]))
-    return
   }
   if (!indexRes.ok) {
     process.exit(report('validate-sitemap', [
       {severity: 'fail', id: 'sitemap-index-fetch', message: `HTTP ${indexRes.status} fetching ${SITEMAP_INDEX_URL}`}
     ]))
-    return
   }
   const indexXml = await indexRes.text()
   const indexPath = path.join(tmpDir, 'sitemap-index.xml')

--- a/scripts/generate-webmcp.mjs
+++ b/scripts/generate-webmcp.mjs
@@ -99,16 +99,14 @@ ${dataSourceLines}
           name: 'get_current_reading',
           description: ${sq(copyLlm.mcp.toolGetCurrentReading)},
           inputSchema: { type: 'object', properties: {}, required: [] },
-          execute: function() {
-            return fetch(${sq(booksUrl)})
-              .then(function(res) { return res.json(); })
-              .then(function(data) {
-                var books = data.books || [];
-                var reading = books.filter(function(b) { return b.status === 'reading'; });
-                var upNext = books.filter(function(b) { return b.status === 'up-next'; });
-                var finished = books.filter(function(b) { return b.status === 'finished'; }).slice(0, 5);
-                return { content: [{ type: 'text', text: JSON.stringify({ reading: reading, upNext: upNext, recentlyFinished: finished }) }] };
-              });
+          execute: async function() {
+            const res = await fetch(${sq(booksUrl)});
+            const data = await res.json();
+            const books = data.books || [];
+            const reading = books.filter((b) => b.status === 'reading');
+            const upNext = books.filter((b) => b.status === 'up-next');
+            const finished = books.filter((b) => b.status === 'finished').slice(0, 5);
+            return { content: [{ type: 'text', text: JSON.stringify({ reading, upNext, recentlyFinished: finished }) }] };
           }
         },
         {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": ["astro/tsconfigs/strict", "@j0nathan-ll0yd/config/tsconfig-base.json"],
-  "exclude": ["tests/**", "public/vendor/**"]
+  "exclude": ["tests/**", "public/vendor/**", "dist/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": ["astro/tsconfigs/strict", "@j0nathan-ll0yd/config/tsconfig-base.json"],
-  "exclude": ["tests/**"]
+  "exclude": ["tests/**", "public/vendor/**"]
 }


### PR DESCRIPTION
> **Update (6 commits — final: 0 hints):** the two follow-ups, a user-approved dependency adoption, and a W9 doc sync were folded in as separate commits. Final state is **0 errors / 0 warnings / 0 hints** — see "Final update" and "W9 doc sync" at the bottom. Hint figures earlier in this description refer to earlier commits only.

## Summary

`astro check` (`npm run typecheck`) passed with 0 errors / 0 warnings but emitted a batch of `ts` **hints**. This PR resolves every actionable hint in our own code and removes the vendored-bundle noise, dropping the count from ~29 hints to **3 intentionally-retained hints** (all documented below). `npm run lint` and the audit unit suite stay green.

Before: `0 errors, 0 warnings, 29 hints`
After: `0 errors, 0 warnings, 3 hints` (see "Residual hints, intentionally left")

## ts(7027) Unreachable code — the real finding

Six `ts(7027) Unreachable code detected` hints, all the same shape: a `return` statement immediately after `process.exit(...)`.

`process.exit()` has return type `never`, so any statement after it is provably unreachable. In each case the trailing `return` was **defensive belt-and-suspenders, not a control-flow bug** — the scripts already behaved correctly (process.exit terminates the process), so the `return` could never execute. No live code was stranded; nothing downstream was being skipped. TypeScript's own control-flow analysis relies on the `never` return to prove the following statements/variables are safe (e.g. `body` is definitely assigned), which is exactly why the returns were redundant.

Fix: delete the dead `return`s. Behavior-preserving (16 audit unit tests still pass).

| File                                   | Line | Before                                                              | After            |
| -------------------------------------- | ---- | ------------------------------------------------------------------- | ---------------- |
| `scripts/audit/validate-robots.mjs`    | 100  | `process.exit(...)` then dead `return` (inside `if (!res.ok)`)      | `return` removed |
| `scripts/audit/validate-robots.mjs`    | 107  | `process.exit(...)` then dead `return` (inside `catch`)             | `return` removed |
| `scripts/audit/validate-sitemap.mjs`   | 63   | `process.exit(...)` then dead `return` (inside `catch`)             | `return` removed |
| `scripts/audit/validate-sitemap.mjs`   | 69   | `process.exit(...)` then dead `return` (inside `if (!indexRes.ok)`) | `return` removed |
| `scripts/audit/check-security-txt.mjs` | 62   | `process.exit(...)` then dead `return` (inside `if (!res.ok)`)      | `return` removed |
| `scripts/audit/check-security-txt.mjs` | 69   | `process.exit(...)` then dead `return` (inside `catch`)             | `return` removed |

**Real bug surfaced?** No latent behavioral bug — the code was already correct. The value of the hint here is dead-code hygiene: these returns falsely implied that `process.exit` might return.

## Vendored leaflet bundle — excluded from type-checking

~20 hints (`ts2568`, `ts2570`, `ts6133`, `ts6385`, `ts80002`) originated **inside** `public/vendor/leaflet/leaflet.js`, a 147 KB minified third-party bundle we do not author.

Root cause: the base Astro tsconfig sets `include: ["**/*"]` with `allowJs: true`, so `astro check` pulled the vendored bundle into the TS program. Nothing in `src/` imports it as a module (only a `<link>` to `leaflet.css` in `Dashboard.astro`), so removing it from the checked set is **side-effect-free** — it changes no runtime/build output, only what `astro check` type-checks.

Fix (`tsconfig.json`): add `"public/vendor/**"` to `exclude`. Narrowly scoped to the vendored dir so `public/js/*` stays type-checked. This drops the checked file count by exactly one (65 → 64) and clears all leaflet hints. No vendored source was touched.

## Residual hints, intentionally left (3)

| Hint                                                   | Location                              | Why left                                                                                                                                                                                                                                                                                                                                                                 |
| ------------------------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `ts6385` `'XMLValidator' is deprecated` (x2)           | `scripts/audit/check-feeds.mjs:13,30` | fast-xml-parser v5 moved validation to a **separate, uninstalled `fast-xml-validator` package**. Migrating adds a new runtime dependency, directly contradicting the documented "bundled, no new dependency" design rationale in `check-feeds.mjs:25-29`. The deprecated API is fully functional. A dependency decision, not a hint fix — deferred to a maintainer call. |
| `ts80006` `may be converted to an async function` (x1) | `public/js/webmcp.js:53`              | `public/js/*.js` is **ES5-only** per the CSP/inline-script rule in `AGENTS.md` (no async/arrow/`const`). `async` is ES2017; converting would break the hard constraint. Not editable without violating the rule.                                                                                                                                                         |

None of the 3 is vendored residue — the vendored (leaflet) residue is now **zero**. Suppressing these three would mean either adding a dependency or weakening a documented constraint, so they are left honest rather than hidden.

## Verification

- `npm run typecheck` -> `0 errors, 0 warnings, 3 hints` (the 3 above)
- `npm run lint` -> clean (0/0)
- `npx vitest ... validate-robots validate-sitemap check-security-txt` -> 16/16 pass
- `node --check` on all three edited scripts -> OK

Non-visual change (config + Node audit scripts); pushed with `SKIP_VISUAL=1` as the pre-push Docker visual suite has no bearing here.

---

# Follow-up: Task A (fast-xml-parser) + Task B (ES2017 policy + webmcp async)

Two approved follow-up tasks were folded into this PR as **separate commits**. Combined with the original work, the hint count is now **0 errors / 0 warnings / 2 hints** (both documented below and intentionally retained).

## Task B — ES2017 policy for raw scripts + webmcp async (`ts80006` cleared)

Commit: `policy: allow ES2017 in raw public/js scripts; convert webmcp tool to async`

**Root cause of the confusion:** `AGENTS.md` conflated two unrelated rules — (1) CSP `script-src 'self'` requires scripts be **externalized** into `public/js/` (about _where_ scripts load) and (2) a separate **ES5 syntax floor** for raw-served files. CSP does not require ES5; `async`/`await` is ES2017 with universal browser support since 2017, and this site's real browser floor (service workers, PWA, canvas islands) is well above ES5.

**What the `audit:inline-scripts` gate actually enforces (investigated first):** CSP/externalization **only**. It flags (a) `<script is:inline>` with a non-empty body and (b) inline `on*=` event-handler attributes (in `src/**` markup and in `public/js/*.js` innerHTML strings). It does **not** inspect for `let`/`const`/arrow/`async` syntax anywhere. So the "ES5-only" rule was a pure prose convention with **no syntax gate** — the gate needed **no change** (Task B step 3).

**Changes:**

- `AGENTS.md`: split the two rules cleanly — the syntax rule for `<script is:inline>` bodies and `public/js/*.js` is now **ES2017** (`const`/`let`, arrow functions, template literals, `async`/`await`); the externalization rule stays a CSP-only _where-scripts-load_ rule. Fixed the "Do Not → use ES6+ syntax in inline scripts" line to match.
- Converted the webmcp `get_current_reading` tool from a `.then()` chain to clean `async`/`await`. `public/js/webmcp.js` is **generated**, so the edit was made in the generator (`scripts/generate-webmcp.mjs`) and the output regenerated (the 4 `.well-known/*.json` the generator also emits stayed byte-identical).

**Verification:** `ts80006` gone; `npm run lint` clean; `npm run audit:inline-scripts` passes (async file does not trip it — confirming CSP-only); `npm run build` succeeds end-to-end; the async `webmcp.js` ships to `dist/js/webmcp.js`; 66/66 audit unit tests pass; dprint clean.

## Task A — fast-xml-parser `XMLValidator` deprecation (`ts6385` x2, retained with rationale)

Commit: `docs(audit): document why fast-xml-parser XMLValidator deprecation is retained`

**Finding — the deprecation is not fixable by an upgrade here:**

- This repo is already on **`fast-xml-parser@5.10.1`, the latest published version** — there is no newer version to bump to.
- In v5 the **entire in-package validation surface is deprecated**: both `XMLValidator.validate()` and the `XMLParser.parse(xml, validationOptions)` overload point to a **separate `fast-xml-validator` package**. There is **no non-deprecated same-package path** (no throwing/strict constructor option; `XMLParser.parse` is deliberately lenient here). Clearing the hint would require adopting a **new runtime dependency**, which `check-feeds.mjs`'s design explicitly avoids → per Task A step 3, **STOP and report rather than force it**.

**On the sibling security advisory (GHSA-8r6m-32jq-jx6q):** it is a _repeated-DOCTYPE entity-expansion DoS_, vulnerable `>=5.9.3 <5.10.1`, **patched in 5.10.1**. This repo is on 5.10.1 and `npm audit` is **clean** — **not vulnerable**. The advisory shown on `mantle-LifegamesPortal` / `mantle` is a **their-side bump to 5.10.1**, unrelated to (and does not fix) the deprecation. So the premise "same root cause = outdated version" does not hold for this repo.

**Action:** recorded the verified finding as a durable code comment in `check-feeds.mjs` so it is not re-investigated. The 2 `ts6385` hints remain **by design**; resolving them is a dependency decision left to the maintainer.

## Final hint count

| Hint                       | Location                           | Status                                                   |
| -------------------------- | ---------------------------------- | -------------------------------------------------------- |
| `ts7027` unreachable (x6)  | 3 audit scripts                    | ✅ fixed (original commit)                               |
| ~20 leaflet hints          | `public/vendor/leaflet/leaflet.js` | ✅ excluded (original commit)                            |
| `ts80006` async            | `public/js/webmcp.js`              | ✅ fixed (Task B)                                        |
| `ts6385` XMLValidator (x2) | `scripts/audit/check-feeds.mjs`    | ⏸ retained — needs a new dependency; documented (Task A) |

**`npm run typecheck` → 0 errors, 0 warnings, 2 hints.** Vendored residue: **0**. The remaining 2 are non-vendored and only clearable by adding `fast-xml-validator` (a maintainer's dependency call).

---

# Final update: 0 hints reached — adopted `fast-xml-validator`

The user accepted the new runtime dependency to clear the last 2 `ts6385` hints. `astro check` is now **0 errors / 0 warnings / 0 hints**.

## Adopt `fast-xml-validator` (`ts6385` x2 → cleared)

Commit: `deps: adopt fast-xml-validator, clear XMLValidator deprecation`

- **Package vetted:** `fast-xml-validator@1.4.0` — MIT, published by `amitgupta` (the same NaturalIntelligence maintainer as `fast-xml-parser`), actively maintained. This is exactly the package v5's deprecation notice redirects to.
- **Migration:** `scripts/audit/check-feeds.mjs` now imports `SyntaxValidator` from `fast-xml-validator` instead of the deprecated `XMLValidator` from `fast-xml-parser`; `XMLParser` (non-deprecated) still does the actual parse.
- **Behavior preserved (important nuance):** unlike `XMLValidator.validate()` which _returned_ `true | ValidationError`, `SyntaxValidator.validate()` returns `true` on well-formed XML but **throws** a `ValidationError` (`.code`/`.line`/`.col`/`.message`) on malformed XML. The call is wrapped in `try/catch` so `validateFeedXml()` keeps its return-a-finding, never-throw contract and emits the identical `feed-xml-parse` finding. All 66 audit unit tests pass, including the not-well-formed-XML case.
- **No new advisory:** the new subtree (`fast-xml-validator` + `detailed-xml-validator`; `path-expression-matcher`/`xml-naming` were already present via `fast-xml-parser`) is clean in `npm audit`. The repo's total advisory count is unchanged (16, all pre-existing — `ws`, `uuid`, etc.).

## Restore `dist/**` exclusion in `tsconfig.json` (incidental durable fix)

Commit: `build: exclude dist/** from astro check (restore base-config intent)`

Discovered while verifying 0 hints: the child `tsconfig` `exclude` array _replaces_ (does not merge with) the base Astro config's `["dist"]`, so `dist/` was being type-checked whenever a local build existed — surfacing ~25 spurious hints from minified `dist/_astro/*.js` and the vendored `dist/workbox` bundle. CI (clean checkout) never saw these, but local typecheck-after-build did. Re-added `dist/**` to `exclude` (side-effect-free — nothing in `src` imports `dist`), so `npm run typecheck` is a stable **0/0/0** regardless of build state.

## Final hint count: **0 / 0 / 0**

| Hint                               | Location                           | Status                                    |
| ---------------------------------- | ---------------------------------- | ----------------------------------------- |
| `ts7027` unreachable (x6)          | 3 audit scripts                    | ✅ fixed                                  |
| ~20 leaflet hints                  | `public/vendor/leaflet/leaflet.js` | ✅ excluded                               |
| `ts80006` async                    | `public/js/webmcp.js`              | ✅ fixed (ES2017 policy)                  |
| `ts6385` XMLValidator (x2)         | `scripts/audit/check-feeds.mjs`    | ✅ fixed (fast-xml-validator)             |
| ~25 `dist/**` build-artifact hints | `dist/_astro/*`, `dist/workbox*`   | ✅ excluded (base-config intent restored) |

**`npm run typecheck` → 0 errors, 0 warnings, 0 hints.** Lint clean · build succeeds · `audit:inline-scripts` passes · dprint clean · 66/66 audit unit tests · `npm audit` adds no new advisory.

---

# W9 doc sync (final straggler)

Commit: `docs: sync W9 inline-script check to ES2017 (match AGENTS.md)`

This branch relaxed AGENTS.md's raw-inline-script syntax floor from ES5 → ES2017, but the parallel agent-facing rule docs still said "ES5 only", contradicting AGENTS.md **on the same branch**. W9 is **prose-only** — no gate enforces inline-script _syntax_ (`audit:inline-scripts` checks CSP/externalization only; eslint sets no ES5 `ecmaVersion`) — so this is a documentation sync.

- **`.claude/principles/widget-checks.md` — W9:** retitled _"Inline Scripts — ES5 Only"_ → _"Inline Scripts — Externalized, ES2017 Syntax"_. Syntax floor is now ES2017 (`const`/`let`, arrow functions, template literals, `async`/`await`). **Kept** the CSP/externalization requirement (externalize to `public/js/`, no inline `on*=` handlers) and clarified that `audit:inline-scripts` enforces _where_ scripts load, not their syntax.
- **`.claude/skills/new-widget/SKILL.md`:** updated the dashboard-integration checklist item and the "Important Conventions" line (which wrongly claimed _"ES5 only … violations break the build"_ — nothing enforces syntax) to the externalize-for-CSP + ES2017-syntax-allowed policy.

**Confirmed nothing enforces ES5 syntax off W9.** The one genuine ES5 _enforcement_ in the repo — `tests/build/sw-update.test.ts` — is scoped **only** to `dist/js/sw-register.js` (an independent service-worker-registration compat rail, not W9). It does not conflict: ES2017 is now _permitted, not mandated_, so that file may stay ES5. Left unchanged intentionally.

**Remaining ES5 references (all descriptive/generated/served — not authoring mandates; left for a separate call):**

- `docs/wiki/LLM-Content-Spec.md:159` — a status-table row still calls WebMCP an "Inline ES5 script" (now stale — webmcp is `async` on this branch). Not fixed here because the repo's markdown auto-formatter reflows the entire file (all tables) on any edit, which would bundle ~30 lines of unrelated cosmetic churn into this doc-sync commit. Flagged for a standalone cleanup.
- `docs/claude-design/DESIGN.md:176` — **generated** (regenerate via the `/update-claude-design` skill; do not hand-edit).
- `docs/wiki/Astro-Implementation.md:145`, `public/.well-known/agent-skills/portfolio-expert/SKILL.md:62` — descriptive/served copy about the existing (still-ES5) scripts.
- Code comments in `public/js/*.js` and `scripts/audit-inline-scripts.mjs` — accurately describe those specific still-ES5 files; the relaxed policy permits ES2017 but does not require rewriting them.
