### PR TITLE
fix(ci): derive yalc package names from cloned sources in ci-setup.sh

### DIFF
--- a/scripts/ci-setup-portal-contract.sh
+++ b/scripts/ci-setup-portal-contract.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
-# Publishes @lifegames/portal-contract to the LOCAL yalc store for CI.
+# Publishes the portal-contract package to the LOCAL yalc store for CI.
 #
-# @lifegames/portal-contract is produced by the backend repo
+# portal-contract is produced by the backend repo
 # (mantle-LifegamesPortal/packages/portal-contract). This web repo depends on it
-# directly (file:.yalc/@lifegames/portal-contract), AND the design-system clone
-# that ci-setup.sh builds also depends on it. Because `.yalc/` is gitignored,
-# CI must publish it to the local yalc store before either consumer installs.
+# directly, AND the design-system clone that ci-setup.sh builds also depends on
+# it. Because `.yalc/` is gitignored, CI must publish it to the local yalc store
+# before either consumer installs.
+#
+# `yalc publish` publishes under whatever name the package.json on disk declares,
+# so no package name is hardcoded here; the yalc retirement (atlas#1) renamed
+# this package, and the refresh guard below derives the current name off the clone.
 #
 # This script ONLY clones the backend and yalc-publishes portal-contract; the
 # caller (ci-setup.sh) is responsible for `npx yalc add`-ing it into the right
@@ -66,19 +70,24 @@ echo "[ci-setup-pc] Installing + yalc-publishing portal-contract..."
 # backend checkout, plus portal-contract's own devDeps.
 (cd "$LP_DIR/packages/portal-contract" && pnpm install && npx -y yalc publish)
 
+# Derive the package's real name from the clone -- the yalc retirement (atlas#1)
+# renamed it, so the store key and any .yalc/<name> link path track this, not a
+# hardcoded literal.
+PC_PKG="$(node -p "require('$LP_DIR/packages/portal-contract/package.json').name")"
+
 # `yalc publish` updates the STORE only -- it does NOT touch an already-linked
 # consumer's .yalc/ tree. A prior standalone run of this script reported
-# "published in store" yet left this web repo's .yalc/@lifegames/portal-contract
-# holding the retired `location` member, needing a separate `yalc update` to
-# actually land (atlas 0013, Task 2 #1 -- the silent-no-op class). So: if THIS
-# web repo already links portal-contract, pull the freshly published bytes into
-# its .yalc/ now. Guarded on the link dir existing, so a fresh CI checkout (where
-# .yalc/ is gitignored/absent and the caller's later `yalc add` handles it) is
-# untouched -- this only refreshes an EXISTING stale consumer.
+# "published in store" yet left this web repo's .yalc/<portal-contract> holding
+# the retired `location` member, needing a separate `yalc update` to actually
+# land (atlas 0013, Task 2 #1 -- the silent-no-op class). So: if THIS web repo
+# already links portal-contract, pull the freshly published bytes into its .yalc/
+# now. Guarded on the link dir existing, so a fresh CI checkout (where .yalc/ is
+# gitignored/absent and the caller's later `yalc add` handles it) is untouched --
+# this only refreshes an EXISTING stale consumer.
 WEB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-if [ -d "$WEB_ROOT/.yalc/@lifegames/portal-contract" ]; then
-  echo "[ci-setup-pc] Refreshing this repo's consumer link (npx yalc update @lifegames/portal-contract)..."
-  (cd "$WEB_ROOT" && npx -y yalc update @lifegames/portal-contract)
+if [ -d "$WEB_ROOT/.yalc/$PC_PKG" ]; then
+  echo "[ci-setup-pc] Refreshing this repo's consumer link (npx yalc update $PC_PKG)..."
+  (cd "$WEB_ROOT" && npx -y yalc update "$PC_PKG")
 fi
 
 echo "[ci-setup-pc] Done."

--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # Phase 2 CI install step. Replaces the default `npm ci --legacy-peer-deps`.
-# Clones design-system-Lifegames, builds its packages, yalc-publishes the
-# @lifegames/* packages (tokens, web, schemas, copy), pulls them into this
-# repo's .yalc/ alongside portal-contract, and then runs npm ci so the
-# file:.yalc/* deps in package.json resolve.
+# Clones design-system-Lifegames, builds its packages, yalc-publishes the DS
+# packages (tokens, web, schemas, copy, fixtures), pulls them into this repo's
+# .yalc/ alongside portal-contract, and then runs npm ci so the file:.yalc/*
+# deps in package.json resolve.
+#
+# Package names are DERIVED from each cloned source repo's package.json, never
+# hardcoded: yalc keys its store by package name, and the yalc retirement
+# (atlas#1) is renaming these packages @lifegames/* -> @j0nathan-ll0yd/* on a
+# per-repo schedule. Deriving is correct before, after, and between renames.
 #
 # Override via env:
 #   DS_REPO  — git URL  (default: HTTPS to j0nathan-ll0yd/design-system-Lifegames)
