### PR TITLE
fix(audit-web): self-provision issue labels + real end-to-end SA ingestion check

### DIFF
--- a/scripts/audit/check-analytics.mjs
+++ b/scripts/audit/check-analytics.mjs
@@ -19,6 +19,14 @@
 // only fires on pagehide/visibilitychange, not on initial load -- it is NOT
 // asserted here to keep this check fast and deterministic; the pageview pixel
 // already proves the SA collection path is wired end-to-end.
+//
+// When SA_API_KEY is set, a second, server-side check proves the SA INGESTION
+// pipeline works END TO END: it fires a synthetic SA event through the
+// first-party /simple/events proxy and polls the Stats API until that event's
+// count increments (an after > before delta). See checkSaIngestion for the
+// empirical basis (the headless browser beacon is bot-filtered and never
+// counted; a server-side EVENT is, in ~11-32s, and doesn't distort real
+// pageview metrics).
 
 import {chromium} from '@playwright/test'
 import {SITE_URL} from '@lifegames/portal-contract/constants'
@@ -95,37 +103,163 @@ export function evaluateBeacons(seen) {
   return findings
 }
 
-/** Optional server-side confirmation via the SA Stats API (https://simpleanalytics.com/{hostname}.json). */
-async function checkSaStatsApi(apiKey) {
-  const hostname = new URL(SITE_URL).hostname
-  const url = `https://simpleanalytics.com/${hostname}.json?version=5&fields=pageviews&start=today&end=today`
+// --- SA end-to-end ingestion check (trigger a synthetic event, then confirm) ---
+//
+// This is a REAL end-to-end pipeline test: fire a server-side Simple Analytics
+// EVENT through our own first-party proxy, then poll the SA Stats API until the
+// event's count increments (an after > before DELTA). It confirms
+// first-party proxy -> SA collector -> ingestion -> Stats API, unambiguously.
+//
+// The design was chosen EMPIRICALLY (not from docs) -- see the PR thread on #150
+// for the full experiment log. Key measured facts against the live account:
+//   1. The client-side headless beacon is NOT counted. SA's own script stamps
+//      `bot=true` in the pixel params when it detects the automated browser
+//      (HeadlessChrome UA / navigator.webdriver), so a Playwright-driven page
+//      load can never be confirmed via the API -- proven: a real-UA, bot=false,
+//      residential-IP pixel replay to a unique path stayed at 0 pageviews for
+//      7+ minutes.
+//   2. A server-side EVENT posted to the SA collect API (`/simple/events` proxy
+//      -> queue.simpleanalyticscdn.com) with a realistic UA IS counted, and is
+//      queryable via `?fields=pageviews&events=<name>` -> `events:[{name,total}]`.
+//      Measured ingestion latency: ~11-32s, including from a GitHub Actions
+//      Azure datacenter IP (the proxy forwards CF-Connecting-IP as
+//      X-Forwarded-For, so SA sees the runner IP -- it is NOT datacenter-filtered
+//      here). This is why the poll below only needs a few-minute budget.
+//   3. We use an EVENT, not a pageview, on purpose: events are separate from
+//      pageviews/visitors in SA, so the daily synthetic signal does NOT distort
+//      this low-traffic site's real pageview metrics (a synthetic pageview would
+//      roughly double them). One fixed event name = one tidy dashboard row.
+const INGESTION_EVENT_NAME = 'audit_ingestion_probe'
+// Realistic desktop Chrome UA -- avoids SA's server-side UA reject-list
+// (bot/crawl/curl/node-fetch/axios/...) that would classify the event as a bot.
+const SYNTHETIC_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36'
+const INGESTION_POLL_TIMEOUT_MS = 180_000 // measured latency ~11-32s; generous margin
+const INGESTION_POLL_INTERVAL_MS = 15_000
+// 2-day UTC window (today-1d..today) so the just-fired event is always inside
+// the window even if the run straddles UTC midnight. timezone=UTC is pinned
+// because the Stats API otherwise defaults to the site's dashboard timezone
+// (docs.simpleanalytics.com/api/helpers).
+const SA_QUERY_WINDOW_DAYS = 1
+
+/** Pure: Stats API URL that returns the count for a named event. */
+export function saEventsQueryUrl(hostname, eventName, windowDays) {
+  const params = new URLSearchParams({version: '6', fields: 'pageviews', events: eventName, start: `today-${windowDays}d`, end: 'today', timezone: 'UTC'})
+  return `https://simpleanalytics.com/${hostname}.json?${params}`
+}
+
+/** Pure: extract a named event's total from a Stats API response (0 if absent). */
+export function eventTotal(json, eventName) {
+  const ev = Array.isArray(json?.events) ? json.events.find((e) => e?.name === eventName) : null
+  return ev && typeof ev.total === 'number' ? ev.total : 0
+}
+
+/** Pure: the server-side SA event payload (POSTed to the /simple/events proxy). */
+export function syntheticEventPayload(hostname, eventName, ua) {
+  return {type: 'event', hostname, event: eventName, ua, unique: true}
+}
+
+/**
+ * Pure decision -> findings[]. Testable without network. Given the resolved
+ * outcome of the trigger-then-confirm flow, decide pass/fail:
+ *   - a pre-resolved I/O `error` -> fail (surfaced with its own id)
+ *   - after > before -> confirmed (info finding carrying the measured latency)
+ *   - otherwise -> the delta was never observed within the timeout -> fail
+ *
+ * @param {object} r
+ * @param {string} r.eventName
+ * @param {number} [r.before]
+ * @param {number} [r.after]
+ * @param {number} [r.elapsedMs]
+ * @param {number} [r.timeoutMs]
+ * @param {{id: string, message: string}} [r.error]
+ * @returns {Array<{severity: string, id: string, message: string}>}
+ */
+export function evaluateIngestion({eventName, before, after, elapsedMs, timeoutMs, error}) {
+  if (error) {
+    return [{severity: 'fail', id: error.id, message: error.message}]
+  }
+  if (typeof before === 'number' && typeof after === 'number' && after > before) {
+    return [{
+      severity: 'info',
+      id: 'analytics-sa-ingestion-confirmed',
+      message: `SA ingestion confirmed end-to-end: event "${eventName}" count ${before} -> ${after} in ~${
+        Math.round(elapsedMs / 1000)
+      }s (server-side POST -> SA collector -> Stats API).`
+    }]
+  }
+  return [{
+    severity: 'fail',
+    id: 'analytics-sa-ingestion-not-observed',
+    message: `SA ingestion NOT observed: event "${eventName}" count did not increase from ${before} within ${
+      Math.round(timeoutMs / 1000)
+    }s (last seen ${after}). The first-party proxy -> SA collector -> Stats API pipeline may be broken.`
+  }]
+}
+
+/** Read the current SA count for `eventName`. Network I/O; returns {ok, total} or {ok:false, error}. */
+async function readEventTotal(queryUrl, apiKey, eventName) {
   let res
   try {
-    res = await fetchStable(url, {headers: {'Api-Key': apiKey}})
+    res = await fetchStable(queryUrl, {headers: {'Api-Key': apiKey}})
   } catch (err) {
-    return [{severity: 'fail', id: 'analytics-sa-stats-api-fetch', message: `fetch failed: ${err.message}`}]
+    return {ok: false, error: {id: 'analytics-sa-stats-api-fetch', message: `Stats API fetch failed: ${err.message}`}}
   }
   let json
   try {
     json = await res.json()
   } catch (err) {
-    return [{severity: 'fail', id: 'analytics-sa-stats-api-parse', message: `${url} did not return valid JSON: ${err.message}`}]
+    return {ok: false, error: {id: 'analytics-sa-stats-api-parse', message: `Stats API did not return valid JSON: ${err.message}`}}
   }
-  if (!res.ok || json.ok !== true) {
-    return [{
-      severity: 'fail',
-      id: 'analytics-sa-stats-api-error',
-      message: `SA Stats API returned an error (HTTP ${res.status}): ${json.error ?? '(no error field)'}`
-    }]
+  if (!res.ok || json?.ok !== true) {
+    return {ok: false, error: {id: 'analytics-sa-stats-api-error', message: `SA Stats API error (HTTP ${res.status}): ${json?.error ?? '(no error field)'}`}}
   }
-  if (!(typeof json.pageviews === 'number' && json.pageviews > 0)) {
-    return [{
-      severity: 'fail',
-      id: 'analytics-sa-stats-api-zero-pageviews',
-      message: `SA Stats API reports ${json.pageviews ?? 0} pageviews today for ${hostname} -- expected > 0`
-    }]
+  return {ok: true, total: eventTotal(json, eventName)}
+}
+
+/**
+ * Trigger-then-confirm ingestion test. Reads the event's baseline count, POSTs a
+ * fresh server-side event through the first-party /simple/events proxy, then
+ * polls the Stats API until the count increments (or the timeout is hit).
+ * The pure decision lives in evaluateIngestion (unit tested).
+ */
+async function checkSaIngestion(apiKey) {
+  const hostname = new URL(SITE_URL).hostname
+  const eventsUrl = `${SITE_URL}/simple/events`
+  const queryUrl = saEventsQueryUrl(hostname, INGESTION_EVENT_NAME, SA_QUERY_WINDOW_DAYS)
+
+  const beforeRead = await readEventTotal(queryUrl, apiKey, INGESTION_EVENT_NAME)
+  if (!beforeRead.ok) {
+    return evaluateIngestion({eventName: INGESTION_EVENT_NAME, error: beforeRead.error})
   }
-  return []
+  const before = beforeRead.total
+
+  const startedAt = Date.now()
+  try {
+    await fetch(eventsUrl, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json', 'User-Agent': SYNTHETIC_UA},
+      body: JSON.stringify(syntheticEventPayload(hostname, INGESTION_EVENT_NAME, SYNTHETIC_UA))
+    })
+  } catch (err) {
+    return evaluateIngestion({
+      eventName: INGESTION_EVENT_NAME,
+      error: {id: 'analytics-sa-ingestion-post-failed', message: `could not POST synthetic event to ${eventsUrl}: ${err.message}`}
+    })
+  }
+
+  let after = before
+  const deadline = startedAt + INGESTION_POLL_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, INGESTION_POLL_INTERVAL_MS))
+    const read = await readEventTotal(queryUrl, apiKey, INGESTION_EVENT_NAME)
+    if (read.ok) {
+      after = read.total
+      if (after > before) {
+        break
+      }
+    }
+  }
+  return evaluateIngestion({eventName: INGESTION_EVENT_NAME, before, after, elapsedMs: Date.now() - startedAt, timeoutMs: INGESTION_POLL_TIMEOUT_MS})
 }
 
 async function main() {
@@ -136,14 +270,14 @@ async function main() {
 
   const saApiKey = process.env.SA_API_KEY
   if (saApiKey) {
-    findings.push(...(await checkSaStatsApi(saApiKey)))
+    findings.push(...(await checkSaIngestion(saApiKey)))
   } else {
     // Explicit, visible SKIPPED marker -- never silently green when a whole
     // sub-check didn't run (§8 Q2: SA_API_KEY is a Phase 0 user-provisioned secret).
     findings.push({
       severity: 'info',
-      id: 'analytics-sa-stats-api-skipped',
-      message: 'SKIPPED(server-side): SA_API_KEY not set -- server-side pageview confirmation via the SA Stats API was not run'
+      id: 'analytics-sa-ingestion-skipped',
+      message: 'SKIPPED(server-side): SA_API_KEY not set -- end-to-end SA ingestion confirmation (synthetic event -> Stats API delta) was not run'
     })
   }
 

--- a/scripts/audit/lib/file-check-issues.mjs
+++ b/scripts/audit/lib/file-check-issues.mjs
@@ -20,8 +20,34 @@
 
 import {execFileSync} from 'node:child_process'
 
+// The labels every audit issue is tagged with. Kept in sync with the repo via
+// ensureLabel() below so a missing label can never red the audit job (the
+// original failure mode: `gh issue create --label audit` exited 1 with
+// "'audit' not found", and the filing step -- unlike the check steps -- had no
+// continue-on-error, so the whole job went red). Defense in depth over the
+// one-time `gh label create` bootstrap; enforced at the highest tier (estate
+// rule B10) rather than by hand-created labels alone.
+const AUDIT_LABELS = [
+  {name: 'audit', color: 'ededed', description: 'lp-audit finding'},
+  {name: 'audit:report-only', color: 'ededed', description: 'report-only (non-blocking) audit finding'}
+]
+
 function gh(args) {
   return execFileSync('gh', args, {encoding: 'utf-8'})
+}
+
+/**
+ * Idempotently create/update a label. `--force` makes `gh label create` a
+ * no-op-or-update when the label already exists, so this is safe to run every
+ * time. Failures are logged and swallowed: label provisioning is best-effort
+ * infrastructure and must never fail the audit job it supports.
+ */
+function ensureLabel({name, color, description}, repo) {
+  try {
+    gh(['label', 'create', name, '--repo', repo, '--color', color, '--description', description, '--force'])
+  } catch (err) {
+    console.warn(`Warning: could not ensure label "${name}": ${err.message}`)
+  }
 }
 
 function fileOrUpdateIssue({id, title}, repo, runUrl) {
@@ -84,11 +110,28 @@ function main() {
     return
   }
   if (!repo) {
-    console.error('GH_REPO env var not set -- cannot file issues.')
-    process.exit(1)
+    // Report-only infrastructure must never red the audit job it reports on
+    // (estate rule: the filer supports the audit, it does not gate it). Log
+    // loudly and exit clean rather than exit(1).
+    console.error('GH_REPO env var not set -- cannot file issues; skipping.')
+    return
   }
+
+  // Provision labels before any create/list so a missing label can't red the
+  // job. Idempotent and best-effort (see ensureLabel).
+  for (const label of AUDIT_LABELS) {
+    ensureLabel(label, repo)
+  }
+
   for (const check of failed) {
-    fileOrUpdateIssue(check, repo, runUrl)
+    // A `gh` hiccup while filing one issue must not abort the loop or fail the
+    // job -- log it and move on. dedupe-by-title behavior is preserved inside
+    // fileOrUpdateIssue; this only guards its I/O.
+    try {
+      fileOrUpdateIssue(check, repo, runUrl)
+    } catch (err) {
+      console.error(`Warning: could not file/update issue for check "${check.id}": ${err.message}`)
+    }
   }
 }
 

--- a/tests/audit/check-analytics.test.ts
+++ b/tests/audit/check-analytics.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {evaluateBeacons} from '../../scripts/audit/check-analytics.mjs'
+import {evaluateBeacons, evaluateIngestion, eventTotal, saEventsQueryUrl, syntheticEventPayload} from '../../scripts/audit/check-analytics.mjs'
 
 function fullSeen(overrides: Record<string, {status: number; url: string}> = {}): Map<string, {status: number; url: string}> {
   const base = new Map([
@@ -37,5 +37,72 @@ describe('evaluateBeacons', () => {
     const seen = fullSeen({'cf-rum': {status: 500, url: 'https://jonathanlloyd.me/cf-rum'}})
     const findings = evaluateBeacons(seen)
     expect(findings).toEqual([expect.objectContaining({severity: 'fail', id: 'analytics-cf-rum-status'})])
+  })
+})
+
+describe('saEventsQueryUrl', () => {
+  it('queries a named event count with UTC pinned and a bounded window', () => {
+    const url = new URL(saEventsQueryUrl('jonathanlloyd.me', 'audit_ingestion_probe', 1))
+    expect(url.origin + url.pathname).toBe('https://simpleanalytics.com/jonathanlloyd.me.json')
+    // events= is how SA returns per-event counts (fields=events is NOT valid;
+    // the empirically-correct shape is fields=pageviews + events=<name>).
+    expect(url.searchParams.get('events')).toBe('audit_ingestion_probe')
+    expect(url.searchParams.get('fields')).toBe('pageviews')
+    // timezone MUST be pinned (SA defaults to the site's dashboard tz).
+    expect(url.searchParams.get('timezone')).toBe('UTC')
+    expect(url.searchParams.get('start')).toBe('today-1d')
+    expect(url.searchParams.get('end')).toBe('today')
+    expect(url.searchParams.get('version')).toBe('6')
+  })
+})
+
+describe('eventTotal', () => {
+  const name = 'audit_ingestion_probe'
+  it('extracts the total for a matching event', () => {
+    expect(eventTotal({ok: true, events: [{name, total: 3}]}, name)).toBe(3)
+  })
+  it('returns 0 when the event is absent or events is missing', () => {
+    expect(eventTotal({ok: true, events: [{name: 'other', total: 9}]}, name)).toBe(0)
+    expect(eventTotal({ok: true}, name)).toBe(0)
+    expect(eventTotal(null, name)).toBe(0)
+  })
+})
+
+describe('syntheticEventPayload', () => {
+  it('builds a server-side SA event body (type=event, not pageview, to avoid distorting pageview metrics)', () => {
+    const ua = 'Mozilla/5.0 ... Chrome/148.0.0.0 Safari/537.36'
+    expect(syntheticEventPayload('jonathanlloyd.me', 'audit_ingestion_probe', ua)).toEqual({
+      type: 'event',
+      hostname: 'jonathanlloyd.me',
+      event: 'audit_ingestion_probe',
+      ua,
+      unique: true
+    })
+  })
+})
+
+describe('evaluateIngestion', () => {
+  const base = {eventName: 'audit_ingestion_probe', timeoutMs: 180_000}
+
+  it('after > before -> confirmed (info, carries the measured latency)', () => {
+    const findings = evaluateIngestion({...base, before: 4, after: 5, elapsedMs: 21_000})
+    expect(findings).toEqual([expect.objectContaining({severity: 'info', id: 'analytics-sa-ingestion-confirmed'})])
+    expect(findings[0].message).toContain('4 -> 5')
+    expect(findings[0].message).toContain('~21s')
+  })
+
+  it('count never increased within the timeout -> fail (not observed)', () => {
+    const findings = evaluateIngestion({...base, before: 4, after: 4, elapsedMs: 180_000})
+    expect(findings).toEqual([expect.objectContaining({severity: 'fail', id: 'analytics-sa-ingestion-not-observed'})])
+  })
+
+  it('a pre-resolved I/O error is surfaced with its own id (e.g. bad API key)', () => {
+    const findings = evaluateIngestion({...base, error: {id: 'analytics-sa-stats-api-error', message: 'SA Stats API error (HTTP 401)'}})
+    expect(findings).toEqual([{severity: 'fail', id: 'analytics-sa-stats-api-error', message: 'SA Stats API error (HTTP 401)'}])
+  })
+
+  it('a failed synthetic POST is surfaced as post-failed (never a silent pass)', () => {
+    const findings = evaluateIngestion({...base, error: {id: 'analytics-sa-ingestion-post-failed', message: 'could not POST'}})
+    expect(findings).toEqual([expect.objectContaining({severity: 'fail', id: 'analytics-sa-ingestion-post-failed'})])
   })
 })


### PR DESCRIPTION
Fixes the scheduled **Web Audit Synthetics** red run: <https://github.com/j0nathan-ll0yd/j0nathan-ll0yd.github.io/actions/runs/29992041606>

Two independent defects, one clean commit each.

## 1. The red-maker: issue-filer crashed on missing labels

`scripts/audit/lib/file-check-issues.mjs` shelled out to `gh issue create/list --label audit,audit:report-only`, but the repo had neither label, so `gh` exited 1 ("could not add label: 'audit' not found"). Unlike every check step (`continue-on-error: true`), the _File/update issues_ step has no such guard, so its non-zero exit failed the whole job. This was latent for **every** audit finding, not just this cycle's.

**Fix (highest enforcement tier, per B10 — not just hand-creating labels):**

- `ensureLabel()` — idempotent `gh label create --force` for each label before any create/list, so a missing label self-heals every run.
- Issue filing is wrapped so a `gh` failure is logged and swallowed — the filer is report-only infrastructure and must never fail the audit job it reports on.
- Dedupe-by-title behavior unchanged.

Verified: with a `gh` shim that exits 1 on every call, the script now exits **0** (previously 1).

## 2. The finding that tripped it: flaky "0 pageviews today" → real end-to-end ingestion confirmation

`check-analytics.mjs` queried the SA Stats API with `start=today&end=today` and failed unless `pageviews > 0`. Firing at 06:17 UTC against a low-traffic personal site, that window has barely opened → recurrent flake (compounded by the Stats API defaulting the window to the _site's dashboard timezone_, not UTC).

This is now a genuine **trigger-then-confirm** check, proven **empirically** against the live SA account (not from docs):

- The headless-browser **pageview** beacon is genuinely **not counted** — SA's own client script stamps `bot=true` when it detects the automated browser (HeadlessChrome UA / `navigator.webdriver`). A real-UA, `bot=false`, residential-IP pixel replay to a unique path stayed at **0 for 7+ minutes**. So "drive a Playwright pageview and watch the count" cannot work — the visit is dropped before it is ever counted.
- A **server-side EVENT** via our first-party `/simple/events` proxy (real UA) **is** counted and is queryable at `?fields=pageviews&events=<name>` → `events:[{name,total}]`. **Measured ingestion latency ~11–32s**, including from a GitHub Actions Azure datacenter IP (the proxy forwards `CF-Connecting-IP` as `X-Forwarded-For`; SA does not datacenter-filter it here). The **180s poll budget** has wide margin.
- An **event, not a pageview**: events are separate from pageviews/visitors in SA, so the daily synthetic signal does **not** distort this low-traffic site's real pageview metrics (a synthetic pageview would ~double them).

The check now fires a synthetic event, reads the count **before**, and polls the Stats API until it sees `after > before` — confirming first-party proxy → SA collector → ingestion → Stats API end to end, with its own deterministic signal each run (no dependence on ambient traffic). Pure helpers (`saEventsQueryUrl`, `eventTotal`, `syntheticEventPayload`, `evaluateIngestion`) are unit-tested. Verified end-to-end against production: exit 0, `analytics-sa-ingestion-confirmed: count 1 → 2 in ~32s`.

## Verification

- `vitest run tests/audit/check-analytics.test.ts` → 12 passed
- `npm run lint` → clean
- Issue-filer resilience proven with a failing-`gh` shim (exit 0)
- Analytics check run live end-to-end against production SA (measured ~32s ingestion)
