### PR TITLE
refactor(web): tighten RESOURCE_DISCRIMINANTS back to a full Record

### DIFF
--- a/src/lib/runtime/live-data.ts
+++ b/src/lib/runtime/live-data.ts
@@ -117,15 +117,11 @@ type ResourceTypeMap = {
   starredRepos: GithubStarredReposExport
 }
 
-// A payload that passed structural validation: one of the known export shapes
-// (each carries generatedAt). Each switch branch narrows this to the concrete
-// export type via ResourceTypeMap.
-type ValidatedPayload = ResourceTypeMap[keyof ResourceTypeMap]
-
-// Partial over ResourceKey: the contract's ResourceKey still enumerates `location`
-// (its ENDPOINTS entry is retired in a coordinated portal-contract change), but the
-// web dashboard no longer polls or renders it, so it carries no discriminant here.
-const RESOURCE_DISCRIMINANTS: Partial<Record<ResourceKey, string>> = {
+// Structural discriminant per resource: a field whose presence (alongside a string
+// `generatedAt`) marks a payload as the expected export shape. A full Record over
+// ResourceKey so that adding a resource to ENDPOINTS without a discriminant here is a
+// compile error, not a silently-unvalidated payload at runtime.
+const RESOURCE_DISCRIMINANTS: Record<ResourceKey, string> = {
   health: 'quantities',
   sleep: 'date',
   workouts: 'workouts',
@@ -137,7 +133,7 @@ const RESOURCE_DISCRIMINANTS: Partial<Record<ResourceKey, string>> = {
   starredRepos: 'repos'
 }
 
-function validateResource(key: ResourceKey, rawData: unknown): ValidatedPayload | null {
+function validateResource<K extends ResourceKey>(key: K, rawData: unknown): ResourceTypeMap[K] | null {
   if (typeof rawData !== 'object' || rawData === null) {
     return null
   }
@@ -145,11 +141,10 @@ function validateResource(key: ResourceKey, rawData: unknown): ValidatedPayload 
   if (typeof obj.generatedAt !== 'string') {
     return null
   }
-  const discriminant = RESOURCE_DISCRIMINANTS[key]
-  if (discriminant === undefined || !(discriminant in obj)) {
+  if (!(RESOURCE_DISCRIMINANTS[key] in obj)) {
     return null
   }
-  return rawData as ValidatedPayload
+  return rawData as ResourceTypeMap[K]
 }
 
 // ── Per-resource incremental update dispatch ─────────────────────────


### PR DESCRIPTION
## Summary

Atlas decision 0012, follow-up (e). Restores the `RESOURCE_DISCRIMINANTS` map and `validateResource` signature that PR #152 (LOCATION removal) temporarily weakened, and picks up the merged `@lifegames/copy` fix that removes the last two stale `location` claims from production copy.

### Task 1 — type tightening (the committed diff)
- **`RESOURCE_DISCRIMINANTS`**: `Partial<Record<ResourceKey, string>>` → `Record<ResourceKey, string>`. The `Partial` was a bridge for the window where the contract's `ResourceKey` still enumerated `location` after its ENDPOINTS entry was slated for removal. That removal has landed (**LP #177**, merged + deployed): `ENDPOINTS.location` is gone, so `ResourceKey` now enumerates exactly the nine resources that carry a discriminant. The full `Record` restores the compile-time guarantee that a resource added to `ENDPOINTS` without a discriminant is a build error rather than a silently-unvalidated runtime payload.
- **`validateResource`**: restored to the generic `<K extends ResourceKey>(key: K, ...): ResourceTypeMap[K] | null`. This was independently de-genericised in #152 only because `ResourceKey` (10 keys incl. `location`) no longer matched `keyof ResourceTypeMap` (9 keys) — `ResourceTypeMap['location']` didn't exist, so the generic couldn't typecheck. With `location` gone the two key sets are identical again, so the restore is clean, not forced. The obsolete `discriminant === undefined` guard (only needed because `Partial` widened the lookup to `string | undefined`) is dropped.
- Removed the stale `ValidatedPayload` bridge type and the comment describing the now-closed transient state.

**Verdict on `validateResource`:** restorable and restored — the de-genericisation was a side-effect of the same transient `ResourceKey`/`ResourceTypeMap` mismatch, not an independent decision.

### Task 2 — copy pickup (flows via CI, not in the diff)
`design-system-Lifegames` #148 (`1a23ee2`, merged) fixed two strings still stale on production:
- `identity.description` → homepage `WebSite` JSON-LD `description`
- `privacy.dataDisplayed` → `/privacy/` notice

`.yalc` is gitignored; CI reconstructs it via `scripts/ci-setup.sh` with `DS_REF=main`, so the deploy build picks these up automatically. Verified locally against the **built** artifacts:

**Built JSON-LD `description` (`dist/index.html`):**
> Personal portfolio of Jonathan Lloyd, an engineering director and backend engineer, built as a living data dashboard. Real biometrics and constant updates of his whole body (health, activity, hydration) and mind (coding, reading, learning). Jack into his human datastream as the world becomes more AI-centric.

**Built privacy sentence (`dist/privacy/index.html`):**
> Everything shown on this dashboard is the owner's own self-published data — health metrics, activity, hydration, reading history, and GitHub activity. No visitor data is displayed.

Both are now `location`-free; a full grep of built HTML/JSON-LD finds zero remaining `location` claims.

## Why this matters beyond the diff
Merging triggers the Cloudflare Pages production deploy that propagates the copy fix. Production currently serves a **stale privacy notice** claiming a data category (`location check-ins`) the site no longer publishes.

## Gates (all green, local)
- `astro check` — 0 errors / 0 warnings / 0 hints
- unit + build — 95 passed
- behavioral (Docker) — 33 passed
- visual (Docker) — 211 passed, 24 skipped (no baseline drift)
- lint (eslint) — clean
- format (dprint check) — clean
- contract-lock check — matches current schemas

**Do not merge yet** — awaiting green CI.