### PR TITLE
refactor(web): remove the DEV-only LOCATION feature lane

### DIFF
--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "description": "Deep technical context about Jonathan Lloyd's portfolio, engineering background, live biometric data sources, and architectural decisions. Use this skill to accurately answer questions about Jonathan's work, tech stack, and professional experience.",
       "type": "skill-md",
       "url": "https://jonathanlloyd.me/.well-known/agent-skills/portfolio-expert/SKILL.md",
-      "digest": "sha256:de0b3c87b52024f93139a078be314c2d879def1170bb1659b52086aa1067e084"
+      "digest": "sha256:d767dd16da34fcc3f80887e64bd8502158bb78b867f2ff077d7e9e9dee822f8e"
     }
   ]
 }

--- a/public/.well-known/agent-skills/portfolio-expert/SKILL.md
+++ b/public/.well-known/agent-skills/portfolio-expert/SKILL.md
@@ -20,7 +20,7 @@ Backend Engineering, Software Engineering, Engineering Leadership, Cloud Infrast
 
 The portfolio at jonathanlloyd.me is a sci-fi "Human Datastream" dashboard — a single-page application that visualizes real-time personal data across two domains:
 
-- **Body:** Heart rate, HRV, sleep, activity, workouts, hydration, location
+- **Body:** Heart rate, HRV, sleep, activity, workouts, hydration
 - **Mind:** GitHub commits, repositories, languages, books, articles, theatre reviews
 
 ### Technology Stack
@@ -46,7 +46,6 @@ All data is served from CloudFront with 5-minute edge TTL. Health data uses 7-da
 | <https://d1pfm520aduift.cloudfront.net/articles.json>             | Article feed items                       |
 | <https://d1pfm520aduift.cloudfront.net/theatre-reviews.json>      | Theatre reviews                          |
 | <https://d1pfm520aduift.cloudfront.net/workouts.json>             | Workout sessions and summaries           |
-| <https://d1pfm520aduift.cloudfront.net/location.json>             | Location aggregates                      |
 
 ## LLM-Optimized Content
 

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -84,12 +84,6 @@
       "name": "Workouts",
       "description": "Workout sessions with type, duration, and calorie burn",
       "mimeType": "application/json"
-    },
-    {
-      "uri": "https://d1pfm520aduift.cloudfront.net/location.json",
-      "name": "Location aggregates",
-      "description": "Aggregated place summaries and location data",
-      "mimeType": "application/json"
     }
   ]
 }

--- a/public/js/webmcp.js
+++ b/public/js/webmcp.js
@@ -24,8 +24,7 @@
       { name: 'Bookshelf', url: 'https://d1pfm520aduift.cloudfront.net/books.json', description: 'Books with status, ratings, progress, and cover images' },
       { name: 'Reading feed', url: 'https://d1pfm520aduift.cloudfront.net/articles.json', description: 'Starred articles and RSS feed items' },
       { name: 'Theatre reviews', url: 'https://d1pfm520aduift.cloudfront.net/theatre-reviews.json', description: 'Theatre show reviews with ratings and venue info' },
