### PR TITLE
refactor(web): retire location claims from discovery surfaces + contract lock

### DIFF
--- a/.contract-lock.json
+++ b/.contract-lock.json
@@ -1,10 +1,10 @@
 {
   "generatedFrom": {
     "repo": "j0nathan-ll0yd/design-system-Lifegames",
-    "sha": "b0688d0e6df7979e20d77daeed27f49177e861b1",
-    "checksum": "sha256:57eacd03e6732399619c814c600496ff316f9129295b12bac4e891365210fe9f"
+    "sha": "unknown",
+    "checksum": "sha256:13e69b71de821ccd80bd6eb18a5e8469cb3e4e842ebb2e28ba1414cb28150b09"
   },
-  "generatedAt": "2026-07-18T17:54:54.176Z",
+  "generatedAt": "2026-07-30T21:31:27.171Z",
   "generatorVersion": "1.0.0",
   "files": {
     "raw-schemas/articles-export.schema.json": "sha256:4a3d6514ab959b251ad88bef79020747bbddb865d0a7c913e71fe36f608ffd36",
@@ -13,7 +13,6 @@
     "raw-schemas/github-events-export.schema.json": "sha256:ff00a3474a0be17e9640407a7bc3d69dd437157ec10936ec5157932f07fec415",
     "raw-schemas/github-starred-repos-export.schema.json": "sha256:dab7effd7bb7fa6a5444d4e32b43fdfff4d8ae1721e6be69ccd0a88be159c33f",
     "raw-schemas/health-export.schema.json": "sha256:6dfd14c274828a038da48db10c900046e7a60bc14cd55f5f1c17dc252661b60c",
-    "raw-schemas/location-export.schema.json": "sha256:72eaba34504ccc55c691857c8879b354b9fbdeba03d9e353b8b295bd13b01f1b",
     "raw-schemas/sleep-export.schema.json": "sha256:ab11c1abeb9cbb3dc327243eb50507dab31f843d9f2a8cea367522431f16b85d",
     "raw-schemas/theatre-reviews-export.schema.json": "sha256:39753a6f58f2bc5f030efcf50193a38f48a29178e733f1ba724e0b28188da640",
     "raw-schemas/workouts-export.schema.json": "sha256:1814cc3935a95c345eece02fb0f560c95ce8bca92a4b90705489c21c7182c67e",

--- a/.contract-lock.json
+++ b/.contract-lock.json
@@ -1,10 +1,10 @@
 {
   "generatedFrom": {
     "repo": "j0nathan-ll0yd/design-system-Lifegames",
-    "sha": "unknown",
+    "sha": "f698fee013068105fa6e251a77648ce39d093e93",
     "checksum": "sha256:13e69b71de821ccd80bd6eb18a5e8469cb3e4e842ebb2e28ba1414cb28150b09"
   },
-  "generatedAt": "2026-07-30T21:31:27.171Z",
+  "generatedAt": "2026-07-30T21:53:28.153Z",
   "generatorVersion": "1.0.0",
   "files": {
     "raw-schemas/articles-export.schema.json": "sha256:4a3d6514ab959b251ad88bef79020747bbddb865d0a7c913e71fe36f608ffd36",

--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -1,6 +1,6 @@
 {
   "name": "Human Datastream",
-  "description": "Read-only data interface for Jonathan Lloyd's personal dashboard. Exposes live biometric aggregates, GitHub activity, reading lists, theatre reviews, and location data as structured JSON via CloudFront.",
+  "description": "Read-only data interface for Jonathan Lloyd's personal dashboard. Exposes live biometric aggregates, GitHub activity, reading lists, and theatre reviews as structured JSON via CloudFront.",
   "version": "1.0.0",
   "supportedInterfaces": [
     {
@@ -25,7 +25,7 @@
     {
       "id": "personal-profile",
       "name": "Personal Profile",
-      "description": "Retrieve Jonathan Lloyd's professional background, live health and activity data, reading list, GitHub contributions, and location aggregates. Useful for agents answering questions about Jonathan's work, expertise, or current status.",
+      "description": "Retrieve Jonathan Lloyd's professional background, live health and activity data, reading list, and GitHub contributions. Useful for agents answering questions about Jonathan's work, expertise, or current status.",
       "tags": [
         "personal",
         "health",

--- a/public/.well-known/ai-catalog.json
+++ b/public/.well-known/ai-catalog.json
@@ -11,7 +11,7 @@
       "displayName": "Human Datastream MCP Server",
       "type": "application/mcp-server-card+json",
       "url": "https://jonathanlloyd.me/.well-known/mcp/server-card.json",
-      "description": "MCP server card describing read-only access to Jonathan Lloyd's live personal data: biometrics, GitHub activity, reading lists, theatre reviews, and location aggregates.",
+      "description": "MCP server card describing read-only access to Jonathan Lloyd's live personal data: biometrics, GitHub activity, reading lists, and theatre reviews.",
       "representativeQueries": [
         "What is Jonathan Lloyd's current heart rate?",
         "What has Jonathan been reading lately?",

--- a/public/js/webmcp.js
+++ b/public/js/webmcp.js
@@ -8,7 +8,7 @@
       site: 'https://jonathanlloyd.me',
       github: 'https://github.com/j0nathan-ll0yd',
       linkedin: 'https://www.linkedin.com/in/lifegames/',
-      bio: 'Engineering director and backend engineer with 24+ years of experience. Built this portfolio as a living data dashboard — real biometrics and constant updates of body (health, activity, hydration, location) and mind (coding, reading, learning). Jack into his human datastream as the world becomes more AI-centric.',
+      bio: 'Engineering director and backend engineer with 24+ years of experience. Built this portfolio as a living data dashboard — real biometrics and constant updates of body (health, activity, hydration) and mind (coding, reading, learning). Jack into his human datastream as the world becomes more AI-centric.',
       expertise: [
         'Backend Engineering', 'Software Engineering', 'Engineering Leadership', 'Cloud Infrastructure', 'Data Visualization', 'Serverless Architecture', 'TypeScript', 'Go', 'AWS'
       ],

--- a/scripts/generate-contract-lock.mjs
+++ b/scripts/generate-contract-lock.mjs
@@ -24,7 +24,29 @@ if (!existsSync(SCHEMAS_PKG)) {
   process.exit(1)
 }
 
-// Read the DS SHA from the yalc package's .lp-sync-manifest.json or yalc.lock
+// Resolve the upstream design-system-Lifegames sha for provenance. Priority:
+//   1. Git HEAD of the DS repo (sibling checkout, or DS_REPO_ROOT override).
+//   2. lpGitSha from the yalc package's .lp-sync-manifest.json.
+// If neither resolves we FAIL LOUDLY rather than silently recording a
+// plausible-looking placeholder. A provenance field whose failure mode is
+// "record nothing" is worse than one that errors: check-contract-lock.mjs
+// deliberately excludes generatedFrom.sha, so no gate can ever tell a genuine
+// sha from a swallowed "unknown". Set CONTRACT_LOCK_ALLOW_UNKNOWN_SHA=1 to opt
+// into a deliberate "unknown" (e.g. an environment with no DS provenance).
+
+// (1) DS repo HEAD. Defaults to the sibling checkout; DS_REPO_ROOT overrides it
+// for worktrees where ../design-system-Lifegames does not resolve. stderr is
+// suppressed so a missing path does not print git's fatal noise before the
+// clean diagnostic below.
+const dsRepoRoot = process.env.DS_REPO_ROOT ?? join(REPO_ROOT, '..', 'design-system-Lifegames')
+let dsRepoSha = null
+try {
+  dsRepoSha = execSync('git rev-parse HEAD', {cwd: dsRepoRoot, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore']}).trim()
+} catch {
+  // Fall through to the manifest, then the loud failure below.
+}
+
+// (2) Manifest fallback — the LP git sha the schemas were synced from.
 let dsSha = null
 const manifestPath = join(SCHEMAS_PKG, 'vendored', '.lp-sync-manifest.json')
 if (existsSync(manifestPath)) {
@@ -32,16 +54,23 @@ if (existsSync(manifestPath)) {
   dsSha = manifest.lpGitSha ?? null
 }
 
-// Also try to get DS repo HEAD directly if available as a sibling
-const dsRepoRoot = join(REPO_ROOT, '..', 'design-system-Lifegames')
-let dsRepoSha = null
-try {
-  dsRepoSha = execSync('git rev-parse HEAD', {cwd: dsRepoRoot, encoding: 'utf-8'}).trim()
-} catch {
-  // DS repo not available as sibling — use manifest SHA
+const resolvedSha = dsRepoSha ?? dsSha
+let upstreamSha
+if (resolvedSha) {
+  upstreamSha = resolvedSha
+} else if (process.env.CONTRACT_LOCK_ALLOW_UNKNOWN_SHA === '1') {
+  upstreamSha = 'unknown'
+  console.warn('[contract-lock] WARNING: recording generatedFrom.sha="unknown" (CONTRACT_LOCK_ALLOW_UNKNOWN_SHA=1).')
+} else {
+  console.error('[contract-lock] ERROR: could not resolve the upstream design-system-Lifegames sha.')
+  console.error(`  tried git HEAD at: ${dsRepoRoot}`)
+  console.error(`  tried manifest at: ${manifestPath}`)
+  console.error('  Fix one of:')
+  console.error('    - run from the main checkout where ../design-system-Lifegames exists, or')
+  console.error('    - set DS_REPO_ROOT=/path/to/design-system-Lifegames, or')
+  console.error('    - set CONTRACT_LOCK_ALLOW_UNKNOWN_SHA=1 to deliberately record "unknown".')
+  process.exit(1)
 }
-
-const upstreamSha = dsRepoSha ?? dsSha ?? 'unknown'
 
 // Collect all schema-relevant files from the yalc package
 // Include vendored schemas, authored schemas, generated schemas, and dist types


### PR DESCRIPTION
## Summary

Final cleanup PR of the estate-wide **LOCATION retirement**. Consumes the already-merged upstream changes and regenerates the two remaining machine-readable surfaces that still advertised location, plus the schema contract lock.

Upstream (already merged, deployed to staging):

- `mantle-LifegamesPortal` #177 (`9d91cda`) — dropped the location export chain + `location-export.schema.json`.
- `design-system-Lifegames` #147 (`f698fee`) — removed location claims from `@lifegames/copy`.

This repo consumes both via yalc, then regenerates from the generators (no hand-edits).

## Changes (all generated)

**`public/.well-known/agent-card.json`** (`scripts/generate-webmcp.mjs` from copy)

- description: `...reading lists, theatre reviews, and location data as structured JSON via CloudFront.` -> `...reading lists, and theatre reviews as structured JSON via CloudFront.`
- skill description: `...reading list, GitHub contributions, and location aggregates. Useful...` -> `...reading list, and GitHub contributions. Useful...`

**`public/.well-known/ai-catalog.json`** (same generator, from copy)

- MCP entry description: `...reading lists, theatre reviews, and location aggregates.` -> `...reading lists, and theatre reviews.`

**`public/js/webmcp.js`** (same generator, from copy `person.longBio`)

- bio: `...body (health, activity, hydration, location) and mind...` -> `...body (health, activity, hydration) and mind...`
- **Preserved (profile identity):** `person.location` = `San Francisco, CA` and the `get_profile` tool wording (`name, title, location, experience...`).

**`.contract-lock.json`** (`scripts/generate-contract-lock.mjs` from portal-contract)

- No longer tracks `raw-schemas/location-export.schema.json` (22 files, was 23).
- `generatedFrom.sha` is `unknown` (worktree layout has no DS sibling for the git-HEAD read); this field is **volatile/excluded** by `check-contract-lock.mjs`, so the freshness check passes.

## Verification — full local gate green

- `astro build` (prebuild regen + schema validation + audits; postbuild precache 38 entries) — pass
- `test:unit` 219 passed · `test:build` 95 passed
- `eslint` clean · `dprint check` clean · `astro check` 0 errors / 0 warnings / 0 hints
- `check:contract-lock` OK
- **visual** (Docker arm64) 211 passed / 24 skipped · **behavioral** (Docker) 33 passed

## Guardrails honored

- `person.location` = "San Francisco, CA" preserved (identity, not a location-data claim).
- No `/location.json` reference exists in this repo's `public/` — nothing re-removed. The live S3 object deletion is a **separate later authorized step**.
- Only location _data / aggregates / stream_ claims removed.

> Merging to `main` auto-deploys production via Cloudflare Pages. **Do not merge** without explicit approval.