@@ -18,15 +23,26 @@ DS_REPO="${DS_REPO:-https://github.com/j0nathan-ll0yd/design-system-Lifegames.gi
 DS_DIR="${DS_DIR:-/tmp/design-system-Lifegames}"
 DS_REF="${DS_REF:-main}"
 
+# Mirror ci-setup-portal-contract.sh's LP clone dir so we can read the backend's
+# real package name off disk after it clones. Same default + override contract.
+LP_DIR="${LP_DIR:-/tmp/mantle-LifegamesPortal}"
+
 echo "[ci-setup] DS_REPO=$DS_REPO"
 echo "[ci-setup] DS_DIR=$DS_DIR"
 echo "[ci-setup] DS_REF=$DS_REF"
 
-# Publish @lifegames/portal-contract to the local yalc store FIRST. Both this
-# web repo and the DS clone (built below) depend on it; it must exist in the
-# store before either runs `pnpm install` / `npm ci`.
-echo "[ci-setup] Publishing @lifegames/portal-contract (backend producer)..."
+# Publish portal-contract to the local yalc store FIRST. Both this web repo and
+# the DS clone (built below) depend on it; it must exist in the store before
+# either runs `pnpm install` / `npm ci`.
+echo "[ci-setup] Publishing portal-contract (backend producer)..."
 bash "$SCRIPT_DIR/ci-setup-portal-contract.sh"
+
+# Derive the backend package name from the cloned source, never hardcode it.
+# yalc keys its store by package name; the backend renamed portal-contract
+# during the yalc retirement (atlas#1), so the literal name is not stable.
+# Reading it off the clone is correct before, after, and across future renames.
+PC_PKG="$(node -p "require('$LP_DIR/packages/portal-contract/package.json').name")"
+echo "[ci-setup] portal-contract package name: $PC_PKG"
 
 # Remove a stale non-repo $DS_DIR (leftover from an aborted run) before cloning,
 # so `git clone` never aborts with "destination path already exists and is not an
@@ -50,13 +66,13 @@ if command -v corepack >/dev/null 2>&1; then
   corepack enable
 fi
 
-# Restore @lifegames/portal-contract into the DS clone's consuming sub-packages
-# BEFORE its `pnpm install --frozen-lockfile`. The DS lockfile pins each of
-# these to its own .yalc/@lifegames/portal-contract; yalc add is idempotent on
-# package.json (the file: dep is already declared), so --frozen-lockfile holds.
-echo "[ci-setup] yalc add portal-contract into DS sub-packages..."
+# Restore portal-contract into the DS clone's consuming sub-packages BEFORE its
+# `pnpm install --frozen-lockfile`. The DS lockfile pins each of these to its own
+# .yalc/<portal-contract>; yalc add is idempotent on package.json (the file: dep
+# is already declared under the derived name), so --frozen-lockfile holds.
+echo "[ci-setup] yalc add $PC_PKG into DS sub-packages..."
 for ds_consumer in packages/web packages/schemas packages/fixtures apps/portfolio; do
-  (cd "$DS_DIR/$ds_consumer" && npx -y yalc add @lifegames/portal-contract)
+  (cd "$DS_DIR/$ds_consumer" && npx -y yalc add "$PC_PKG")
 done
 
 (cd "$DS_DIR" && pnpm install --frozen-lockfile)
@@ -67,8 +83,17 @@ echo "[ci-setup] Building DS packages (tokens + web + schemas)..."
 echo "[ci-setup] yalc:publish from DS..."
 (cd "$DS_DIR" && pnpm yalc:publish)
 
+# Derive the five DS package names from the cloned DS source too. DS #151
+# (yalc retirement) renames these @lifegames/* -> @j0nathan-ll0yd/*; reading
+# them off the clone tracks whichever names DS main currently publishes.
+DS_PKGS=()
+for ds_pkg in tokens web schemas copy fixtures; do
+  DS_PKGS+=("$(node -p "require('$DS_DIR/packages/$ds_pkg/package.json').name")")
+done
+echo "[ci-setup] DS package names: ${DS_PKGS[*]}"
+
 echo "[ci-setup] yalc add into consumer..."
-npx yalc add @lifegames/portal-contract @lifegames/tokens @lifegames/web @lifegames/schemas @lifegames/copy @lifegames/fixtures
+npx yalc add "$PC_PKG" "${DS_PKGS[@]}"
 
 echo "[ci-setup] npm ci --legacy-peer-deps..."
 npm ci --legacy-peer-deps