-      { name: 'Workouts', url: 'https://d1pfm520aduift.cloudfront.net/workouts.json', description: 'Workout sessions with type, duration, and calorie burn' },
-      { name: 'Location aggregates', url: 'https://d1pfm520aduift.cloudfront.net/location.json', description: 'Aggregated place summaries and location data' }
+      { name: 'Workouts', url: 'https://d1pfm520aduift.cloudfront.net/workouts.json', description: 'Workout sessions with type, duration, and calorie burn' }
     ];
 
     navigator.modelContext.provideContext({

--- a/scripts/generate-webmcp.mjs
+++ b/scripts/generate-webmcp.mjs
@@ -32,8 +32,7 @@ const dataSources = [
   {name: copyLlm.mcp.dsBooksName, url: cf(ENDPOINTS.books), description: copyLlm.mcp.dsBooksDesc},
   {name: copyLlm.mcp.dsArticlesName, url: cf(ENDPOINTS.articles), description: copyLlm.mcp.dsArticlesDesc},
   {name: copyLlm.mcp.dsTheatreReviewsName, url: cf(ENDPOINTS.theatreReviews), description: copyLlm.mcp.dsTheatreReviewsDesc},
-  {name: copyLlm.mcp.dsWorkoutsName, url: cf(ENDPOINTS.workouts), description: copyLlm.mcp.dsWorkoutsDesc},
-  {name: copyLlm.mcp.dsLocationName, url: cf(ENDPOINTS.location), description: copyLlm.mcp.dsLocationDesc}
+  {name: copyLlm.mcp.dsWorkoutsName, url: cf(ENDPOINTS.workouts), description: copyLlm.mcp.dsWorkoutsDesc}
 ]
 
 const booksUrl = cf(ENDPOINTS.books)
@@ -164,8 +163,7 @@ const serverCard = {
     {uri: cf(ENDPOINTS.books), name: copyLlm.mcp.dsBooksName, description: copyLlm.mcp.dsBooksDesc, mimeType: 'application/json'},
     {uri: cf(ENDPOINTS.articles), name: copyLlm.mcp.dsArticlesName, description: copyLlm.mcp.dsArticlesDesc, mimeType: 'application/json'},
     {uri: cf(ENDPOINTS.theatreReviews), name: copyLlm.mcp.dsTheatreReviewsName, description: copyLlm.mcp.dsTheatreReviewsDesc, mimeType: 'application/json'},
-    {uri: cf(ENDPOINTS.workouts), name: copyLlm.mcp.dsWorkoutsName, description: copyLlm.mcp.dsWorkoutsDesc, mimeType: 'application/json'},
-    {uri: cf(ENDPOINTS.location), name: copyLlm.mcp.dsLocationName, description: copyLlm.mcp.dsLocationDesc, mimeType: 'application/json'}
+    {uri: cf(ENDPOINTS.workouts), name: copyLlm.mcp.dsWorkoutsName, description: copyLlm.mcp.dsWorkoutsDesc, mimeType: 'application/json'}
   ]
 }
 
@@ -181,7 +179,7 @@ const agentSkills = {
       description: copyLlm.mcp.agentSkillDescription,
       type: 'skill-md',
       url: `${SITE_URL}/.well-known/agent-skills/portfolio-expert/SKILL.md`,
-      digest: 'sha256:de0b3c87b52024f93139a078be314c2d879def1170bb1659b52086aa1067e084'
+      digest: 'sha256:d767dd16da34fcc3f80887e64bd8502158bb78b867f2ff077d7e9e9dee822f8e'
     }
   ]
 }

