### PR TITLE
chore: re-sync contract lock after LP #182/#183 and DS #149

### DIFF
--- a/.contract-lock.json
+++ b/.contract-lock.json
@@ -1,10 +1,10 @@
 {
   "generatedFrom": {
     "repo": "j0nathan-ll0yd/design-system-Lifegames",
-    "sha": "f698fee013068105fa6e251a77648ce39d093e93",
-    "checksum": "sha256:13e69b71de821ccd80bd6eb18a5e8469cb3e4e842ebb2e28ba1414cb28150b09"
+    "sha": "1a23ee2f3350c4824aabef7b9ae44e69253ba654",
+    "checksum": "sha256:fe1f22a8f36ef2d5da60fd0cc0ea5b92baf02966c23c31e452807a86b05b077b"
   },
-  "generatedAt": "2026-07-30T21:53:28.153Z",
+  "generatedAt": "2026-07-31T20:34:45.255Z",
   "generatorVersion": "1.0.0",
   "files": {
     "raw-schemas/articles-export.schema.json": "sha256:4a3d6514ab959b251ad88bef79020747bbddb865d0a7c913e71fe36f608ffd36",
@@ -12,7 +12,7 @@
     "raw-schemas/focus-export.schema.json": "sha256:b9b8deaa9f427ece873937c251495dbf3a69e5d054f635d1ecb49b36679b6144",
     "raw-schemas/github-events-export.schema.json": "sha256:ff00a3474a0be17e9640407a7bc3d69dd437157ec10936ec5157932f07fec415",
     "raw-schemas/github-starred-repos-export.schema.json": "sha256:dab7effd7bb7fa6a5444d4e32b43fdfff4d8ae1721e6be69ccd0a88be159c33f",
-    "raw-schemas/health-export.schema.json": "sha256:6dfd14c274828a038da48db10c900046e7a60bc14cd55f5f1c17dc252661b60c",
+    "raw-schemas/health-export.schema.json": "sha256:1469e169cc585c1eb4a298d953399eb4540a8baf33ff3b101697b5a6b80e158d",
     "raw-schemas/sleep-export.schema.json": "sha256:ab11c1abeb9cbb3dc327243eb50507dab31f843d9f2a8cea367522431f16b85d",
     "raw-schemas/theatre-reviews-export.schema.json": "sha256:39753a6f58f2bc5f030efcf50193a38f48a29178e733f1ba724e0b28188da640",
     "raw-schemas/workouts-export.schema.json": "sha256:1814cc3935a95c345eece02fb0f560c95ce8bca92a4b90705489c21c7182c67e",
@@ -28,6 +28,6 @@
     "authored/system.schema.json": "sha256:27b60ad1e003fdfe74f21bfa514bfc4507131f4fc9351e06fc348604976546df",
     "authored/visit-timeline.schema.json": "sha256:ce0af8bcbd93cf7fe7d7d2078fe9c71e8b46a17e7c0d4cf4b2c4800de92fc42f",
     "authored/widget-pinned-repos.schema.json": "sha256:8a3bb0fda1dde74a496acb07afa589b759bd5b44b465cae824a83fb8823db9f3",
-    "generated/dashboard-health.schema.json": "sha256:f79f0274db7ca93fa1760d666d30d1b34d3e1c1a91e8abe2c775f9601d71d1b1"
+    "generated/dashboard-health.schema.json": "sha256:6df8f7e109142fe3373a01bffdd399212cc5055e4823a338d898b2715a229d96"
   }
 }


### PR DESCRIPTION
**Unblocks both open web PRs.** `Schema Contract Check` currently fails on #157 *and* #158 — neither is mergeable until this lands, because the committed lock disagrees with upstream.

## What changed

`raw-schemas/health-export.schema.json`: `6dfd14c2…` → **`1469e169…`**

Upstream moved twice: `mantle-LifegamesPortal` #182 closed the `quantities` contract to a `propertyNames.enum`, then #183 removed five unpublished quantity types (22 → 17). `design-system-Lifegames` #149 propagated it. This consumer lock still recorded the pre-change schema.

## Verification

- Regenerated the backend schemas (`pnpm run generate:types` in LP) and compared: **all nine hashes identical** — the backend was already current, so only this consumer lock lagged. `1469e169` is exactly what LP `main` produces.
- Refreshed yalc from upstream before regenerating, so the lock is computed against real current bytes rather than a stale linked tree.
- Pre-push `check:contract-lock` → `OK: .contract-lock.json matches the current schemas`.

## Notes

- The `generatedFrom.sha` field records `1a23ee2f` rather than DS `main` (`f837b3c6`). That field is **provenance only** — `generate-contract-lock.mjs` deliberately excludes it from the checksum, precisely so no gate can confuse a genuine sha with a swallowed `unknown`. The content checksums are what the gate compares, and those are correct.
- Pushed with `SKIP_VISUAL=1`: this diff is a single JSON lock file with no rendering surface, and the visual suite currently reds on a wall-clock time bomb that #158 fixes independently.

⚠️ Merging deploys to production.