### PR DESCRIPTION
> Rebased onto current `main` (`3a31dd3`, atlas 0013 / #157). The initial push was
> based on a stale checkout; this branch now sits on top of the yalc-freshness /
> install-doctor work and its refresh-script changes.

## What

The CI setup scripts hardcoded the yalc package names. Derive them from each
cloned source repo's own `package.json` instead. yalc keys its store by package
name, and the yalc retirement (`atlas#1`) is renaming these `@lifegames/*` ->
`@j0nathan-ll0yd/*` on a per-repo schedule, so any hardcoded literal is wrong in
at least one migration state.

Three hardcoded sites replaced:

- `ci-setup.sh` — `yalc add <portal-contract>` into the DS sub-packages
- `ci-setup.sh` — the final `yalc add` of portal-contract + the five DS packages
- `ci-setup-portal-contract.sh` — the consumer-link refresh guard
  (`.yalc/<name>` test + `yalc update`, added in atlas 0013 / #157)

Derivations:

- `PC_PKG` <- `$LP_DIR/packages/portal-contract/package.json` `.name`
- `DS_PKGS` <- `$DS_DIR/packages/{tokens,web,schemas,copy,fixtures}/package.json` `.name`

This deletes a duplicated constant. It is **not** a rename-window shim: derived
names are correct before, after, and between the renames.

## Why now

`mantle-LifegamesPortal` renamed `@lifegames/portal-contract` ->
`@j0nathan-ll0yd/portal-contract` on `main` (merged 2026-07-31T23:12Z). The next
CI run here would hit the old hardcoded `yalc add @lifegames/portal-contract`.
`design-system-Lifegames#151` renames the five DS packages next.

## Verification (measured, isolated reproduction)

**Three-state known-answer** — same derivation expressions, real `package.json`
content fetched per repo/branch:

| State | portal-contract (from LP) | DS five (from DS) |
| --- | --- | --- |
| LP `main` + DS `main` (today) | `@j0nathan-ll0yd/portal-contract` | `@lifegames/{tokens,web,schemas,copy,fixtures}` |
| LP `main` + DS PR `feat/rename-publish-ds-packages` | `@j0nathan-ll0yd/portal-contract` | `@j0nathan-ll0yd/{tokens,web,schemas,copy,fixtures}` |

Right answer in each state, from the exact `node -p "require(...).name"` calls the
scripts issue.

**Current breakage reproduced** (isolated yalc store holding only the renamed
package):

```
# unpatched, old hardcoded name:
$ yalc add @lifegames/portal-contract
Could not find package `@lifegames/portal-contract` in store (...), skipping.   # exit 0 (silent skip)

# patched, derived name:
$ yalc add @j0nathan-ll0yd/portal-contract
Package @j0nathan-ll0yd/portal-contract@1.0.0 added ==> node_modules/...          # exit 0, resolved
```

The failure is a **silent skip (exit 0)**, so `set -e` does not catch it; it
surfaces downstream at the DS `pnpm install --frozen-lockfile` / web `npm ci`.

**Local static gates:** `dprint check`, `astro check` (0 errors), `eslint` all
pass; `bash -n` clean on both scripts. (dprint/eslint don't cover `.sh`.)

## Assumed vs measured

- **Measured:** the three-state derivation; the silent-skip failure; the DS-clone
  side works (DS `main` sub-packages already declare
  `@j0nathan-ll0yd/portal-contract` under a frozen lockfile); the npm-ci desync below.
- **Assumed:** nothing load-bearing. LP is private, so its `package.json` was read
  via `gh api` rather than a local clone; the derivation code path is identical.

## IMPORTANT — necessary but NOT sufficient for green CI

**Deriving the name does not, on its own, make this repo's CI green, because the
web consumer still references `@lifegames/portal-contract` in three places this
PR is scoped out of touching:**

1. `package.json:33-38` -> `file:.yalc/@lifegames/portal-contract` (PR 5 territory)
2. `package-lock.json` (the matching entries)
3. ~15 source imports `@lifegames/portal-contract/constants` (`scripts/fetch-images.mjs`,
   `scripts/generate-webmcp.mjs` [runs in `prebuild`], `scripts/audit/*`)

Measured: `yalc add @j0nathan-ll0yd/portal-contract` into a consumer that still
declares the old name **adds a new dep key** and leaves the stale one, desyncing
the lockfile:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json ... are in sync.
npm error Missing: @j0nathan-ll0yd/portal-contract@1.0.0 from lock file
```

Even with `--no-save`, `.yalc/@lifegames/portal-contract` is never created (the
store holds only the new name), so the `file:` dep can't resolve and `prebuild`'s
`@lifegames/portal-contract/*` imports fail.

**Conclusion: the dep keys, `file:` paths, lockfile, and source imports must move
together with the renamed producer. That is migration PR 5 and is deliberately
NOT pre-empted here.** This repo's CI (which clones LP `main`) will remain red
until PR 5 lands the web-consumer cutover; the two must be coordinated.

## Scope

- Touched: `scripts/ci-setup.sh`, `scripts/ci-setup-portal-contract.sh`.
- Untouched (deliberately): `package.json:33-38`, `package-lock.json`, yalc
  freshness machinery (`.yalc-lock.json`, `check-yalc-freshness.mjs`,
  `doctor-install.mjs`, `generate-yalc-lock.mjs`), and all other repos.

## Do not merge

Merge to `main` is a production Cloudflare Pages deploy. Opening for review /
coordination with PR 5 only.