--- a/src/lib/runtime/api.ts
+++ b/src/lib/runtime/api.ts
@@ -6,7 +6,6 @@ import type {
   GithubEventsExport,
   GithubStarredReposExport,
   HealthExport,
-  LocationExport,
   SleepExport,
   TheatreReviewsExport,
   WorkoutsExport
@@ -24,7 +23,6 @@ export interface FetchResult {
   githubEvents: GithubEventsExport | null
   starredRepos: GithubStarredReposExport | null
   articles: ArticlesExport | null
-  location: LocationExport | null
   focus: FocusExport | null
   theatreReviews: TheatreReviewsExport | null
   timestamps: Record<string, string | null>
@@ -55,7 +53,6 @@ export async function fetchAllEndpoints(): Promise<FetchResult> {
     githubEvents,
     starredRepos,
     articles,
-    location,
     focus,
     theatreReviews
   ] = await Promise.all([
@@ -66,9 +63,6 @@ export async function fetchAllEndpoints(): Promise<FetchResult> {
     fetchWithTimeout<GithubEventsExport>(BASE + ENDPOINTS.githubEvents),
     fetchWithTimeout<GithubStarredReposExport>(BASE + ENDPOINTS.starredRepos),
     fetchWithTimeout<ArticlesExport>(BASE + ENDPOINTS.articles),
-    import.meta.env.DEV
-      ? fetchWithTimeout<LocationExport>(BASE + ENDPOINTS.location)
-      : Promise.resolve(null),
     fetchWithTimeout<FocusExport>(BASE + ENDPOINTS.focus),
     fetchWithTimeout<TheatreReviewsExport>(BASE + ENDPOINTS.theatreReviews)
   ])
@@ -81,7 +75,6 @@ export async function fetchAllEndpoints(): Promise<FetchResult> {
     githubEvents,
     starredRepos,
     articles,
-    location,
     focus,
     theatreReviews,
     timestamps: {
@@ -91,7 +84,6 @@ export async function fetchAllEndpoints(): Promise<FetchResult> {
       githubEvents: githubEvents?.generatedAt ?? null,
       starredRepos: starredRepos?.generatedAt ?? null,
       articles: articles?.generatedAt ?? null,
-      location: location?.generatedAt ?? null,
       focus: focus?.generatedAt ?? null,
       theatreReviews: theatreReviews?.generatedAt ?? null
     }

--- a/src/lib/runtime/live-data.ts
+++ b/src/lib/runtime/live-data.ts
@@ -10,7 +10,6 @@ import type {
   GithubEventsExport,
   GithubStarredReposExport,
   HealthExport,
-  LocationExport,
   SleepExport,
   TheatreReviewsExport,
   WorkoutsExport
@@ -29,8 +28,6 @@ import {
   updateSystemStatus,
   updateWorkouts
 } from '@lifegames/web/runtime/updaters'
-import {updatePlaceLeaderboardV3} from '@lifegames/web/runtime/updaters-leaderboard-variations'
-import {updateExplorationOdometerV3} from '@lifegames/web/runtime/updaters-odometer-variations'
 import {PollEngine} from './poll-engine'
 import type {ResourceKey} from '@lifegames/portal-contract/constants'
 
@@ -43,8 +40,7 @@ const LIVE_CARDS = [
   'cardDevLog',
   'cardReading',
   'cardStarredRepos',
-  'cardTheatreReviews',
-  ...(import.meta.env.DEV ? ['cardPlaceLeaderboardV3', 'cardExplorationOdometerV3'] : [])
+  'cardTheatreReviews'
 ]
 
 // ── Module-scoped state for cross-resource dependencies ──────────────
@@ -116,26 +112,32 @@ type ResourceTypeMap = {
   books: BooksExport
   githubEvents: GithubEventsExport
   articles: ArticlesExport
-  location: LocationExport
   focus: FocusExport
   theatreReviews: TheatreReviewsExport
   starredRepos: GithubStarredReposExport
 }
 
-const RESOURCE_DISCRIMINANTS: Record<ResourceKey, string> = {
+// A payload that passed structural validation: one of the known export shapes
+// (each carries generatedAt). Each switch branch narrows this to the concrete
+// export type via ResourceTypeMap.
+type ValidatedPayload = ResourceTypeMap[keyof ResourceTypeMap]
+
+// Partial over ResourceKey: the contract's ResourceKey still enumerates `location`
+// (its ENDPOINTS entry is retired in a coordinated portal-contract change), but the
+// web dashboard no longer polls or renders it, so it carries no discriminant here.
+const RESOURCE_DISCRIMINANTS: Partial<Record<ResourceKey, string>> = {
   health: 'quantities',
   sleep: 'date',
   workouts: 'workouts',
   books: 'books',
   githubEvents: 'events',
   articles: 'articles',
-  location: 'topPlaces',
   focus: 'currentFocus',
   theatreReviews: 'reviews',
   starredRepos: 'repos'
 }
 
-function validateResource<K extends ResourceKey>(key: K, rawData: unknown): ResourceTypeMap[K] | null {
+function validateResource(key: ResourceKey, rawData: unknown): ValidatedPayload | null {
   if (typeof rawData !== 'object' || rawData === null) {
     return null
   }
@@ -143,10 +145,11 @@ function validateResource<K extends ResourceKey>(key: K, rawData: unknown): Reso
   if (typeof obj.generatedAt !== 'string') {
     return null
   }
-  if (!(RESOURCE_DISCRIMINANTS[key] in obj)) {
+  const discriminant = RESOURCE_DISCRIMINANTS[key]
+  if (discriminant === undefined || !(discriminant in obj)) {
     return null
   }
-  return rawData as ResourceTypeMap[K]
+  return rawData as ValidatedPayload
 }
 
 // ── Per-resource incremental update dispatch ─────────────────────────
@@ -194,12 +197,6 @@ function handleResourceUpdate(key: ResourceKey, rawData: unknown): void {
       case 'articles':
         updateReadingFeed(adaptArticles(validated as ResourceTypeMap['articles']))
         break
-      case 'location': {
-        const data = validated as ResourceTypeMap['location']
-        updatePlaceLeaderboardV3(data)
-        updateExplorationOdometerV3(data)
-        break
-      }
       case 'focus': {
         // Route through applyFocus so a focus change detected by polling (e.g. the WS is down)
         // also transitions client-side suppression, not just the overlay. But within the
@@ -305,15 +302,6 @@ const startFetch = async () => {
       updateReadingFeed(adaptArticles(data.articles))
     } catch (e) {
       console.warn('[live-data] Articles update failed:', e)
-    }
-  }
-
-  if (data.location) {
-    try {
-      updatePlaceLeaderboardV3(data.location)
-      updateExplorationOdometerV3(data.location)
-    } catch (e) {
-      console.warn('[live-data] Location update failed:', e)
     }
   }
 

--- a/src/lib/runtime/poll-engine.ts
+++ b/src/lib/runtime/poll-engine.ts
@@ -28,8 +28,6 @@ const SLOW_KEYS: ResourceKey[] = [
   'starredRepos',
   'theatreReviews'
 ]
-// DEV-only: location polling (tree-shaken in production)
-const DEV_KEYS: ResourceKey[] = import.meta.env.DEV ? ['location'] : []
 
 const FAST_INTERVAL_MS = 30_000
 const SLOW_INTERVAL_MS = 120_000
@@ -128,7 +126,7 @@ export class PollEngine {
 
   /** Immediately poll all resources */
   async pollNow(): Promise<void> {
-    await this.pollTier([...FAST_KEYS, ...DEV_KEYS, ...SLOW_KEYS])
+    await this.pollTier([...FAST_KEYS, ...SLOW_KEYS])
   }
 
   getStatus(): PollStatus {
@@ -156,7 +154,7 @@ export class PollEngine {
   private startTimers(): void {
     const fastMs = this.mode === 'passive' ? PASSIVE_FAST_INTERVAL_MS : FAST_INTERVAL_MS
     const slowMs = this.mode === 'passive' ? PASSIVE_SLOW_INTERVAL_MS : SLOW_INTERVAL_MS
-    this.fastTimer = setInterval(() => void this.pollTier([...FAST_KEYS, ...DEV_KEYS]), fastMs)
+    this.fastTimer = setInterval(() => void this.pollTier(FAST_KEYS), fastMs)
     this.slowTimer = setInterval(() => void this.pollTier(SLOW_KEYS), slowMs)
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import {
   BioTerminal, BookModal, Hydration, IdentityCard,
   SystemStatus, HeartRate, MovementRings, Workouts, NightSummary,
   StarredRepoList, DevActivityLog, ReadingFeed, Bookshelf,
-  FocusOverlay, DndOverlay, PlaceLeaderboardV3, ExplorationOdometerV3,
+  FocusOverlay, DndOverlay,
   TheatreReviews,
 } from '@lifegames/web/production';
 import { loadDashboardData } from '../lib/load-dashboard-data';
@@ -54,8 +54,6 @@ const { profile, health, github, reading, books, system, starredRepos } = await 
               <MovementRings health={health} />
               <Hydration health={health} />
               <NightSummary health={health} />
-              {import.meta.env.DEV && <PlaceLeaderboardV3 />}
-              {import.meta.env.DEV && <ExplorationOdometerV3 />}
             </div>
           </div>
         </section>

--- a/tests/behavioral/book-modal.spec.ts
+++ b/tests/behavioral/book-modal.spec.ts
@@ -40,7 +40,6 @@ async function interceptRoutes(page: Page): Promise<void> {
       '/github-starred-repos.json': baselineFixture('github-starred-repos', 'baseline'),
       '/github-events.json': baselineFixture('github-events', 'baseline'),
       '/articles.json': baselineFixture('articles', 'baseline'),
-      '/location.json': baselineFixture('location', 'baseline'),
       '/focus.json': baselineFixture('focus', 'empty'),
       '/theatre-reviews.json': baselineFixture('theatre-reviews', 'baseline')
     }

--- a/tests/behavioral/mobile-layout.spec.ts
+++ b/tests/behavioral/mobile-layout.spec.ts
@@ -56,7 +56,6 @@ async function interceptRoutes(page: Page, overrides: Record<string, string> = {
       '/github-starred-repos.json': baselineFixture('github-starred-repos'),
       '/github-events.json': baselineFixture('github-events'),
       '/articles.json': baselineFixture('articles'),
-      '/location.json': baselineFixture('location'),
       '/focus.json': emptyFixture('focus'),
       '/theatre-reviews.json': baselineFixture('theatre-reviews'),
       ...overrides

--- a/tests/behavioral/system-status-popover.spec.ts
+++ b/tests/behavioral/system-status-popover.spec.ts
@@ -5,7 +5,7 @@
  * build with baseline fixtures, asserting the Health row's .sys-info button
  * + #tip-health popover (Health has the most links — canonical example):
  *   - SSR: 7 info buttons (Health, Sleep, Books, Articles, GithubEvents,
- *     StarredRepos, TheatreReviews); Location row gets none.
+ *     StarredRepos, TheatreReviews).
  *   - Click opens popover; Escape closes + focus returns to the button.
  *   - Enter and Space keyboard activation.
  *   - Exact link href / rel / target inside the popover.
@@ -40,7 +40,6 @@ async function interceptRoutes(page: Page): Promise<void> {
       '/github-starred-repos.json': baselineFixture('github-starred-repos', 'baseline'),
       '/github-events.json': baselineFixture('github-events', 'baseline'),
       '/articles.json': baselineFixture('articles', 'baseline'),
-      '/location.json': baselineFixture('location', 'baseline'),
       '/focus.json': baselineFixture('focus', 'empty'),
       '/theatre-reviews.json': baselineFixture('theatre-reviews', 'baseline')
     }
@@ -118,15 +117,12 @@ test.describe('SystemStatus provenance disclosure — popover behavior', () => {
   })
 
   // -----------------------------------------------------------------------
-  // 1. SSR structure — 7 buttons present; Location row has none
+  // 1. SSR structure — 7 buttons present
   // -----------------------------------------------------------------------
-  test('1. seven .sys-info buttons rendered; Location row gets none', async () => {
+  test('1. seven .sys-info buttons rendered', async () => {
     const buttons = page.locator('#systemStatus .sys-info')
     // Health, Sleep, Books, Articles, GithubEvents, StarredRepos, TheatreReviews
     await expect(buttons).toHaveCount(7)
-
-    // Location is filtered in production (SystemStatus.astro compact branch line 48)
-    await expect(page.locator('#systemStatus .sys-line[data-source="location"] .sys-info')).toHaveCount(0)
   })
 
   // -----------------------------------------------------------------------

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -13,7 +13,6 @@ vi.mock('@lifegames/portal-contract/constants',
       starredRepos: '/github-starred-repos.json',
       githubEvents: '/github-events.json',
       articles: '/articles.json',
-      location: '/location.json',
       focus: '/focus.json',
       theatreReviews: '/theatre-reviews.json'
     }
@@ -31,7 +30,6 @@ const booksFixture = {generatedAt: '2024-01-01T00:00:00Z', books: []}
 const githubEventsFixture = {generatedAt: '2024-01-01T00:00:00Z', events: []}
 const starredReposFixture = {generatedAt: '2024-01-01T00:00:00Z'}
 const articlesFixture = {generatedAt: '2024-01-01T00:00:00Z', articles: []}
-const locationFixture = {generatedAt: '2024-01-01T00:00:00Z', lat: 37.7, lng: -122.4}
 const focusFixture = {generatedAt: '2024-01-01T00:00:00Z', sessions: []}
 const theatreFixture = {generatedAt: '2024-01-01T00:00:00Z', reviews: []}
 
@@ -111,9 +109,8 @@ describe('fetchAllEndpoints', () => {
   })
 
   it('returns all data when all endpoints succeed', async () => {
-    // Order matches Promise.all in fetchAllEndpoints.
-    // In the vitest environment import.meta.env.DEV=true, so location IS fetched:
-    // health, sleep, workouts, books, githubEvents, starredRepos, articles, location, focus, theatreReviews
+    // Order matches Promise.all in fetchAllEndpoints:
+    // health, sleep, workouts, books, githubEvents, starredRepos, articles, focus, theatreReviews
     const fetchMock = vi.fn().mockResolvedValueOnce(makeFetchResponse(healthFixture)) // health
       .mockResolvedValueOnce(makeFetchResponse(sleepFixture)) // sleep
       .mockResolvedValueOnce(makeFetchResponse(workoutsFixture)) // workouts
@@ -121,7 +118,6 @@ describe('fetchAllEndpoints', () => {
       .mockResolvedValueOnce(makeFetchResponse(githubEventsFixture)) // githubEvents
       .mockResolvedValueOnce(makeFetchResponse(starredReposFixture)) // starredRepos
       .mockResolvedValueOnce(makeFetchResponse(articlesFixture)) // articles
-      .mockResolvedValueOnce(makeFetchResponse(locationFixture)) // location (DEV=true)
       .mockResolvedValueOnce(makeFetchResponse(focusFixture)) // focus
       .mockResolvedValueOnce(makeFetchResponse(theatreFixture)) // theatreReviews
     vi.stubGlobal('fetch', fetchMock)
@@ -143,8 +139,7 @@ describe('fetchAllEndpoints', () => {
         makeFetchResponse(booksFixture)
       ).mockResolvedValueOnce(makeFetchResponse(githubEventsFixture)).mockResolvedValueOnce(makeFetchResponse(starredReposFixture)).mockResolvedValueOnce(
         makeFetchResponse(articlesFixture)
-      ).mockResolvedValueOnce(makeFetchResponse(locationFixture)) // location (DEV=true)
-      .mockResolvedValueOnce(makeFetchResponse(focusFixture)).mockResolvedValueOnce(makeFetchResponse(theatreFixture))
+      ).mockResolvedValueOnce(makeFetchResponse(focusFixture)).mockResolvedValueOnce(makeFetchResponse(theatreFixture))
     vi.stubGlobal('fetch', fetchMock)
 
     const result = await fetchAllEndpoints()
@@ -173,9 +168,8 @@ describe('fetchAllEndpoints', () => {
       .mockResolvedValueOnce(makeFetchResponse(workoutsFixture)).mockResolvedValueOnce(makeFetchResponse(booksFixture)).mockResolvedValueOnce(
         makeFetchResponse(githubEventsFixture)
       ).mockResolvedValueOnce(makeFetchResponse(starredReposFixture)).mockResolvedValueOnce(makeFetchResponse(articlesFixture)).mockResolvedValueOnce(
-        makeFetchResponse(locationFixture)
-      ) // location (DEV=true)
-      .mockResolvedValueOnce(makeFetchResponse(focusFixture)).mockResolvedValueOnce(makeFetchResponse(theatreFixture))
+        makeFetchResponse(focusFixture)
+      ).mockResolvedValueOnce(makeFetchResponse(theatreFixture))
     vi.stubGlobal('fetch', fetchMock)
 
     const result = await fetchAllEndpoints()

--- a/tests/unit/live-data.app-update.test.ts
+++ b/tests/unit/live-data.app-update.test.ts
@@ -65,7 +65,6 @@ vi.mock('../../src/lib/runtime/api',
         githubEvents: null,
         starredRepos: null,
         articles: null,
-        location: null,
         focus: null,
         theatreReviews: null,
         timestamps: {}
@@ -90,7 +89,6 @@ vi.mock('@lifegames/portal-contract/constants', async (importActual) => {
       starredRepos: '/github-starred-repos.json',
       githubEvents: '/github-events.json',
       articles: '/articles.json',
-      location: '/location.json',
       focus: '/focus.json',
       theatreReviews: '/theatre-reviews.json'
     }

--- a/tests/unit/poll-engine.test.ts
+++ b/tests/unit/poll-engine.test.ts
@@ -14,7 +14,6 @@ vi.mock('@lifegames/portal-contract/constants',
       starredRepos: '/github-starred-repos.json',
       githubEvents: '/github-events.json',
       articles: '/articles.json',
-      location: '/location.json',
       focus: '/focus.json',
       theatreReviews: '/theatre-reviews.json'
     }
@@ -274,7 +273,7 @@ describe('PollEngine', () => {
       await engine.pollNow()
 
       // FAST (health, sleep, workouts, focus) + SLOW (books, articles, githubEvents,
-      // starredRepos, theatreReviews) = 9 in production (location is DEV-only).
+      // starredRepos, theatreReviews) = 9 resources.
       expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(9)
     })
   })

--- a/tests/visual/fixtures.ts
+++ b/tests/visual/fixtures.ts
@@ -2,7 +2,7 @@
  * Fixture scenario compositions for visual regression tests.
  *
  * Maps scenario names to raw fixture file paths owned by `@lifegames/fixtures`
- * (Plan #04). Each scenario defines which JSON file serves each of the 10
+ * (Plan #04). Each scenario defines which JSON file serves each of the 9
  * CloudFront endpoints; the Playwright route-interception layer (helpers.ts)
  * fulfills `${CLOUDFRONT_BASE}/<endpoint>` from these files.
  */
@@ -28,7 +28,7 @@ function fixture(dir: string, file: string): string {
   return require.resolve(`@lifegames/fixtures/generated/${dir}/${camelFile}.json`)
 }
 
-/** Baseline fixtures for all 10 endpoints */
+/** Baseline fixtures for all 9 endpoints */
 const BASELINE: FixtureSet = {
   '/health.json': fixture('health', 'baseline'),
   '/sleep.json': fixture('sleep', 'baseline'),
@@ -37,7 +37,6 @@ const BASELINE: FixtureSet = {
   '/github-starred-repos.json': fixture('github-starred-repos', 'baseline'),
   '/github-events.json': fixture('github-events', 'baseline'),
   '/articles.json': fixture('articles', 'baseline'),
-  '/location.json': fixture('location', 'baseline'),
   '/focus.json': fixture('focus', 'empty'),
   '/theatre-reviews.json': fixture('theatre-reviews', 'baseline')
 }
@@ -49,8 +48,8 @@ const DASHBOARD_SCENARIOS: Record<string, FixtureSet> = {
   populated: {...BASELINE},
 
   // True-empty state for every domain. Uses the DS triad `empty` variations
-  // (real empties that did not exist before the triad — health/location formerly
-  // borrowed `missing-optional`/`empty-top-places` as the closest stand-ins).
+  // (real empties that did not exist before the triad — health formerly
+  // borrowed `missing-optional` as the closest stand-in).
   // The `missing-optional` health render path it no longer exercises here is
   // preserved by the `health-missing-optional` widget variation below.
   empty: {
@@ -61,7 +60,6 @@ const DASHBOARD_SCENARIOS: Record<string, FixtureSet> = {
     '/books.json': fixture('books', 'empty'),
     '/github-events.json': fixture('github-events', 'empty'),
     '/articles.json': fixture('articles', 'empty'),
-    '/location.json': fixture('location', 'empty'),
     '/theatre-reviews.json': fixture('theatre-reviews', 'empty'),
     '/github-starred-repos.json': fixture('github-starred-repos', 'empty')
   },
@@ -86,7 +84,6 @@ const DASHBOARD_SCENARIOS: Record<string, FixtureSet> = {
     '/github-starred-repos.json': fixture('github-starred-repos', 'full'),
     '/github-events.json': fixture('github-events', 'full'),
     '/articles.json': fixture('articles', 'full'),
-    '/location.json': fixture('location', 'full'),
     '/theatre-reviews.json': fixture('theatre-reviews', 'full')
   }
 }


### PR DESCRIPTION
## Remove the DEV-only LOCATION feature lane (web)

Location is being retired from web + backend. iOS keeps its local-only feature; the design-system location widgets stay (orphaned-but-documented). This PR removes the LOCATION lane from the web repo.

### This is dead-code cleanup — no user-visible change

Every web location path was `import.meta.env.DEV`-gated (`poll-engine`, `api`, `live-data`, `index.astro`), so **production builds already tree-shake it**. Removing it changes nothing users see.

> [!IMPORTANT]
> **Merging this PR is a production deploy.** `main` → `.github/workflows/deploy.yml` → Cloudflare Pages. Per B5 the merge is **held for the repo owner** — do not merge without explicit go-ahead.

### What changed

- **Runtime** (`src/lib/runtime/{poll-engine,api,live-data}.ts`, `src/pages/index.astro`): dropped `location` from the poll tiers, `fetchAllEndpoints`, the `FetchResult`/`ResourceTypeMap` shapes, and the update dispatch; removed the two DEV-only `PlaceLeaderboardV3`/`ExplorationOdometerV3` renders.
  - `RESOURCE_DISCRIMINANTS` became `Partial<Record<ResourceKey, string>>` and `validateResource` was de-genericised. This is required because the linked `@lifegames/portal-contract` still enumerates `location` in `ResourceKey` (`keyof typeof ENDPOINTS`) until its coordinated removal — a naive deletion would fail `astro check`. See the code comment for the rationale.
- **AI-agent advertisements**: removed the `location.json` resource from the WebMCP client (`public/js/webmcp.js`) and the MCP server-card (`public/.well-known/mcp/server-card.json`) via `scripts/generate-webmcp.mjs`, and from the `SKILL.md` endpoint table. Also **fixed a pre-existing `SKILL.md` digest drift** in the generator (the hardcoded sha256 pointed at a superseded revision).
- **Tests**: re-sequenced the `api.test.ts` `Promise.all` mocks (location vacated a slot), updated the poll-engine resource count, dropped location route stubs/fixtures across the unit/behavioral/visual suites, and removed the now-meaningless "Location row has 0 buttons" assertion.

### Deliberately NOT touched

- `.contract-lock.json` — regenerated in a **later step** after the backend drops the upstream schema.
- `geolocation=()` in the `Permissions-Policy` (`functions/_middleware.ts`, `public/_headers`) — security hardening, kept.
- Browser `location.*` APIs (`index.astro` `location.search`, `sw-register.js`).
- `design-system-Lifegames` (widgets + copy package).

### ⚠️ Two residuals that need a follow-up (out of this PR's scope)

1. **`@lifegames/copy`-sourced prose still names location.** `agent-card.json:3,28`, `ai-catalog.json:14`, and the `webmcp.js` bio are generated from `@lifegames/copy` (`agentDiscovery.*`, `person.longBio`). Removing "location" there requires a **design-system copy change**, which this web-only PR cannot make. Needs a coordinated copy edit + re-yalc.
2. **Leaflet is now a full orphan.** The DEV-only leaflet map loader (`public/js/leaflet-lazy.js`, `public/vendor/leaflet/`, `Dashboard.astro` DEV-gated refs) has no `[data-widget="map"]` consumer anywhere (repo or DS bundle). It was already orphaned; left in place here as it's outside the location-removal manifest. Candidate for a separate cleanup (~388 KB vendored).

### Verification

`npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run test:unit` (219), `npm run build`, `npm run test:build` (95) — all green locally. Visual + behavioral suites run in CI (production render is unchanged, so baselines are unaffected).
